### PR TITLE
feat: live document processing statuses

### DIFF
--- a/frontend/__tests__/jobStream.test.js
+++ b/frontend/__tests__/jobStream.test.js
@@ -1,0 +1,63 @@
+const { listenToJob } = require("../src/utils/jobStream.js");
+const { isProcessingStatus } = require("../src/utils/documentStatus.js");
+
+jest.useFakeTimers();
+
+describe("listenToJob", () => {
+  test("receives status events", () => {
+    let instance;
+    global.EventSource = class {
+      constructor() {
+        instance = this;
+      }
+      close() {}
+    };
+    const statuses = [];
+    listenToJob("123", (s) => statuses.push(s));
+    instance.onmessage({ data: JSON.stringify({ status: "downloading" }) });
+    instance.onmessage({ data: JSON.stringify({ status: "failed" }) });
+    expect(statuses).toEqual(["DOWNLOADING", "FAILED"]);
+  });
+
+  test("reconnects after error", () => {
+    let instances = 0;
+    const handlers = [];
+    global.EventSource = class {
+      constructor() {
+        instances++;
+        handlers.push(this);
+      }
+      close() {}
+    };
+    listenToJob("abc", () => {});
+    expect(instances).toBe(1);
+    handlers[0].onerror();
+    jest.runOnlyPendingTimers();
+    expect(instances).toBe(2);
+  });
+
+  test("simulated failures at each stage", () => {
+    let instance;
+    global.EventSource = class {
+      constructor() {
+        instance = this;
+      }
+      close() {}
+    };
+    const received = [];
+    listenToJob("job", (s) => received.push(s));
+    const stages = [
+      "PENDING",
+      "DOWNLOADING",
+      "CHUNKING",
+      "EMBEDDING",
+      "INDEXING",
+    ];
+    stages.forEach((stage) => {
+      instance.onmessage({ data: JSON.stringify({ status: stage }) });
+      expect(isProcessingStatus(stage)).toBe(true);
+      instance.onmessage({ data: JSON.stringify({ status: "FAILED" }) });
+      expect(received[received.length - 1]).toBe("FAILED");
+    });
+  });
+});

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FileRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FileRow/index.jsx
@@ -5,6 +5,7 @@ import {
   middleTruncate,
 } from "@/utils/directories";
 import { File } from "@phosphor-icons/react";
+import StatusBadge from "@/components/StatusBadge";
 
 export default function FileRow({ item, selected, toggleSelection }) {
   return (
@@ -42,10 +43,14 @@ export default function FileRow({ item, selected, toggleSelection }) {
         </p>
       </div>
       <div className="col-span-2 flex justify-end items-center">
-        {item?.cached && (
-          <div className="bg-theme-settings-input-active rounded-3xl">
-            <p className="text-xs px-2 py-0.5">Cached</p>
-          </div>
+        {item?.status ? (
+          <StatusBadge status={item.status} />
+        ) : (
+          item?.cached && (
+            <div className="bg-theme-settings-input-active rounded-3xl">
+              <p className="text-xs px-2 py-0.5">Cached</p>
+            </div>
+          )
         )}
       </div>
     </tr>

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
@@ -8,6 +8,7 @@ import { ArrowUUpLeft, Eye, File, PushPin } from "@phosphor-icons/react";
 import Workspace from "@/models/workspace";
 import showToast from "@/utils/toast";
 import System from "@/models/system";
+import StatusBadge from "@/components/StatusBadge";
 
 export default function WorkspaceFileRow({
   item,
@@ -98,7 +99,9 @@ export default function WorkspaceFileRow({
         </p>
       </div>
       <div className="col-span-2 flex justify-end items-center">
-        {hasChanges ? (
+        {item?.status ? (
+          <StatusBadge status={item.status} />
+        ) : hasChanges ? (
           <div className="w-4 h-4 ml-2 flex-shrink-0" />
         ) : (
           <div className="flex gap-x-2 items-center">

--- a/frontend/src/components/StatusBadge/index.jsx
+++ b/frontend/src/components/StatusBadge/index.jsx
@@ -1,0 +1,34 @@
+import { CircleNotch } from "@phosphor-icons/react";
+import { DOCUMENT_STATUS_LABELS, isProcessingStatus } from "@/utils/documentStatus";
+
+export default function StatusBadge({ status }) {
+  if (!status) return null;
+  const upper = status.toUpperCase();
+  const label = DOCUMENT_STATUS_LABELS[upper] || upper;
+
+  if (upper === "READY") {
+    return (
+      <span className="bg-green-600 text-white text-[10px] px-2 py-0.5 rounded-3xl">
+        {label}
+      </span>
+    );
+  }
+  if (upper === "FAILED") {
+    return (
+      <span className="bg-red-600 text-white text-[10px] px-2 py-0.5 rounded-3xl">
+        {label}
+      </span>
+    );
+  }
+
+  if (isProcessingStatus(upper)) {
+    return (
+      <span className="flex items-center gap-1 text-[10px] text-white">
+        <CircleNotch size={10} className="animate-spin" />
+        {label}
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
@@ -12,6 +12,15 @@ import {
 } from "@phosphor-icons/react";
 import { REMOVE_ATTACHMENT_EVENT } from "../../DnDWrapper";
 import { Tooltip } from "react-tooltip";
+import { isProcessingStatus } from "@/utils/documentStatus";
+
+const STATUS_TEXT = {
+  PENDING: "Pending...",
+  DOWNLOADING: "Downloading...",
+  CHUNKING: "Chunking...",
+  EMBEDDING: "Embedding...",
+  INDEXING: "Indexing...",
+};
 
 /**
  * @param {{attachments: import("../../DnDWrapper").Attachment[]}}
@@ -42,7 +51,8 @@ function AttachmentItem({ attachment }) {
     );
   }
 
-  if (status === "in_progress") {
+  if (isProcessingStatus(status)) {
+    const label = STATUS_TEXT[status.toUpperCase()] || "Processing...";
     return (
       <div className="relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-bg border-none w-[180px] group">
         <div
@@ -59,14 +69,14 @@ function AttachmentItem({ attachment }) {
             {file.name}
           </p>
           <p className="text-theme-attachment-text-secondary text-[10px] leading-[14px] font-medium">
-            Uploading...
+            {label}
           </p>
         </div>
       </div>
     );
   }
 
-  if (status === "failed") {
+  if (status === "FAILED") {
     return (
       <>
         <div
@@ -95,6 +105,20 @@ function AttachmentItem({ attachment }) {
             <p className="text-theme-attachment-text-secondary text-[10px] leading-[14px] font-medium truncate">
               {error ?? "File not embedded!"}
             </p>
+            <div className="flex gap-1 mt-1">
+              <button
+                onClick={removeFileFromQueue}
+                className="text-theme-attachment-text-secondary text-[10px] underline"
+              >
+                Retry
+              </button>
+              <a
+                href="/"
+                className="text-theme-attachment-text-secondary text-[10px] underline"
+              >
+                Open settings
+              </a>
+            </div>
           </div>
         </div>
         <Tooltip
@@ -107,7 +131,7 @@ function AttachmentItem({ attachment }) {
     );
   }
 
-  if (type === "attachment") {
+  if (status === "READY" && type === "attachment") {
     return (
       <>
         <div
@@ -156,48 +180,52 @@ function AttachmentItem({ attachment }) {
     );
   }
 
-  return (
-    <>
-      <div
-        data-tooltip-id={`attachment-uid-${uid}-success`}
-        data-tooltip-content={`${file.name} was uploaded and embedded into this workspace. It will be available for RAG chat now.`}
-        className={`relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-bg border-none w-[180px] group`}
-      >
-        <div className="invisible group-hover:visible absolute -top-[5px] -right-[5px] w-fit h-fit z-[10]">
-          <button
-            onClick={removeFileFromQueue}
-            type="button"
-            className="bg-white hover:bg-error hover:text-theme-attachment-text rounded-full p-1 flex items-center justify-center hover:border-transparent border border-theme-attachment-bg"
-          >
-            <X size={10} className="flex-shrink-0" />
-          </button>
-        </div>
+  if (status === "READY") {
+    return (
+      <>
         <div
-          className={`${iconBgColor} rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
+          data-tooltip-id={`attachment-uid-${uid}-success`}
+          data-tooltip-content={`${file.name} was uploaded and embedded into this workspace. It will be available for RAG chat now.`}
+          className={`relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-bg border-none w-[180px] group`}
         >
-          <Icon
-            size={24}
-            weight="light"
-            className="text-theme-attachment-icon"
-          />
+          <div className="invisible group-hover:visible absolute -top-[5px] -right-[5px] w-fit h-fit z-[10]">
+            <button
+              onClick={removeFileFromQueue}
+              type="button"
+              className="bg-white hover:bg-error hover:text-theme-attachment-text rounded-full p-1 flex items-center justify-center hover:border-transparent border border-theme-attachment-bg"
+            >
+              <X size={10} className="flex-shrink-0" />
+            </button>
+          </div>
+          <div
+            className={`${iconBgColor} rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
+          >
+            <Icon
+              size={24}
+              weight="light"
+              className="text-theme-attachment-icon"
+            />
+          </div>
+          <div className="flex flex-col w-[125px]">
+            <p className="text-white text-xs font-semibold truncate">
+              {file.name}
+            </p>
+            <p className="text-theme-attachment-text-secondary text-[10px] leading-[14px] font-medium">
+              File embedded!
+            </p>
+          </div>
         </div>
-        <div className="flex flex-col w-[125px]">
-          <p className="text-white text-xs font-semibold truncate">
-            {file.name}
-          </p>
-          <p className="text-theme-attachment-text-secondary text-[10px] leading-[14px] font-medium">
-            File embedded!
-          </p>
-        </div>
-      </div>
-      <Tooltip
-        id={`attachment-uid-${uid}-success`}
-        place="top"
-        delayShow={300}
-        className="allm-tooltip !allm-text-xs"
-      />
-    </>
-  );
+        <Tooltip
+          id={`attachment-uid-${uid}-success`}
+          place="top"
+          delayShow={300}
+          className="allm-tooltip !allm-text-xs"
+        />
+      </>
+    );
+  }
+
+  return null;
 }
 
 /**

--- a/frontend/src/utils/documentStatus.js
+++ b/frontend/src/utils/documentStatus.js
@@ -1,0 +1,33 @@
+const DOCUMENT_JOB_STATUSES = [
+  "PENDING",
+  "DOWNLOADING",
+  "CHUNKING",
+  "EMBEDDING",
+  "INDEXING",
+  "READY",
+  "FAILED",
+];
+
+const DOCUMENT_STATUS_LABELS = {
+  PENDING: "Pending",
+  DOWNLOADING: "Downloading",
+  CHUNKING: "Chunking",
+  EMBEDDING: "Embedding",
+  INDEXING: "Indexing",
+  READY: "Ready",
+  FAILED: "Failed",
+};
+
+function isProcessingStatus(status) {
+  return (
+    status &&
+    !["READY", "FAILED"].includes(status.toUpperCase()) &&
+    DOCUMENT_JOB_STATUSES.includes(status.toUpperCase())
+  );
+}
+
+module.exports = {
+  DOCUMENT_JOB_STATUSES,
+  DOCUMENT_STATUS_LABELS,
+  isProcessingStatus,
+};

--- a/frontend/src/utils/jobStream.js
+++ b/frontend/src/utils/jobStream.js
@@ -1,0 +1,35 @@
+const API_BASE = process.env.API_BASE || "/api";
+
+/**
+ * Subscribe to document processing job updates via SSE.
+ * Automatically reconnects on failure.
+ * @param {string} jobId
+ * @param {(status:string)=>void} onStatus
+ * @returns {() => void} cleanup function
+ */
+function listenToJob(jobId, onStatus) {
+  let es;
+  const connect = () => {
+    es = new EventSource(`${API_BASE}/document/${jobId}/events`, {
+      withCredentials: true,
+    });
+    es.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        if (data?.status) {
+          onStatus(data.status.toUpperCase());
+        }
+      } catch (err) {
+        // ignore invalid messages
+      }
+    };
+    es.onerror = () => {
+      es.close();
+      setTimeout(connect, 3000);
+    };
+  };
+  connect();
+  return () => es && es.close();
+}
+
+module.exports = { listenToJob };


### PR DESCRIPTION
## Summary
- show unified processing badges for workspace files and attachments
- stream job updates via SSE with auto-reconnect
- basic hook tests simulating stage failures

## Tech
- SSE/WebSocket channel; status badges

## Tests
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6898d7bc55408328ba00199fa3762f73