### PR TITLE
Enforce admin/manager presence in workspaces

### DIFF
--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -56,7 +56,7 @@ const TRANSLATIONS = {
       description:
         "Create your first workspace and get started with AnythingLLM.",
       adminWarning:
-        "Each workspace must always have at least one admin. Removing all admin users can break workspace features.",
+        "Each workspace must always have at least one admin or manager. Removing all elevated users can break workspace features.",
     },
   },
   common: {
@@ -74,7 +74,7 @@ const TRANSLATIONS = {
     no: "No",
     search: "Search",
     adminRemoveWarning:
-      "Admins are automatically part of every workspace. Removing all admin users will break workspace features.",
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
 
   // Setting Sidebar menu items.

--- a/server/models/workspace.js
+++ b/server/models/workspace.js
@@ -438,14 +438,14 @@ const Workspace = {
     try {
       const { User } = require("./user");
       const { ROLES } = require("../utils/middleware/multiUserProtected");
-      const adminCount = await User.count({
+      const adminManagerCount = await User.count({
         id: { in: userIds.map(Number) },
-        role: ROLES.admin,
+        role: { in: [ROLES.admin, ROLES.manager] },
       });
-      if (adminCount === 0) {
+      if (adminManagerCount === 0) {
         return {
           success: false,
-          error: "Workspace must include at least one admin user.",
+          error: "Workspace must include at least one admin or manager user.",
         };
       }
 


### PR DESCRIPTION
## Summary
- require at least one admin or manager in each workspace when updating users
- update English locale messages to mention admins or managers

## Testing
- `npm test --silent` *(fails: @prisma/client did not initialize)*

------
https://chatgpt.com/codex/tasks/task_e_688c99208288832882dc4ab5fd0dc329