### PR TITLE
chore: update yarn.lock to match package.json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,3 +3425,4 @@ __metadata:
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard
+


### PR DESCRIPTION
## Summary
- run `yarn install` so the lockfile matches `package.json`

## Testing
- `yarn test` *(fails: Cannot find module 'lodash' from server/__tests__/utils/TextSplitter)*

------
https://chatgpt.com/codex/tasks/task_e_689b8a06918883289d656a33d3b0448e