### PR TITLE
Refactor streaming handler for provider hooks

### DIFF
--- a/server/__tests__/utils/AiProviders/deepseekReasoning.test.js
+++ b/server/__tests__/utils/AiProviders/deepseekReasoning.test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+jest.mock("../../../utils/AiProviders/modelMap", () => ({
+  MODEL_MAP: new Map([["deepseek", 8192]]),
+}));
+const { DeepSeekLLM } = require("../../../utils/AiProviders/deepseek");
+
+describe("DeepSeekLLM reasoning stream", () => {
+  beforeEach(() => {
+    process.env.DEEPSEEK_API_KEY = "test";
+  });
+
+  test("streams reasoning content before final answer", async () => {
+    const mockResponse = {
+      write: jest.fn(),
+      on: jest.fn(),
+      removeListener: jest.fn(),
+    };
+
+    async function* generator() {
+      yield { choices: [{ delta: { reasoning_content: "because" } }] };
+      yield { choices: [{ delta: { reasoning_content: " why" } }] };
+      yield { choices: [{ delta: { content: "answer" } }] };
+      yield { choices: [{ finish_reason: "stop" }] };
+    }
+    const stream = generator();
+    stream.endMeasurement = jest.fn();
+
+    const llm = new DeepSeekLLM({
+      embedTextInput: jest.fn(),
+      embedChunks: jest.fn(),
+    });
+
+    const result = await llm.handleStream(mockResponse, stream, {
+      uuid: "1",
+      sources: [],
+    });
+
+    const writes = mockResponse.write.mock.calls.map(([data]) =>
+      JSON.parse(data.replace(/^data: /, "").trim())
+    );
+
+    expect(writes[0].textResponse).toBe("<think>because");
+    expect(writes[1].textResponse).toBe(" why");
+    expect(writes[2].textResponse).toBe("</think>");
+    expect(writes[3].textResponse).toBe("answer");
+    expect(result).toBe("<think>because why</think>answer");
+  });
+});

--- a/server/utils/AiProviders/deepseek/index.js
+++ b/server/utils/AiProviders/deepseek/index.js
@@ -2,12 +2,8 @@ const { NativeEmbedder } = require("../../EmbeddingEngines/native");
 const {
   LLMPerformanceMonitor,
 } = require("../../helpers/chat/LLMPerformanceMonitor");
-const { v4: uuidv4 } = require("uuid");
 const { MODEL_MAP } = require("../modelMap");
-const {
-  writeResponseChunk,
-  clientAbortedHandler,
-} = require("../../helpers/chat/responses");
+const { handleStreamResponse } = require("../../helpers/chat/responses");
 
 class DeepSeekLLM {
   constructor(embedder = null, modelPreference = null) {
@@ -153,143 +149,14 @@ class DeepSeekLLM {
     return measuredStreamRequest;
   }
 
-  // TODO: This is a copy of the generic handleStream function in responses.js
-  // to specifically handle the DeepSeek reasoning model `reasoning_content` field.
-  // When or if ever possible, we should refactor this to be in the generic function.
   handleStream(response, stream, responseProps) {
-    const { uuid = uuidv4(), sources = [] } = responseProps;
-    let hasUsageMetrics = false;
-    let usage = {
-      completion_tokens: 0,
-    };
-
-    return new Promise(async (resolve) => {
-      let fullText = "";
-      let reasoningText = "";
-
-      // Establish listener to early-abort a streaming response
-      // in case things go sideways or the user does not like the response.
-      // We preserve the generated text but continue as if chat was completed
-      // to preserve previously generated content.
-      const handleAbort = () => {
-        stream?.endMeasurement(usage);
-        clientAbortedHandler(resolve, fullText);
-      };
-      response.on("close", handleAbort);
-
-      try {
-        for await (const chunk of stream) {
-          const message = chunk?.choices?.[0];
-          const token = message?.delta?.content;
-          const reasoningToken = message?.delta?.reasoning_content;
-
-          if (
-            chunk.hasOwnProperty("usage") && // exists
-            !!chunk.usage && // is not null
-            Object.values(chunk.usage).length > 0 // has values
-          ) {
-            if (chunk.usage.hasOwnProperty("prompt_tokens")) {
-              usage.prompt_tokens = Number(chunk.usage.prompt_tokens);
-            }
-
-            if (chunk.usage.hasOwnProperty("completion_tokens")) {
-              hasUsageMetrics = true; // to stop estimating counter
-              usage.completion_tokens = Number(chunk.usage.completion_tokens);
-            }
-          }
-
-          // Reasoning models will always return the reasoning text before the token text.
-          if (reasoningToken) {
-            // If the reasoning text is empty (''), we need to initialize it
-            // and send the first chunk of reasoning text.
-            if (reasoningText.length === 0) {
-              writeResponseChunk(response, {
-                uuid,
-                sources: [],
-                type: "textResponseChunk",
-                textResponse: `<think>${reasoningToken}`,
-                close: false,
-                error: false,
-              });
-              reasoningText += `<think>${reasoningToken}`;
-              continue;
-            } else {
-              writeResponseChunk(response, {
-                uuid,
-                sources: [],
-                type: "textResponseChunk",
-                textResponse: reasoningToken,
-                close: false,
-                error: false,
-              });
-              reasoningText += reasoningToken;
-            }
-          }
-
-          // If the reasoning text is not empty, but the reasoning token is empty
-          // and the token text is not empty we need to close the reasoning text and begin sending the token text.
-          if (!!reasoningText && !reasoningToken && token) {
-            writeResponseChunk(response, {
-              uuid,
-              sources: [],
-              type: "textResponseChunk",
-              textResponse: `</think>`,
-              close: false,
-              error: false,
-            });
-            fullText += `${reasoningText}</think>`;
-            reasoningText = "";
-          }
-
-          if (token) {
-            fullText += token;
-            // If we never saw a usage metric, we can estimate them by number of completion chunks
-            if (!hasUsageMetrics) usage.completion_tokens++;
-            writeResponseChunk(response, {
-              uuid,
-              sources: [],
-              type: "textResponseChunk",
-              textResponse: token,
-              close: false,
-              error: false,
-            });
-          }
-
-          // LocalAi returns '' and others return null on chunks - the last chunk is not "" or null.
-          // Either way, the key `finish_reason` must be present to determine ending chunk.
-          if (
-            message?.hasOwnProperty("finish_reason") && // Got valid message and it is an object with finish_reason
-            message.finish_reason !== "" &&
-            message.finish_reason !== null
-          ) {
-            writeResponseChunk(response, {
-              uuid,
-              sources,
-              type: "textResponseChunk",
-              textResponse: "",
-              close: true,
-              error: false,
-            });
-            response.removeListener("close", handleAbort);
-            stream?.endMeasurement(usage);
-            resolve(fullText);
-            break; // Break streaming when a valid finish_reason is first encountered
-          }
-        }
-      } catch (e) {
-        console.log(`\x1b[43m\x1b[34m[STREAMING ERROR]\x1b[0m ${e.message}`);
-        writeResponseChunk(response, {
-          uuid,
-          type: "abort",
-          textResponse: null,
-          sources: [],
-          close: true,
-          error: e.message,
-        });
-        stream?.endMeasurement(usage);
-        resolve(fullText); // Return what we currently have - if anything.
-      }
-    });
+    return handleStreamResponse(
+      response,
+      stream,
+      responseProps,
+      deepseekProcessDelta,
+      () => ({ reasoningText: "" })
+    );
   }
 
   async embedTextInput(textInput) {
@@ -304,6 +171,79 @@ class DeepSeekLLM {
     const messageArray = this.constructPrompt(promptArgs);
     return await messageArrayCompressor(this, messageArray, rawHistory);
   }
+}
+
+function deepseekProcessDelta({
+  message,
+  state,
+  writeResponseChunk,
+  uuid,
+  sources,
+  response,
+}) {
+  const token = message?.delta?.content;
+  const reasoningToken = message?.delta?.reasoning_content;
+
+  if (reasoningToken) {
+    if (state.reasoningText.length === 0) {
+      writeResponseChunk(response, {
+        uuid,
+        sources: [],
+        type: "textResponseChunk",
+        textResponse: `<think>${reasoningToken}`,
+        close: false,
+        error: false,
+      });
+      state.reasoningText += `<think>${reasoningToken}`;
+    } else {
+      writeResponseChunk(response, {
+        uuid,
+        sources: [],
+        type: "textResponseChunk",
+        textResponse: reasoningToken,
+        close: false,
+        error: false,
+      });
+      state.reasoningText += reasoningToken;
+    }
+    return { text: "", usageDelta: 0 };
+  }
+
+  if (state.reasoningText && token) {
+    writeResponseChunk(response, {
+      uuid,
+      sources: [],
+      type: "textResponseChunk",
+      textResponse: `</think>`,
+      close: false,
+      error: false,
+    });
+    const reasoning = state.reasoningText;
+    state.reasoningText = "";
+    writeResponseChunk(response, {
+      uuid,
+      sources: [],
+      type: "textResponseChunk",
+      textResponse: token,
+      close: false,
+      error: false,
+    });
+    return { text: `${reasoning}</think>${token}`, usageDelta: 1 };
+  }
+
+  if (token) {
+    writeResponseChunk(response, {
+      uuid,
+      sources: [],
+      type: "textResponseChunk",
+      textResponse: token,
+      close: false,
+      error: false,
+    });
+    return { text: token, usageDelta: 1 };
+  }
+
+  return { text: "", usageDelta: 0 };
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- extract generic `handleStreamResponse` with provider-specific hooks
- use new handler for DeepSeek reasoning streams
- add unit test for DeepSeek reasoning model

## Testing
- `npm test`
- `npm run lint` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6891be287864832882b37d923c05fdd7