### PR TITLE
Mock YouTube transcript fetch to stabilize tests

### DIFF
--- a/collector/__tests__/utils/extensions/YoutubeTranscript/YoutubeLoader/youtube-transcript.test.js
+++ b/collector/__tests__/utils/extensions/YoutubeTranscript/YoutubeLoader/youtube-transcript.test.js
@@ -1,16 +1,65 @@
 const { YoutubeTranscript } = require("../../../../../utils/extensions/YoutubeTranscript/YoutubeLoader/youtube-transcript.js");
 
 describe("YoutubeTranscript", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   it("should fetch transcript from YouTube video", async () => {
     const videoId = "BJjsfNO5JTo";
+
+    const mockResponse = {
+      actions: [
+        {
+          updateEngagementPanelAction: {
+            content: {
+              transcriptRenderer: {
+                content: {
+                  transcriptSearchPanelRenderer: {
+                    body: {
+                      transcriptSegmentListRenderer: {
+                        initialSegments: [
+                          {
+                            transcriptSegmentRenderer: {
+                              snippet: {
+                                runs: [
+                                  { text: "Hello" },
+                                  { text: " world" },
+                                ],
+                              },
+                            },
+                          },
+                          {
+                            transcriptSegmentRenderer: {
+                              snippet: {
+                                runs: [
+                                  { text: "Another" },
+                                  { text: " segment" },
+                                ],
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    });
+
     const transcript = await YoutubeTranscript.fetchTranscript(videoId, {
       lang: "en",
     });
 
-    expect(transcript).toBeDefined();
-    expect(typeof transcript).toBe("string");
-    expect(transcript.length).toBeGreaterThan(0);
-    // console.log("Success! Transcript length:", transcript.length);
-    // console.log("First 200 characters:", transcript.substring(0, 200) + "...");
-  }, 30000);
+    expect(global.fetch).toHaveBeenCalled();
+    expect(transcript).toBe("Hello world Another segment");
+  });
 });


### PR DESCRIPTION
## Summary
- mock YouTube transcript requests in collector test to remove network dependency

## Testing
- `yarn test`
- `node frontend/src/locales/verifyTranslations.mjs` *(fails: missing translation keys)*
- `yarn prisma:setup` *(fails: cannot find @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_6891056cae8883289e159a002d245e41