### PR TITLE
Use non-interactive GHCR login in build workflows

### DIFF
--- a/.github/workflows/build-and-push-image-semver.yaml
+++ b/.github/workflows/build-and-push-image-semver.yaml
@@ -49,11 +49,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/build-and-push-image.yaml
+++ b/.github/workflows/build-and-push-image.yaml
@@ -68,11 +68,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
## Summary
- avoid interactive GHCR login in build workflows by piping token to `docker login`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892402b5dfc8328b863ed4b296f6e31