### PR TITLE
Fix sqlite migration defaults

### DIFF
--- a/server/prisma/migrations/20250818220000_init/migration.sql
+++ b/server/prisma/migrations/20250818220000_init/migration.sql
@@ -4,7 +4,7 @@ CREATE TABLE "roles" (
     "name" TEXT NOT NULL,
     "permissions" TEXT,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "lastUpdatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    "lastUpdatedAt" DATETIME NOT NULL
 );
 
 -- CreateTable

--- a/server/prisma/migrations/20250925120000_private_workspace/migration.sql
+++ b/server/prisma/migrations/20250925120000_private_workspace/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "workspaces" ADD COLUMN "private" BOOLEAN DEFAULT false;
+ALTER TABLE "workspaces" ADD COLUMN "private" BOOLEAN NOT NULL DEFAULT true;

--- a/server/prisma/migrations/20251001120000_default_private_true/migration.sql
+++ b/server/prisma/migrations/20251001120000_default_private_true/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "workspaces" ALTER COLUMN "private" SET DEFAULT true;


### PR DESCRIPTION
## Summary
- remove invalid default-changing migration
- set workspace privacy default in original migration
- adjust roles migration to avoid sqlite drift

## Testing
- `yarn prisma:setup`
- `yarn test` *(fails: YoutubeTranscript fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_689077759df0832882a2107377a7b03e