### PR TITLE
Improve onboarding admin warnings

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -55,6 +55,8 @@ const TRANSLATIONS = {
       title: "Create your first workspace",
       description:
         "Create your first workspace and get started with AnythingLLM.",
+      adminWarning:
+        "Each workspace must always have at least one admin. Removing all admin users can break workspace features.",
     },
   },
   common: {
@@ -71,6 +73,8 @@ const TRANSLATIONS = {
     yes: "Yes",
     no: "No",
     search: "Search",
+    adminRemoveWarning:
+      "Admins are automatically part of every workspace. Removing all admin users will break workspace features.",
   },
 
   // Setting Sidebar menu items.

--- a/frontend/src/pages/OnboardingFlow/Steps/CreateWorkspace/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/CreateWorkspace/index.jsx
@@ -82,6 +82,9 @@ export default function CreateWorkspace({
             autoComplete="off"
             onChange={(e) => setWorkspaceName(e.target.value)}
           />
+          <p className="text-theme-text-secondary text-xs mt-2">
+            {t("onboarding.workspace.adminWarning")}
+          </p>
         </div>
       </div>
       <button

--- a/frontend/src/pages/WorkspaceSettings/Members/AddMemberModal/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/Members/AddMemberModal/index.jsx
@@ -2,8 +2,10 @@ import React, { useState } from "react";
 import { MagnifyingGlass, X } from "@phosphor-icons/react";
 import Admin from "@/models/admin";
 import showToast from "@/utils/toast";
+import { useTranslation } from "react-i18next";
 
 export default function AddMemberModal({ closeModal, workspace, users }) {
+  const { t } = useTranslation();
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedUsers, setSelectedUsers] = useState(workspace?.userIds || []);
 
@@ -118,6 +120,9 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
               )}
             </table>
           </div>
+          <p className="text-theme-text-secondary text-xs px-5 pb-2">
+            {t("common.adminRemoveWarning")}
+          </p>
           <div className="flex w-full justify-between items-center p-3 space-x-2 border-t rounded-b border-gray-500/50">
             <div className="flex items-center gap-x-2">
               <button

--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -435,6 +435,19 @@ const Workspace = {
    */
   updateUsers: async function (workspaceId, userIds = []) {
     try {
+      const { User } = require("./user");
+      const { ROLES } = require("../utils/middleware/multiUserProtected");
+      const adminCount = await User.count({
+        id: { in: userIds.map(Number) },
+        role: ROLES.admin,
+      });
+      if (adminCount === 0) {
+        return {
+          success: false,
+          error: "Workspace must include at least one admin user.",
+        };
+      }
+
       await WorkspaceUser.delete({ workspace_id: Number(workspaceId) });
       await WorkspaceUser.createManyUsers(userIds, workspaceId);
       return { success: true, error: null };


### PR DESCRIPTION
## Summary
- warn users about admin requirements when creating workspaces
- show admin removal warning on members modal
- enforce at least one admin in workspace on the server

## Testing
- `npm run lint`
- `npm test` *(fails: Youtube transcript fetch and Prisma initialization)*

------
https://chatgpt.com/codex/tasks/task_e_688c8faf5f948328a990d0f23a17d143