### PR TITLE
Handle aborted streams without leaking listeners

### DIFF
--- a/server/__tests__/utils/responses/handleDefaultStreamResponseV2.test.js
+++ b/server/__tests__/utils/responses/handleDefaultStreamResponseV2.test.js
@@ -1,0 +1,39 @@
+/* eslint-env jest */
+const { EventEmitter } = require('events');
+const { handleDefaultStreamResponseV2 } = require('../../../utils/helpers/chat/responses');
+
+class MockResponse extends EventEmitter {
+  constructor() {
+    super();
+    this.write = jest.fn();
+  }
+}
+
+function createStream() {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      await new Promise(() => {});
+    },
+    endMeasurement: jest.fn(),
+  };
+}
+
+describe('handleDefaultStreamResponseV2', () => {
+  test('cleans up close listeners after aborted requests', async () => {
+    const response = new MockResponse();
+
+    const firstStream = createStream();
+    const firstPromise = handleDefaultStreamResponseV2(response, firstStream, {});
+    expect(response.listenerCount('close')).toBe(1);
+    response.emit('close');
+    await firstPromise;
+    expect(response.listenerCount('close')).toBe(0);
+
+    const secondStream = createStream();
+    const secondPromise = handleDefaultStreamResponseV2(response, secondStream, {});
+    expect(response.listenerCount('close')).toBe(1);
+    response.emit('close');
+    await secondPromise;
+    expect(response.listenerCount('close')).toBe(0);
+  });
+});

--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -55,6 +55,7 @@ function handleStreamResponse(
     // We preserve the generated text but continue as if chat was completed
     // to preserve previously generated content.
     const handleAbort = () => {
+      response.removeListener("close", handleAbort);
       stream?.endMeasurement(usage);
       clientAbortedHandler(resolve, fullText);
     };


### PR DESCRIPTION
## Summary
- remove `close` event listener when streaming responses abort
- test that close listeners are cleaned up across aborted requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891c676838c8328bda14b263d824e7c