### PR TITLE
fix: update yarn.lock to match package.json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,4 +3425,3 @@ __metadata:
   checksum: 10c0/dceb44c28578b31641e13695d200d34ec4ab3966a5729814d5445b194933c096b7ced71494ce53a0e8820685d1d010df8b2422e5bf2cdea7e469d97ffbea306f
   languageName: node
   linkType: hard
-


### PR DESCRIPTION
## Summary
- update yarn.lock to match package.json

## Testing
- `yarn lint` *(fails: command interrupted due to large output)*
- `yarn test` *(fails: Cannot find module 'moment', 'uuid', '@prisma/client' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689ba2c8cdfc83289e286a6ce9929807