### PR TITLE
Handle invalid path uploads as client errors

### DIFF
--- a/server/endpoints/api/document/index.js
+++ b/server/endpoints/api/document/index.js
@@ -907,7 +907,8 @@ function apiDocumentEndpoints(app) {
         response.status(200).json({ success: true, message: null });
       } catch (e) {
         console.error(e);
-        response.status(500).json({
+        const isPathError = /Invalid path/.test(e.message);
+        response.status(isPathError ? 400 : 500).json({
           success: false,
           message: `Failed to create folder: ${e.message}`,
         });

--- a/server/endpoints/system.js
+++ b/server/endpoints/system.js
@@ -751,7 +751,10 @@ function systemEndpoints(app) {
         });
       } catch (error) {
         console.error("Error processing the profile picture upload:", error);
-        response.status(500).json({ message: "Internal server error" });
+        const isPathError = /Invalid path/.test(error.message);
+        response
+          .status(isPathError ? 400 : 500)
+          .json({ message: isPathError ? error.message : "Internal server error" });
       }
     }
   );
@@ -787,7 +790,10 @@ function systemEndpoints(app) {
         });
       } catch (error) {
         console.error("Error processing the profile picture removal:", error);
-        response.status(500).json({ message: "Internal server error" });
+        const isPathError = /Invalid path/.test(error.message);
+        response
+          .status(isPathError ? 400 : 500)
+          .json({ message: isPathError ? error.message : "Internal server error" });
       }
     }
   );

--- a/server/endpoints/workspaces.js
+++ b/server/endpoints/workspaces.js
@@ -739,7 +739,10 @@ function workspaceEndpoints(app) {
         });
       } catch (error) {
         console.error("Error processing the profile picture upload:", error);
-        response.status(500).json({ message: "Internal server error" });
+        const isPathError = /Invalid path/.test(error.message);
+        response
+          .status(isPathError ? 400 : 500)
+          .json({ message: isPathError ? error.message : "Internal server error" });
       }
     }
   );
@@ -783,7 +786,10 @@ function workspaceEndpoints(app) {
         });
       } catch (error) {
         console.error("Error processing the profile picture removal:", error);
-        response.status(500).json({ message: "Internal server error" });
+        const isPathError = /Invalid path/.test(error.message);
+        response
+          .status(isPathError ? 400 : 500)
+          .json({ message: isPathError ? error.message : "Internal server error" });
       }
     }
   );


### PR DESCRIPTION
## Summary
- send HTTP 400 for invalid path errors during folder creation
- report invalid path issues for workspace and system profile picture uploads

## Testing
- `yarn test` *(fails: Cannot find module 'lodash', 'uuid', 'moment', '@prisma/client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689b9f7fa0388328b24cc021e99116c2