### PR TITLE
Limit manager workspace access

### DIFF
--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -259,7 +259,7 @@ const Workspace = {
   },
 
   getWithUser: async function (user = null, clause = {}) {
-    if ([ROLES.admin, ROLES.manager].includes(user.role))
+    if ([ROLES.admin].includes(user.role))
       return this.get(clause);
 
     try {
@@ -338,7 +338,7 @@ const Workspace = {
     limit = null,
     orderBy = null
   ) {
-    if ([ROLES.admin, ROLES.manager].includes(user.role))
+    if ([ROLES.admin].includes(user.role))
       return await this.where(clause, limit, orderBy);
 
     try {


### PR DESCRIPTION
## Summary
- restrict workspace get/where functions to only allow global visibility for admins

## Testing
- `mise exec node@18.18.0 -- yarn test` *(fails: YoutubeTranscript.fetchTranscript fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688b59fe4928832893bf3b142dfd5097