### PR TITLE
Handle malformed chat history responses

### DIFF
--- a/server/__tests__/utils/responses/convertHistory.test.js
+++ b/server/__tests__/utils/responses/convertHistory.test.js
@@ -1,0 +1,83 @@
+/* eslint-env jest */
+const moment = require("moment");
+const {
+  convertToChatHistory,
+  convertToPromptHistory,
+} = require("../../../utils/helpers/chat/responses");
+
+describe("convertToChatHistory", () => {
+  test("processes valid history records", () => {
+    const createdAt = Date.now();
+    const history = [
+      {
+        id: 1,
+        prompt: "Hello",
+        response: JSON.stringify({ text: "Hi", sources: [], attachments: [], metrics: {} }),
+        createdAt,
+        feedbackScore: 2,
+      },
+    ];
+
+    const result = convertToChatHistory(history);
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: "Hello",
+        sentAt: moment(createdAt).unix(),
+        attachments: [],
+        chatId: 1,
+      },
+      {
+        type: "chart",
+        role: "assistant",
+        content: "Hi",
+        sources: [],
+        chatId: 1,
+        sentAt: moment(createdAt).unix(),
+        feedbackScore: 2,
+        metrics: {},
+      },
+    ]);
+  });
+
+  test("skips records with malformed response JSON", () => {
+    const history = [
+      { id: 2, prompt: "Hello", response: "malformed", createdAt: Date.now() },
+    ];
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const result = convertToChatHistory(history);
+    expect(result).toEqual([]);
+    expect(logSpy).toHaveBeenCalledWith(
+      "[convertToChatHistory] ChatHistory #2 response is not valid JSON - skipping record."
+    );
+    logSpy.mockRestore();
+  });
+});
+
+describe("convertToPromptHistory", () => {
+  test("processes valid history records", () => {
+    const history = [
+      {
+        id: 1,
+        prompt: "Hello",
+        response: JSON.stringify({ text: "Hi" }),
+      },
+    ];
+    const result = convertToPromptHistory(history);
+    expect(result).toEqual([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+    ]);
+  });
+
+  test("skips records with malformed response JSON", () => {
+    const history = [{ id: 3, prompt: "Hello", response: "malformed" }];
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const result = convertToPromptHistory(history);
+    expect(result).toEqual([]);
+    expect(logSpy).toHaveBeenCalledWith(
+      "[convertToPromptHistory] ChatHistory #3 response is not valid JSON - skipping record."
+    );
+    logSpy.mockRestore();
+  });
+});

--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -124,7 +124,15 @@ function convertToChatHistory(history = []) {
   const formattedHistory = [];
   for (const record of history) {
     const { prompt, response, createdAt, feedbackScore = null, id } = record;
-    const data = JSON.parse(response);
+    let data;
+    try {
+      data = JSON.parse(response);
+    } catch (e) {
+      console.log(
+        `[convertToChatHistory] ChatHistory #${record.id} response is not valid JSON - skipping record.`
+      );
+      continue;
+    }
 
     // In the event that a bad response was stored - we should skip its entire record
     // because it was likely an error and cannot be used in chats and will fail to render on UI.
@@ -173,7 +181,15 @@ function convertToPromptHistory(history = []) {
   const formattedHistory = [];
   for (const record of history) {
     const { prompt, response } = record;
-    const data = JSON.parse(response);
+    let data;
+    try {
+      data = JSON.parse(response);
+    } catch (e) {
+      console.log(
+        `[convertToPromptHistory] ChatHistory #${record.id} response is not valid JSON - skipping record.`
+      );
+      continue;
+    }
 
     // In the event that a bad response was stored - we should skip its entire record
     // because it was likely an error and cannot be used in chats and will fail to render on UI.


### PR DESCRIPTION
## Summary
- Safely parse chat history records by catching JSON parsing errors in `convertToChatHistory` and `convertToPromptHistory`
- Log record IDs and skip entries with malformed responses
- Add unit tests for valid and malformed response handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68917fdeb9408328b06a460ea6e12914