### PR TITLE
Fix invalid paths when uploading workspace files

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/FileUploadProgress/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/FileUploadProgress/index.jsx
@@ -46,7 +46,10 @@ function FileUploadProgressComponent({
       formData.append("policy", policy);
       const pathName = file.path || file.webkitRelativePath;
       if (pathName) {
-        const dirs = pathName.split(/[\\/]/).slice(0, -1);
+        const dirs = pathName
+          .split(/[\\/]/)
+          .slice(0, -1)
+          .filter((d) => d && d !== ".");
         dirs.forEach((d) => formData.append("path[]", d));
       }
       const timer = setInterval(() => {
@@ -54,7 +57,10 @@ function FileUploadProgressComponent({
       }, 100);
 
       // Chunk streaming not working in production so we just sit and wait
-      const { response, data } = await Workspace.uploadAndEmbedFile(slug, formData);
+      const { response, data } = await Workspace.uploadAndEmbedFile(
+        slug,
+        formData
+      );
       if (!response.ok) {
         setStatus("failed");
         clearInterval(timer);

--- a/server/utils/files/index.js
+++ b/server/utils/files/index.js
@@ -443,7 +443,9 @@ async function fileToPickerData({
 function resolveMultipartPath(request) {
   const bodyPath = request.body?.path || request.body?.["path[]"]; // path[] may be array
   const parts = Array.isArray(bodyPath) ? bodyPath : bodyPath ? [bodyPath] : [];
-  const segments = parts.filter(Boolean).map((p) => normalizePath(p));
+  const segments = parts
+    .filter((p) => p && p !== "." && p !== "./")
+    .map((p) => normalizePath(p));
   if (segments.length === 0) return request.file.originalname;
 
   const uploadRoot = path.dirname(request.file.path);


### PR DESCRIPTION
## Summary
- ignore leading `./` segments when resolving upload paths
- avoid sending `./` directory markers from frontend upload logic

## Testing
- `yarn prettier --ignore-path ../.prettierignore --check utils/files/index.js`
- `yarn prettier --ignore-path ../.prettierignore --check src/components/Modals/ManageWorkspace/Documents/UploadFile/FileUploadProgress/index.jsx`
- `yarn test` *(fails: Cannot find module 'uuid' from 'server/utils/helpers/chat', Cannot find module '@prisma/client' ...)*


------
https://chatgpt.com/codex/tasks/task_e_689bab91cf7c83288f2d58c5f162230b