### PR TITLE
embed files during upload

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/FileUploadProgress/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/FileUploadProgress/index.jsx
@@ -46,12 +46,12 @@ function FileUploadProgressComponent({
       }, 100);
 
       // Chunk streaming not working in production so we just sit and wait
-      const { response, data } = await Workspace.uploadFile(slug, formData);
+      const { response, data } = await Workspace.uploadAndEmbedFile(slug, formData);
       if (!response.ok) {
         setStatus("failed");
         clearInterval(timer);
-        onUploadError(data.error);
-        setError(data.error);
+        onUploadError(data?.error);
+        setError(data?.error);
       } else {
         setLoading(false);
         setLoadingMessage("");


### PR DESCRIPTION
## Summary
- embed uploaded files in a single API call
- handle upload errors with optional chaining

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894b1ff95fc8328b9d85fc2b306a3eb