### PR TITLE
fix: configure tus datastore correctly

### DIFF
--- a/server/endpoints/uploads.js
+++ b/server/endpoints/uploads.js
@@ -14,10 +14,10 @@ function uploadEndpoints(app) {
 
   const tusServer = new TusServer({
     path: "/uploads",
-    // FileStore expects a `directory` option pointing to the upload folder.
-    // Passing `path` results in an undefined directory and crashes on startup.
-    datastore: new FileStore({ directory: uploadDir }),
   });
+  // FileStore expects a `directory` option pointing to the upload folder.
+  // Passing `path` results in an undefined directory and crashes on startup.
+  tusServer.datastore = new FileStore({ directory: uploadDir });
 
   app.all("/uploads/*", (req, res) => {
     tusServer.handle(req, res);


### PR DESCRIPTION
## Summary
- ensure tus FileStore is initialized via `tusServer.datastore`
- avoid startup crash when handling upload events

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module 'uuid'...)*

------
https://chatgpt.com/codex/tasks/task_e_689b86e0a4508328b62d5b7ab6328ae8