### PR TITLE
fix(frontend): replace FolderNotch icon

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FolderRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FolderRow/index.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import FileRow from "../FileRow";
-import { CaretDown, FolderNotch } from "@phosphor-icons/react";
+import { CaretDown, Folder } from "@phosphor-icons/react";
 import { middleTruncate } from "@/utils/directories";
 
 export default function FolderRow({
@@ -53,7 +53,7 @@ export default function FolderRow({
           >
             <CaretDown className="text-base font-bold w-4 h-4" />
           </div>
-          <FolderNotch
+          <Folder
             className="shrink-0 text-base font-bold w-4 h-4 mr-[3px]"
             weight="fill"
           />


### PR DESCRIPTION
## Summary
- fix broken FolderNotch import in Document Directory folder rows

## Testing
- `cd frontend && yarn prettier src/components/Modals/ManageWorkspace/Documents/Directory/FolderRow/index.jsx --write`
- `yarn test` *(fails: Cannot find module 'lodash' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b173bf9b08328b8d79efd0d47ad2e