### PR TITLE
fix: add missing admin warning translations

### DIFF
--- a/frontend/src/locales/ar/common.js
+++ b/frontend/src/locales/ar/common.js
@@ -53,6 +53,7 @@ const TRANSLATIONS = {
       title: "قم بإنشاء مساحة العمل الأولى الخاصة بك",
       description:
         "قم بإنشاء مساحة العمل الأولى الخاصة بك وابدأ مع إيني ثينك إلْلْمْ.",
+      adminWarning: null,
     },
   },
   common: {
@@ -69,6 +70,8 @@ const TRANSLATIONS = {
     yes: "نعم",
     no: "لا",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "إعدادات المثيل",
@@ -635,6 +638,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/da/common.js
+++ b/frontend/src/locales/da/common.js
@@ -55,6 +55,7 @@ const TRANSLATIONS = {
       title: "Opret dit første arbejdsområde",
       description:
         "Opret dit første arbejdsområde og kom i gang med OneNew.",
+      adminWarning: null,
     },
   },
   common: {
@@ -71,6 +72,8 @@ const TRANSLATIONS = {
     yes: "Ja",
     no: "Nej",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Instansindstillinger",
@@ -667,6 +670,15 @@ const TRANSLATIONS = {
       "fetch-website": "Hent hjemmeside",
       "privacy-notice":
         "Disse filer vil blive uploadet til dokumentbehandleren, der kører på denne OneNew-instans. Filene sendes ikke eller deles med en tredjepart.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "Hvad er dokumentfastlåsning?",

--- a/frontend/src/locales/de/common.js
+++ b/frontend/src/locales/de/common.js
@@ -55,6 +55,7 @@ const TRANSLATIONS = {
       title: "Ersten Workspace erstellen",
       description:
         "Erstellen Sie Ihren ersten Workspace und starten Sie OneNew.",
+      adminWarning: null,
     },
   },
   common: {
@@ -71,6 +72,8 @@ const TRANSLATIONS = {
     yes: "Ja",
     no: "Nein",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Instanzeinstellungen",
@@ -873,6 +876,15 @@ const TRANSLATIONS = {
       "fetch-website": "Website abrufen",
       "privacy-notice":
         "Diese Dateien werden zum Dokumentenprozessor hochgeladen, der auf dieser OneNew-Instanz läuft. Diese Dateien werden nicht an Dritte gesendet oder geteilt.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "Was bedeutet es Dokumente anzuheften?",

--- a/frontend/src/locales/es/common.js
+++ b/frontend/src/locales/es/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Configuración de instancia",
@@ -634,6 +637,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/et/common.js
+++ b/frontend/src/locales/et/common.js
@@ -53,6 +53,7 @@ const TRANSLATIONS = {
     workspace: {
       title: "Loo oma esimene tööruum",
       description: "Loo esimene tööruum ja alusta OneNew-iga.",
+      adminWarning: null,
     },
   },
   common: {
@@ -69,6 +70,8 @@ const TRANSLATIONS = {
     yes: "Jah",
     no: "Ei",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Instantsi seaded",
@@ -834,6 +837,15 @@ const TRANSLATIONS = {
       "fetch-website": "Tõmba veebisait",
       "privacy-notice":
         "Failid laetakse üles selle instantsi dokumenditöötlejasse ega jagata kolmandatele osapooltele.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "Mis on dokumendi kinnitamine?",

--- a/frontend/src/locales/fa/common.js
+++ b/frontend/src/locales/fa/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "تنظیمات سامانه",
@@ -627,6 +630,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/fr/common.js
+++ b/frontend/src/locales/fr/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Paramètres de l'instance",
@@ -635,6 +638,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/he/common.js
+++ b/frontend/src/locales/he/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "הגדרות מופע",
@@ -620,6 +623,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/it/common.js
+++ b/frontend/src/locales/it/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Impostazioni istanza",
@@ -633,6 +636,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/ja/common.js
+++ b/frontend/src/locales/ja/common.js
@@ -54,6 +54,7 @@ const TRANSLATIONS = {
       title: "最初のワークスペースを作成する",
       description:
         "最初のワークスペースを作成して、OneNewを始めましょう。",
+      adminWarning: null,
     },
   },
   common: {
@@ -70,6 +71,8 @@ const TRANSLATIONS = {
     yes: "はい",
     no: "いいえ",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "インスタンス設定",
@@ -660,6 +663,15 @@ const TRANSLATIONS = {
       "fetch-website": "ウェブサイトを取得",
       "privacy-notice":
         "これらのファイルは、このOneNewインスタンス上のドキュメント処理機能にアップロードされます。第三者に送信・共有されることはありません。",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "ドキュメントのピン留めとは？",

--- a/frontend/src/locales/ko/common.js
+++ b/frontend/src/locales/ko/common.js
@@ -53,6 +53,7 @@ const TRANSLATIONS = {
       title: "첫 번째 워크스페이스 만들기",
       description:
         "첫 번째 워크스페이스를 생성하고 OneNew을 시작해보세요.",
+      adminWarning: null,
     },
   },
   common: {
@@ -69,6 +70,8 @@ const TRANSLATIONS = {
     yes: "예",
     no: "아니오",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "인스턴스 설정",
@@ -849,6 +852,15 @@ const TRANSLATIONS = {
       "fetch-website": "웹사이트 가져오기",
       "privacy-notice":
         "이 파일들은 이 OneNew 인스턴스에서 실행 중인 문서 처리기로 업로드됩니다. 파일은 제3자에게 전송되거나 공유되지 않습니다.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "문서 고정이란 무엇인가요?",

--- a/frontend/src/locales/lv/common.js
+++ b/frontend/src/locales/lv/common.js
@@ -54,6 +54,7 @@ const TRANSLATIONS = {
       title: "Izveidojiet savu pirmo darba telpu",
       description:
         "Izveidojiet savu pirmo darba telpu un sāciet darbu ar OneNew.",
+      adminWarning: null,
     },
   },
   common: {
@@ -70,6 +71,8 @@ const TRANSLATIONS = {
     yes: "Jā",
     no: "Nē",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Instances iestatījumi",
@@ -865,6 +868,15 @@ const TRANSLATIONS = {
       "fetch-website": "Iegūt vietni",
       "privacy-notice":
         "Šie faili tiks augšupielādēti dokumentu apstrādātājā, kas darbojas šajā OneNew instancē. Šie faili netiek nosūtīti vai kopīgoti ar trešo pusi.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "Kas ir dokumentu piespraušana?",

--- a/frontend/src/locales/nl/common.js
+++ b/frontend/src/locales/nl/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Instelling Instanties",
@@ -630,6 +633,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/pl/common.js
+++ b/frontend/src/locales/pl/common.js
@@ -55,6 +55,7 @@ const TRANSLATIONS = {
       title: "Utwórz swój pierwszy obszar roboczy",
       description:
         "Stwórz swój pierwszy obszar roboczy i zacznij korzystać z OneNew.",
+      adminWarning: null,
     },
   },
   common: {
@@ -71,6 +72,8 @@ const TRANSLATIONS = {
     yes: "Tak",
     no: "Nie",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Ustawienia instancji",
@@ -869,6 +872,15 @@ const TRANSLATIONS = {
       "fetch-website": "Pobierz zawartość strony",
       "privacy-notice":
         "Pliki zostaną przetworzone w obrębie danej instancji OneNew. Pliki te nie będą udostępniane innym podmiotom.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "Czym jest przypinanie dokumentów?",

--- a/frontend/src/locales/pt_BR/common.js
+++ b/frontend/src/locales/pt_BR/common.js
@@ -53,6 +53,7 @@ const TRANSLATIONS = {
     workspace: {
       title: "Crie seu primeiro workspace",
       description: "Crie seu primeiro workspace e comece a usar o OneNew.",
+      adminWarning: null,
     },
   },
   common: {
@@ -69,6 +70,8 @@ const TRANSLATIONS = {
     yes: "Sim",
     no: "Não",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Configurações da Instância",
@@ -845,6 +848,15 @@ const TRANSLATIONS = {
       "fetch-website": "Buscar site",
       "privacy-notice":
         "Esses arquivos são enviados ao processador local do OneNew. Não são compartilhados com terceiros.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "O que é fixar documento?",

--- a/frontend/src/locales/ru/common.js
+++ b/frontend/src/locales/ru/common.js
@@ -54,6 +54,7 @@ const TRANSLATIONS = {
       title: "Создайте ваше первое рабочее пространство",
       description:
         "Создайте ваше первое рабочее пространство и начните работу с OneNew.",
+      adminWarning: null,
     },
   },
   common: {
@@ -70,6 +71,8 @@ const TRANSLATIONS = {
     yes: "Да",
     no: "Нет",
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Настройки экземпляра",
@@ -668,6 +671,15 @@ const TRANSLATIONS = {
       "fetch-website": "Получить сайт",
       "privacy-notice":
         "Эти файлы будут загружены в процессор документов на этом экземпляре OneNew. Файлы не отправляются и не передаются третьим лицам.",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "Что такое закрепление документа?",

--- a/frontend/src/locales/tr/common.js
+++ b/frontend/src/locales/tr/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Instance Ayarları",
@@ -630,6 +633,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/vn/common.js
+++ b/frontend/src/locales/vn/common.js
@@ -46,6 +46,7 @@ const TRANSLATIONS = {
     workspace: {
       title: null,
       description: null,
+      adminWarning: null,
     },
   },
   common: {
@@ -62,6 +63,8 @@ const TRANSLATIONS = {
     yes: null,
     no: null,
     search: null,
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "Cài đặt hệ thống",
@@ -629,6 +632,15 @@ const TRANSLATIONS = {
       fetching: null,
       "fetch-website": null,
       "privacy-notice": null,
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: null,

--- a/frontend/src/locales/zh/common.js
+++ b/frontend/src/locales/zh/common.js
@@ -50,6 +50,7 @@ const TRANSLATIONS = {
     workspace: {
       title: "创建你的第一个工作区",
       description: "创建你的第一个工作区并开始使用 OneNew。",
+      adminWarning: null,
     },
   },
   common: {
@@ -66,6 +67,8 @@ const TRANSLATIONS = {
     yes: "是",
     no: "否",
     search: "搜索",
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "设置",
@@ -796,6 +799,15 @@ const TRANSLATIONS = {
       "fetch-website": "获取网站",
       "privacy-notice":
         "这些文件将被上传到此 OneNew 实例上的文档处理器。这些文件不会发送或共享给第三方。",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "什么是文档固定？",

--- a/frontend/src/locales/zh_TW/common.js
+++ b/frontend/src/locales/zh_TW/common.js
@@ -50,6 +50,7 @@ const TRANSLATIONS = {
     workspace: {
       title: "創建您的第一個工作區",
       description: "創建您的第一個工作區並開始使用 OneNew。",
+      adminWarning: null,
     },
   },
   common: {
@@ -66,6 +67,8 @@ const TRANSLATIONS = {
     yes: "是",
     no: "否",
     search: "搜尋",
+    adminRemoveWarning:
+      "Admins and managers are automatically part of every workspace. Removing all elevated users will break workspace features.",
   },
   settings: {
     title: "系統設定",
@@ -629,6 +632,15 @@ const TRANSLATIONS = {
       "fetch-website": "擷取網站",
       "privacy-notice":
         "這些檔案將上傳到此 OneNew 實例中的文件處理器。這些檔案不會發送或共享給第三方。",
+      preflight: {
+        title: null,
+        summary: null,
+        conflict: null,
+        replace: null,
+        keep_both: null,
+        skip: null,
+        "add_to_library": null,
+      },
     },
     pinning: {
       what_pinning: "什麼是文件固定？",


### PR DESCRIPTION
## Summary
- add `adminRemoveWarning` translation key across all locales
- sync locale schemas with placeholders for `workspace.adminWarning` and `upload.preflight`

## Testing
- `node frontend/src/locales/verifyTranslations.mjs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898ee113f5483288f193b670e3243d0