### PR TITLE
Add private workspace flag

### DIFF
--- a/server/prisma/migrations/20250925120000_private_workspace/migration.sql
+++ b/server/prisma/migrations/20250925120000_private_workspace/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN "private" BOOLEAN DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -140,6 +140,7 @@ model workspaces {
   agentProvider                String?
   agentModel                   String?
   queryRefusalResponse         String?
+  private                      Boolean                        @default(false)
   vectorSearchMode             String?                        @default("default")
   workspace_users              workspace_users[]
   documents                    workspace_documents[]

--- a/server/utils/middleware/validApiKey.js
+++ b/server/utils/middleware/validApiKey.js
@@ -14,13 +14,20 @@ async function validApiKey(request, response, next) {
     return;
   }
 
-  if (!(await ApiKey.get({ secret: bearerKey }))) {
+  const apiKey = await ApiKey.get({ secret: bearerKey });
+  if (!apiKey) {
     response.status(403).json({
       error: "No valid api key found.",
     });
     return;
   }
 
+  if (multiUserMode && apiKey.createdBy) {
+    const { User } = require("../../models/user");
+    response.locals.user = await User.get({ id: apiKey.createdBy });
+  }
+
+  response.locals.apiKey = apiKey;
   next();
 }
 


### PR DESCRIPTION
## Summary
- add `private` column to workspace schema with migration
- include `private` in workspace model updates and validations
- filter workspace queries so only owners or members see private workspaces
- attach API key owner to request context
- limit admin and API workspace listings to authorized users only

## Testing
- `yarn test` *(fails: @prisma/client did not initialize yet)*

------
https://chatgpt.com/codex/tasks/task_e_688c6e22de1483289ea73fc6f213e900