### PR TITLE
fix: add tus server options

### DIFF
--- a/server/endpoints/uploads.js
+++ b/server/endpoints/uploads.js
@@ -12,8 +12,10 @@ function uploadEndpoints(app) {
       : path.resolve(process.env.STORAGE_DIR, 'uploads');
   if (!fs.existsSync(uploadDir)) fs.mkdirSync(uploadDir, { recursive: true });
 
-  const tusServer = new TusServer();
-  tusServer.datastore = new FileStore({ path: uploadDir });
+  const tusServer = new TusServer({
+    path: '/uploads',
+    datastore: new FileStore({ path: uploadDir }),
+  });
 
   app.all('/uploads/*', (req, res) => {
     tusServer.handle(req, res);


### PR DESCRIPTION
## Summary
- add required path and datastore options when creating Tus server

## Testing
- `yarn test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_689b3a5c173c83289dc5cc035004a59f