### PR TITLE
fix: use string for Prisma role permissions on SQLite

### DIFF
--- a/server/models/roles.js
+++ b/server/models/roles.js
@@ -1,5 +1,13 @@
 const prisma = require("../utils/prisma");
 
+const parseRole = (role) => {
+  if (!role) return role;
+  return {
+    ...role,
+    permissions: role.permissions ? JSON.parse(role.permissions) : [],
+  };
+};
+
 const Role = {
   create: async function ({ name, permissions = [] }) {
     try {
@@ -9,7 +17,7 @@ const Role = {
           permissions: JSON.stringify(permissions),
         },
       });
-      return { role, error: null };
+      return { role: parseRole(role), error: null };
     } catch (error) {
       console.error(error.message);
       return { role: null, error: error.message };
@@ -28,7 +36,7 @@ const Role = {
             : {}),
         },
       });
-      return { role, error: null };
+      return { role: parseRole(role), error: null };
     } catch (error) {
       console.error(error.message);
       return { role: null, error: error.message };
@@ -48,7 +56,7 @@ const Role = {
   get: async function (clause = {}) {
     try {
       const role = await prisma.roles.findFirst({ where: clause });
-      return role || null;
+      return parseRole(role) || null;
     } catch (error) {
       console.error(error.message);
       return null;
@@ -61,7 +69,7 @@ const Role = {
         where: clause,
         ...(limit !== null ? { take: limit } : {}),
       });
-      return roles;
+      return roles.map(parseRole);
     } catch (error) {
       console.error(error.message);
       return [];

--- a/server/prisma/migrations/20250818220000_init/migration.sql
+++ b/server/prisma/migrations/20250818220000_init/migration.sql
@@ -2,7 +2,7 @@
 CREATE TABLE "roles" (
     "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
     "name" TEXT NOT NULL,
-    "permissions" JSON,
+    "permissions" TEXT,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "lastUpdatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -11,10 +11,7 @@ CREATE TABLE "roles" (
 -- NOTE: workspace_users already exists; we alter to add column
 
 -- AlterTable
-ALTER TABLE "workspace_users" ADD COLUMN "role_id" INTEGER;
-
--- AddForeignKey
-ALTER TABLE "workspace_users" ADD CONSTRAINT "workspace_users_role_id_fkey" FOREIGN KEY ("role_id") REFERENCES "roles" ("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "workspace_users" ADD COLUMN "role_id" INTEGER REFERENCES "roles"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- CreateIndex
 CREATE UNIQUE INDEX "roles_name_key" ON "roles"("name");

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -361,10 +361,10 @@ model prompt_history {
 }
 
 model roles {
-  id            Int      @id @default(autoincrement())
-  name          String   @unique
-  permissions   Json?
-  createdAt     DateTime @default(now())
-  lastUpdatedAt DateTime @updatedAt
+  id              Int               @id @default(autoincrement())
+  name            String            @unique
+  permissions     String?
+  createdAt       DateTime          @default(now())
+  lastUpdatedAt   DateTime          @updatedAt
   workspace_users workspace_users[]
 }


### PR DESCRIPTION
## Summary
- use `String` for `roles.permissions` in Prisma schema and migration to support SQLite
- parse role `permissions` JSON in model helpers

## Testing
- `npx prisma generate`
- `npx eslint models/roles.js --format json`
- `npm test` *(fails: YoutubeTranscript fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6890619cc3cc8328886f952de9b5e3c5