### PR TITLE
feat: scope vectors by workspace

### DIFF
--- a/server/endpoints/admin.js
+++ b/server/endpoints/admin.js
@@ -11,6 +11,7 @@ const { WorkspaceChats } = require("../models/workspaceChats");
 const {
   getVectorDbClass,
   getEmbeddingEngineSelection,
+  workspaceVectorNamespace,
 } = require("../utils/helpers");
 const {
   validRoleSelection,
@@ -314,7 +315,8 @@ function adminEndpoints(app) {
         await Document.delete({ workspaceId: Number(workspace.id) });
         await Workspace.delete({ id: Number(workspace.id) });
         try {
-          await VectorDb["delete-namespace"]({ namespace: workspace.slug });
+          const namespace = workspaceVectorNamespace(workspace);
+          await VectorDb["delete-namespace"]({ namespace });
         } catch (e) {
           console.error(e.message);
         }

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -11,7 +11,10 @@ const { Workspace } = require("../models/workspace");
 const { Document } = require("../models/documents");
 const { DocumentVectors } = require("../models/vectors");
 const { WorkspaceChats } = require("../models/workspaceChats");
-const { getVectorDbClass } = require("../utils/helpers");
+const {
+  getVectorDbClass,
+  workspaceVectorNamespace,
+} = require("../utils/helpers");
 const { handleFileUpload, handlePfpUpload } = require("../utils/files/multer");
 const { validatedRequest } = require("../utils/middleware/validatedRequest");
 const { Telemetry } = require("../models/telemetry");
@@ -279,7 +282,8 @@ function workspaceEndpoints(app) {
         );
 
         try {
-          await VectorDb["delete-namespace"]({ namespace: slug });
+          const namespace = workspaceVectorNamespace(workspace);
+          await VectorDb["delete-namespace"]({ namespace });
         } catch (e) {
           console.error(e.message);
         }
@@ -320,7 +324,8 @@ function workspaceEndpoints(app) {
         );
 
         try {
-          await VectorDb["delete-namespace"]({ namespace: slug });
+          const namespace = workspaceVectorNamespace(workspace);
+          await VectorDb["delete-namespace"]({ namespace });
         } catch (e) {
           console.error(e.message);
         }

--- a/server/jobs/sync-watched-documents.js
+++ b/server/jobs/sync-watched-documents.js
@@ -3,7 +3,10 @@ const { DocumentSyncQueue } = require('../models/documentSyncQueue.js');
 const { CollectorApi } = require('../utils/collectorApi');
 const { fileData } = require("../utils/files");
 const { log, conclude, updateSourceDocument } = require('./helpers/index.js');
-const { getVectorDbClass } = require('../utils/helpers/index.js');
+const {
+  getVectorDbClass,
+  workspaceVectorNamespace,
+} = require('../utils/helpers/index.js');
 const { DocumentSyncRun } = require('../models/documentSyncRun.js');
 
 (async () => {
@@ -90,9 +93,10 @@ const { DocumentSyncRun } = require('../models/documentSyncRun.js');
       // update the defined document and workspace vectorDB with the latest information
       // it will skip cache and create a new vectorCache file.
       const vectorDatabase = getVectorDbClass();
-      await vectorDatabase.deleteDocumentFromNamespace(workspace.slug, document.docId);
+      const namespace = workspaceVectorNamespace(workspace);
+      await vectorDatabase.deleteDocumentFromNamespace(namespace, document.docId);
       await vectorDatabase.addDocumentToNamespace(
-        workspace.slug,
+        namespace,
         { ...currentDocumentData, pageContent: newContent, docId: document.docId },
         document.docpath,
         true
@@ -123,9 +127,10 @@ const { DocumentSyncRun } = require('../models/documentSyncRun.js');
           const additionalWorkspace = additionalDocumentRef.workspace;
           workspacesModified.push(additionalWorkspace.slug);
 
-          await vectorDatabase.deleteDocumentFromNamespace(additionalWorkspace.slug, additionalDocumentRef.docId);
+          const addNamespace = workspaceVectorNamespace(additionalWorkspace);
+          await vectorDatabase.deleteDocumentFromNamespace(addNamespace, additionalDocumentRef.docId);
           await vectorDatabase.addDocumentToNamespace(
-            additionalWorkspace.slug,
+            addNamespace,
             { ...currentDocumentData, pageContent: newContent, docId: additionalDocumentRef.docId },
             additionalDocumentRef.docpath,
           );

--- a/server/models/documents.js
+++ b/server/models/documents.js
@@ -1,5 +1,8 @@
 const { v4: uuidv4 } = require("uuid");
-const { getVectorDbClass } = require("../utils/helpers");
+const {
+  getVectorDbClass,
+  workspaceVectorNamespace,
+} = require("../utils/helpers");
 const prisma = require("../utils/prisma");
 const { Telemetry } = require("./telemetry");
 const { EventLogs } = require("./eventLogs");
@@ -102,8 +105,9 @@ const Document = {
         metadata: JSON.stringify(metadata),
       };
 
+      const namespace = workspaceVectorNamespace(workspace);
       const { vectorized, error } = await VectorDb.addDocumentToNamespace(
-        workspace.slug,
+        namespace,
         { ...data, docId },
         path
       );
@@ -148,16 +152,14 @@ const Document = {
     const VectorDb = getVectorDbClass();
     if (removals.length === 0) return;
 
+    const namespace = workspaceVectorNamespace(workspace);
     for (const path of removals) {
       const document = await this.get({
         docpath: path,
         workspaceId: workspace.id,
       });
       if (!document) continue;
-      await VectorDb.deleteDocumentFromNamespace(
-        workspace.slug,
-        document.docId
-      );
+      await VectorDb.deleteDocumentFromNamespace(namespace, document.docId);
 
       try {
         await prisma.workspace_documents.delete({

--- a/server/utils/agents/aibitat/plugins/memory.js
+++ b/server/utils/agents/aibitat/plugins/memory.js
@@ -1,5 +1,9 @@
 const { v4 } = require("uuid");
-const { getVectorDbClass, getLLMProvider } = require("../../../helpers");
+const {
+  getVectorDbClass,
+  getLLMProvider,
+  workspaceVectorNamespace,
+} = require("../../../helpers");
 const { Deduplicator } = require("../utils/dedupe");
 
 const memory = {
@@ -89,9 +93,10 @@ const memory = {
                 model: workspace?.chatModel,
               });
               const vectorDB = getVectorDbClass();
+              const namespace = workspaceVectorNamespace(workspace);
               const { contextTexts = [] } =
                 await vectorDB.performSimilaritySearch({
-                  namespace: workspace.slug,
+                  namespace,
                   input: query,
                   LLMConnector,
                   topN: workspace?.topN ?? 4,
@@ -123,8 +128,9 @@ const memory = {
             try {
               const workspace = this.super.handlerProps.invocation.workspace;
               const vectorDB = getVectorDbClass();
+              const namespace = workspaceVectorNamespace(workspace);
               const { error } = await vectorDB.addDocumentToNamespace(
-                workspace.slug,
+                namespace,
                 {
                   docId: v4(),
                   id: v4(),

--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -1,7 +1,11 @@
 const { v4: uuidv4 } = require("uuid");
 const { DocumentManager } = require("../DocumentManager");
 const { WorkspaceChats } = require("../../models/workspaceChats");
-const { getVectorDbClass, getLLMProvider } = require("../helpers");
+const {
+  getVectorDbClass,
+  getLLMProvider,
+  workspaceVectorNamespace,
+} = require("../helpers");
 const { writeResponseChunk } = require("../helpers/chat/responses");
 const {
   chatPrompt,
@@ -139,9 +143,10 @@ async function chatSync({
     model: workspace?.chatModel,
   });
   const VectorDb = getVectorDbClass();
+  const namespace = workspaceVectorNamespace(workspace);
   const messageLimit = workspace?.openAiHistory || 20;
-  const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
-  const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);
+  const hasVectorizedSpace = await VectorDb.hasNamespace(namespace);
+  const embeddingsCount = await VectorDb.namespaceCount(namespace);
 
   // User is trying to query-mode chat a workspace that has no data in it - so
   // we should exit early as no information can be found under these conditions.
@@ -211,7 +216,7 @@ async function chatSync({
   const vectorSearchResults =
     embeddingsCount !== 0
       ? await VectorDb.performSimilaritySearch({
-          namespace: workspace.slug,
+          namespace,
           input: message,
           LLMConnector,
           similarityThreshold: workspace?.similarityThreshold,
@@ -465,9 +470,10 @@ async function streamChat({
   });
 
   const VectorDb = getVectorDbClass();
+  const namespace = workspaceVectorNamespace(workspace);
   const messageLimit = workspace?.openAiHistory || 20;
-  const hasVectorizedSpace = await VectorDb.hasNamespace(workspace.slug);
-  const embeddingsCount = await VectorDb.namespaceCount(workspace.slug);
+  const hasVectorizedSpace = await VectorDb.hasNamespace(namespace);
+  const embeddingsCount = await VectorDb.namespaceCount(namespace);
 
   // User is trying to query-mode chat a workspace that has no data in it - so
   // we should exit early as no information can be found under these conditions.
@@ -547,7 +553,7 @@ async function streamChat({
   const vectorSearchResults =
     embeddingsCount !== 0
       ? await VectorDb.performSimilaritySearch({
-          namespace: workspace.slug,
+          namespace,
           input: message,
           LLMConnector,
           similarityThreshold: workspace?.similarityThreshold,

--- a/server/utils/chats/embed.js
+++ b/server/utils/chats/embed.js
@@ -1,5 +1,9 @@
 const { v4: uuidv4 } = require("uuid");
-const { getVectorDbClass, getLLMProvider } = require("../helpers");
+const {
+  getVectorDbClass,
+  getLLMProvider,
+  workspaceVectorNamespace,
+} = require("../helpers");
 const { chatPrompt, sourceIdentifier } = require("./index");
 const { EmbedChats } = require("../../models/embedChats");
 const {
@@ -33,10 +37,11 @@ async function streamChatWithForEmbed(
     model: chatModel ?? embed.workspace?.chatModel,
   });
   const VectorDb = getVectorDbClass();
+  const namespace = workspaceVectorNamespace(embed.workspace);
 
   const messageLimit = embed.message_limit ?? 20;
-  const hasVectorizedSpace = await VectorDb.hasNamespace(embed.workspace.slug);
-  const embeddingsCount = await VectorDb.namespaceCount(embed.workspace.slug);
+  const hasVectorizedSpace = await VectorDb.hasNamespace(namespace);
+  const embeddingsCount = await VectorDb.namespaceCount(namespace);
 
   // User is trying to query-mode chat a workspace that has no data in it - so
   // we should exit early as no information can be found under these conditions.
@@ -87,7 +92,7 @@ async function streamChatWithForEmbed(
   const vectorSearchResults =
     embeddingsCount !== 0
       ? await VectorDb.performSimilaritySearch({
-          namespace: embed.workspace.slug,
+          namespace,
           input: message,
           LLMConnector,
           similarityThreshold: embed.workspace?.similarityThreshold,

--- a/server/utils/helpers/index.js
+++ b/server/utils/helpers/index.js
@@ -116,6 +116,30 @@ function getVectorDbClass(getExactly = null) {
 }
 
 /**
+ * Build a vector namespace for a workspace and optional embed profile.
+ * Historically the system used the workspace slug for namespacing which meant
+ * vectors were shared when slugs changed or documents moved.  Namespacing by
+ * workspace id (and profile) ensures embeddings remain isolated per
+ * workspace/profile pair.
+ *
+ * @param {object|number|string} workspace - Workspace object or id value.
+ * @param {number|null} embedProfileId - Optional embed profile id.
+ * @returns {string}
+ */
+function workspaceVectorNamespace(workspace, embedProfileId = null) {
+  const id =
+    typeof workspace === "object"
+      ? workspace?.id ?? workspace?.workspaceId
+      : workspace;
+  const profile =
+    embedProfileId ??
+    (typeof workspace === "object" ? workspace?.embedProfileId : null);
+  if (id === undefined || id === null)
+    throw new Error("Invalid workspace identifier for namespace");
+  return profile ? `${id}-${profile}` : String(id);
+}
+
+/**
  * Returns the LLMProvider with its embedder attached via system or via defined provider.
  * @param {{provider: string | null, model: string | null} | null} params - Initialize params for LLMs provider
  * @returns {BaseLLMProvider}
@@ -459,5 +483,6 @@ module.exports = {
   getLLMProviderClass,
   getBaseLLMProviderModel,
   getLLMProvider,
+  workspaceVectorNamespace,
   toChunks,
 };

--- a/server/utils/vectorStore/resetAllVectorStores.js
+++ b/server/utils/vectorStore/resetAllVectorStores.js
@@ -3,7 +3,7 @@ const { Document } = require("../../models/documents");
 const { DocumentVectors } = require("../../models/vectors");
 const { EventLogs } = require("../../models/eventLogs");
 const { purgeEntireVectorCache } = require("../files");
-const { getVectorDbClass } = require("../helpers");
+const { getVectorDbClass, workspaceVectorNamespace } = require("../helpers");
 
 /**
  * Resets all vector database and associated content:
@@ -42,7 +42,8 @@ async function resetAllVectorStores({ vectorDbKey }) {
     } else {
       for (const workspace of workspaces) {
         try {
-          await VectorDb["delete-namespace"]({ namespace: workspace.slug });
+          const namespace = workspaceVectorNamespace(workspace);
+          await VectorDb["delete-namespace"]({ namespace });
         } catch (e) {
           console.error(e.message);
         }


### PR DESCRIPTION
## Summary
- add `workspaceVectorNamespace` helper to build workspace+profile namespaces
- update document ingestion, sync job and chat flows to use workspace-scoped namespaces
- ensure vector store resets and admin deletion use workspace ids

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898800480688328a7a0f0b6e72e5704