### PR TITLE
Enable uploads for default users

### DIFF
--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -115,7 +115,7 @@ function workspaceEndpoints(app) {
     "/workspace/:slug/upload",
     [
       validatedRequest,
-      flexUserRoleValid([ROLES.admin, ROLES.manager]),
+      flexUserRoleValid([ROLES.admin, ROLES.manager, ROLES.default]),
       handleFileUpload,
     ],
     async function (request, response) {
@@ -163,7 +163,7 @@ function workspaceEndpoints(app) {
 
   app.post(
     "/workspace/:slug/upload-link",
-    [validatedRequest, flexUserRoleValid([ROLES.admin, ROLES.manager])],
+    [validatedRequest, flexUserRoleValid([ROLES.admin, ROLES.manager, ROLES.default])],
     async (request, response) => {
       try {
         const Collector = new CollectorApi();
@@ -206,7 +206,7 @@ function workspaceEndpoints(app) {
 
   app.post(
     "/workspace/:slug/update-embeddings",
-    [validatedRequest, flexUserRoleValid([ROLES.admin, ROLES.manager])],
+    [validatedRequest, flexUserRoleValid([ROLES.admin, ROLES.manager, ROLES.default])],
     async (request, response) => {
       try {
         const user = await userFromSession(request, response);
@@ -875,7 +875,7 @@ function workspaceEndpoints(app) {
     "/workspace/:slug/upload-and-embed",
     [
       validatedRequest,
-      flexUserRoleValid([ROLES.admin, ROLES.manager]),
+      flexUserRoleValid([ROLES.admin, ROLES.manager, ROLES.default]),
       handleFileUpload,
     ],
     async function (request, response) {


### PR DESCRIPTION
## Summary
- allow default users to upload documents and links to workspaces
- permit default role to embed uploads directly in chat
- allow default role to run the embedding update endpoint

## Testing
- `npm test` *(fails: Cannot find module 'uuid', 'dotenv', '@langchain/textsplitters')*

------
https://chatgpt.com/codex/tasks/task_e_688a2acbe49c832896bfe4a8a318f347