### PR TITLE
Set private as default for new workspaces

### DIFF
--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -202,6 +202,7 @@ const Workspace = {
       const workspace = await prisma.workspaces.create({
         data: {
           name: this.validations.name(name),
+          private: true,
           ...this.validateFields(additionalFields),
           slug,
         },

--- a/server/prisma/migrations/20251001120000_default_private_true/migration.sql
+++ b/server/prisma/migrations/20251001120000_default_private_true/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ALTER COLUMN "private" SET DEFAULT true;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -140,7 +140,7 @@ model workspaces {
   agentProvider                String?
   agentModel                   String?
   queryRefusalResponse         String?
-  private                      Boolean                        @default(false)
+  private                      Boolean                        @default(true)
   vectorSearchMode             String?                        @default("default")
   workspace_users              workspace_users[]
   documents                    workspace_documents[]


### PR DESCRIPTION
## Summary
- default new workspaces to `private` in the schema
- ensure workspace creation sets `private: true`
- add migration to update the default value

## Testing
- `yarn test` *(fails: `@prisma/client did not initialize yet`)*

------
https://chatgpt.com/codex/tasks/task_e_688c94c27ee88328b18b287692a0ead3