### PR TITLE
Restrict manager visibility to owned workspaces

### DIFF
--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -259,8 +259,7 @@ const Workspace = {
   },
 
   getWithUser: async function (user = null, clause = {}) {
-    if ([ROLES.admin, ROLES.manager].includes(user.role))
-      return this.get(clause);
+    if ([ROLES.admin].includes(user.role)) return this.get(clause);
 
     try {
       const workspace = await prisma.workspaces.findFirst({
@@ -338,7 +337,7 @@ const Workspace = {
     limit = null,
     orderBy = null
   ) {
-    if ([ROLES.admin, ROLES.manager].includes(user.role))
+    if ([ROLES.admin].includes(user.role))
       return await this.where(clause, limit, orderBy);
 
     try {


### PR DESCRIPTION
## Summary
- adjust workspace queries to limit manager access

## Testing
- `npm test --silent` *(fails: Youtube transcript, prisma client, jsonwebtoken)*

------
https://chatgpt.com/codex/tasks/task_e_688b64c824b483289fa9f2bdfca54296