### PR TITLE
feat: allow default users to upload to workspaces

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
@@ -114,8 +114,6 @@ export function DnDFileUploaderProvider({ workspace, children }) {
           type: "attachment",
         });
       } else {
-        // If the user is a default user, we do not want to allow them to upload files.
-        if (!!user && user.role === "default") continue;
         newAccepted.push({
           uid: v4(),
           file,
@@ -151,8 +149,6 @@ export function DnDFileUploaderProvider({ workspace, children }) {
           type: "attachment",
         });
       } else {
-        // If the user is a default user, we do not want to allow them to upload files.
-        if (!!user && user.role === "default") continue;
         newAccepted.push({
           uid: v4(),
           file,

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/AttachItem/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/AttachItem/index.jsx
@@ -1,4 +1,3 @@
-import useUser from "@/hooks/useUser";
 import { PaperclipHorizontal } from "@phosphor-icons/react";
 import { Tooltip } from "react-tooltip";
 import { useTranslation } from "react-i18next";
@@ -9,8 +8,6 @@ import { useTranslation } from "react-i18next";
  */
 export default function AttachItem() {
   const { t } = useTranslation();
-  const { user } = useUser();
-  if (!!user && user.role === "default") return null;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- allow default-role accounts to upload documents from chat drag-and-drop
- show attachment button for default users

## Testing
- `npm test`
- `npm run lint` *(fails: anything-llm-server@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6894d69fa91083289b8e08c3f42d954d