### PR TITLE
feat: refresh sidebar and shell styles

### DIFF
--- a/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
@@ -13,6 +13,7 @@ import ThreadContainer from "./ThreadContainer";
 import { useMatch } from "react-router-dom";
 import { DragDropContext, Droppable, Draggable } from "react-beautiful-dnd";
 import showToast from "@/utils/toast";
+import { cn } from "@/lib/utils";
 
 export default function ActiveWorkspaces() {
   const navigate = useNavigate();
@@ -75,7 +76,7 @@ export default function ActiveWorkspaces() {
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable droppableId="workspaces">
         {(provided) => (
-          <div
+          <ul
             role="list"
             aria-label="Workspaces"
             className="flex flex-col gap-y-2"
@@ -85,22 +86,37 @@ export default function ActiveWorkspaces() {
             {workspaces.map((workspace, index) => {
               const isActive = workspace.slug === slug;
               return (
-                <Draggable
-                  key={workspace.id}
-                  draggableId={workspace.id.toString()}
-                  index={index}
-                  isDragDisabled={user?.role === "default"}
-                >
-                  {(provided, snapshot) => (
-                    <div
-                      ref={provided.innerRef}
-                      {...provided.draggableProps}
-                      className={`flex flex-col w-full group ${
-                        snapshot.isDragging ? "opacity-50" : ""
-                      }`}
-                      role="listitem"
-                    >
-                      <div className="flex gap-x-2 items-center justify-between">
+                <React.Fragment key={workspace.id}>
+                  <Draggable
+                    draggableId={workspace.id.toString()}
+                    index={index}
+                    isDragDisabled={user?.role === "default"}
+                  >
+                    {(provided, snapshot) => (
+                      <li
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                        className={cn(
+                          "group flex items-center gap-2 px-3 py-2 rounded-lg",
+                          "text-[var(--text)] hover:bg-[color-mix(in srgb,var(--accent),transparent 90%)]",
+                          isActive &&
+                            "bg-[color-mix(in srgb,var(--accent),transparent 86%)] font-semibold",
+                          snapshot.isDragging && "opacity-50"
+                        )}
+                        role="listitem"
+                      >
+                        {user?.role !== "default" && (
+                          <div
+                            {...provided.dragHandleProps}
+                            className="cursor-grab"
+                          >
+                            <DotsSixVertical
+                              size={20}
+                              color="var(--theme-sidebar-item-workspace-active)"
+                              weight="bold"
+                            />
+                          </div>
+                        )}
                         <a
                           href={
                             isActive
@@ -108,94 +124,69 @@ export default function ActiveWorkspaces() {
                               : paths.workspace.chat(workspace.slug)
                           }
                           aria-current={isActive ? "page" : ""}
-                          className={`
-                            transition-all duration-[200ms]
-                            flex flex-grow w-[75%] gap-x-2 py-[6px] pl-[4px] pr-[6px] rounded-[4px] text-white justify-start items-center
-                            bg-theme-sidebar-item-default
-                            hover:bg-theme-sidebar-subitem-hover hover:font-bold
-                            ${isActive ? "bg-theme-sidebar-item-selected font-bold light:outline-2 light:outline light:outline-blue-400 light:outline-offset-[-2px]" : ""}
-                          `}
+                          className="flex flex-grow overflow-hidden"
                         >
-                          <div className="flex flex-row justify-between w-full items-center">
-                            {user?.role !== "default" && (
-                              <div
-                                {...provided.dragHandleProps}
-                                className="cursor-grab mr-[3px]"
-                              >
-                                <DotsSixVertical
-                                  size={20}
-                                  color="var(--theme-sidebar-item-workspace-active)"
-                                  weight="bold"
-                                />
-                              </div>
-                            )}
-                            <div className="flex items-center space-x-2 overflow-hidden flex-grow">
-                              <div className="w-[130px] overflow-hidden">
-                                <p
-                                  className={`
-                                  text-[14px] leading-loose whitespace-nowrap overflow-hidden text-white
-                                  ${isActive ? "font-bold" : "font-medium"} truncate
-                                  w-full group-hover:w-[130px] group-hover:font-bold group-hover:duration-200
-                                `}
-                                >
-                                  {workspace.name}
-                                </p>
-                              </div>
-                            </div>
-                            {user?.role !== "default" && (
-                              <div
-                                className={`flex items-center gap-x-[2px] transition-opacity duration-200 ${isActive ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
-                              >
-                                <button
-                                  type="button"
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    setSelectedWs(workspace);
-                                    showModal();
-                                  }}
-                                  className="border-none rounded-md flex items-center justify-center ml-auto p-[2px] hover:bg-[#646768] text-[#A7A8A9] hover:text-white"
-                                >
-                                  <UploadSimple className="h-[20px] w-[20px]" />
-                                </button>
-                                <button
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    navigate(
-                                      isInWorkspaceSettings
-                                        ? paths.workspace.chat(workspace.slug)
-                                        : paths.workspace.settings.generalAppearance(
-                                            workspace.slug
-                                          )
-                                    );
-                                  }}
-                                  className="rounded-md flex items-center justify-center text-[#A7A8A9] hover:text-white ml-auto p-[2px] hover:bg-[#646768]"
-                                  aria-label="General appearance settings"
-                                >
-                                  <GearSix
-                                    color={
-                                      isInWorkspaceSettings &&
-                                      workspace.slug === slug
-                                        ? "#46C8FF"
-                                        : undefined
-                                    }
-                                    className="h-[20px] w-[20px]"
-                                  />
-                                </button>
-                              </div>
-                            )}
-                          </div>
+                          <span className="truncate w-[130px]">
+                            {workspace.name}
+                          </span>
                         </a>
-                      </div>
-                      {isActive && (
-                        <ThreadContainer
-                          workspace={workspace}
-                          isActive={isActive}
-                        />
-                      )}
-                    </div>
+                        {user?.role !== "default" && (
+                          <div
+                            className={cn(
+                              "flex items-center gap-x-[2px] transition-opacity duration-200",
+                              isActive
+                                ? "opacity-100"
+                                : "opacity-0 group-hover:opacity-100"
+                            )}
+                          >
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                setSelectedWs(workspace);
+                                showModal();
+                              }}
+                              className="border-none rounded-md flex items-center justify-center ml-auto p-[2px] hover:bg-[#646768] text-[#A7A8A9] hover:text-white"
+                            >
+                              <UploadSimple className="h-[20px] w-[20px]" />
+                            </button>
+                            <button
+                              onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                navigate(
+                                  isInWorkspaceSettings
+                                    ? paths.workspace.chat(workspace.slug)
+                                    : paths.workspace.settings.generalAppearance(
+                                        workspace.slug
+                                      )
+                                );
+                              }}
+                              className="rounded-md flex items-center justify-center text-[#A7A8A9] hover:text-white ml-auto p-[2px] hover:bg-[#646768]"
+                              aria-label="General appearance settings"
+                            >
+                              <GearSix
+                                color={
+                                  isInWorkspaceSettings &&
+                                  workspace.slug === slug
+                                    ? "#46C8FF"
+                                    : undefined
+                                }
+                                className="h-[20px] w-[20px]"
+                              />
+                            </button>
+                          </div>
+                        )}
+                      </li>
+                    )}
+                  </Draggable>
+                  {isActive && (
+                    <ThreadContainer
+                      workspace={workspace}
+                      isActive={isActive}
+                    />
                   )}
-                </Draggable>
+                </React.Fragment>
               );
             })}
             {provided.placeholder}
@@ -205,7 +196,7 @@ export default function ActiveWorkspaces() {
                 providedSlug={selectedWs ? selectedWs.slug : null}
               />
             )}
-          </div>
+          </ul>
         )}
       </Droppable>
     </DragDropContext>

--- a/frontend/src/components/Sidebar/index.jsx
+++ b/frontend/src/components/Sidebar/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
+// Sidebar navigation styled with the OneNew theme.
 import { List, Plus } from "@phosphor-icons/react";
 import NewWorkspaceModal, {
   useNewWorkspaceModal,
@@ -13,6 +14,7 @@ import paths from "@/utils/paths";
 import { useTranslation } from "react-i18next";
 import { useSidebarToggle, ToggleSidebarButton } from "./SidebarToggle";
 import SearchBox from "./SearchBox";
+import { cn } from "@/lib/utils";
 
 export default function Sidebar() {
   const { user } = useUser();
@@ -28,12 +30,12 @@ export default function Sidebar() {
 
   return (
     <>
-      <div
+      <aside
         style={{
           width: showSidebar ? "292px" : "0px",
           paddingLeft: showSidebar ? "0px" : "16px",
         }}
-        className="transition-all duration-500"
+        className="onenew-card h-full p-3 md:p-4 transition-all duration-500"
       >
         <div className="flex shrink-0 w-full justify-center my-[18px]">
           <div className="flex justify-between w-[250px] min-w-[250px]">
@@ -41,7 +43,10 @@ export default function Sidebar() {
               <img
                 src={logo}
                 alt="Logo"
-                className={`rounded max-h-[24px] object-contain transition-opacity duration-500 ${showSidebar ? "opacity-100" : "opacity-0"}`}
+                className={cn(
+                  "h-8 w-auto rounded object-contain transition-opacity duration-500",
+                  showSidebar ? "opacity-100" : "opacity-0"
+                )}
               />
             </Link>
             {canToggleSidebar && (
@@ -52,10 +57,7 @@ export default function Sidebar() {
             )}
           </div>
         </div>
-        <div
-          ref={sidebarRef}
-          className="relative m-[16px] rounded-[16px] bg-theme-bg-sidebar border-[2px] border-theme-sidebar-border light:border-none min-w-[250px] p-[10px] h-[calc(100%-76px)]"
-        >
+        <div ref={sidebarRef} className="flex flex-col h-[calc(100%-76px)]">
           <div className="flex flex-col h-full overflow-x-hidden">
             <div className="flex-grow flex flex-col min-w-[235px]">
               <div className="relative h-[calc(100%-60px)] flex flex-col w-full justify-between pt-[10px] overflow-y-scroll no-scroll">
@@ -64,14 +66,14 @@ export default function Sidebar() {
                   <ActiveWorkspaces />
                 </div>
               </div>
-              <div className="absolute bottom-0 left-0 right-0 pt-4 pb-3 rounded-b-[16px] bg-theme-bg-sidebar bg-opacity-80 backdrop-filter backdrop-blur-md z-1">
+              <div className="mt-auto pt-4 pb-3">
                 <Footer />
               </div>
             </div>
           </div>
         </div>
         {showingNewWsModal && <NewWorkspaceModal hideModal={hideNewWsModal} />}
-      </div>
+      </aside>
     </>
   );
 }
@@ -120,8 +122,7 @@ export function SidebarMobileHeader() {
           <img
             src={logo}
             alt="Logo"
-            className="block mx-auto h-6 w-auto"
-            style={{ maxHeight: "40px", objectFit: "contain" }}
+            className="block mx-auto h-8 w-auto"
           />
         </div>
         <div className="w-12"></div>

--- a/frontend/src/layouts/AppShell.jsx
+++ b/frontend/src/layouts/AppShell.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import Sidebar, { SidebarMobileHeader } from "@/components/Sidebar";
+import { isMobile } from "react-device-detect";
+
+export default function AppShell({ children }) {
+  return (
+    <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
+      {!isMobile ? <Sidebar /> : <SidebarMobileHeader />}
+      <div className="flex-1 border-l border-[var(--border)]">{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/lib/utils.js
+++ b/frontend/src/lib/utils.js
@@ -1,0 +1,3 @@
+export function cn(...classes) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/frontend/src/pages/Main/index.jsx
+++ b/frontend/src/pages/Main/index.jsx
@@ -3,8 +3,7 @@ import PasswordModal, { usePasswordModal } from "@/components/Modals/Password";
 import { FullScreenLoader } from "@/components/Preloader";
 import Home from "./Home";
 import DefaultChatContainer from "@/components/DefaultChat";
-import { isMobile } from "react-device-detect";
-import Sidebar, { SidebarMobileHeader } from "@/components/Sidebar";
+import AppShell from "@/layouts/AppShell";
 import { userFromStorage } from "@/utils/request";
 
 export default function Main() {
@@ -16,9 +15,8 @@ export default function Main() {
 
   const user = userFromStorage();
   return (
-    <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
-      {!isMobile ? <Sidebar /> : <SidebarMobileHeader />}
+    <AppShell>
       {!!user && user?.role !== "admin" ? <DefaultChatContainer /> : <Home />}
-    </div>
+    </AppShell>
   );
 }

--- a/frontend/src/pages/WorkspaceChat/index.jsx
+++ b/frontend/src/pages/WorkspaceChat/index.jsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useState } from "react";
 import { default as WorkspaceChatContainer } from "@/components/WorkspaceChat";
-import Sidebar from "@/components/Sidebar";
+import AppShell from "@/layouts/AppShell";
 import { useParams } from "react-router-dom";
 import Workspace from "@/models/workspace";
 import PasswordModal, { usePasswordModal } from "@/components/Modals/Password";
-import { isMobile } from "react-device-detect";
 import { FullScreenLoader } from "@/components/Preloader";
 
 export default function WorkspaceChat() {
@@ -44,11 +43,8 @@ function ShowWorkspaceChat() {
   }, []);
 
   return (
-    <>
-      <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
-        {!isMobile && <Sidebar />}
-        <WorkspaceChatContainer loading={loading} workspace={workspace} />
-      </div>
-    </>
+    <AppShell>
+      <WorkspaceChatContainer loading={loading} workspace={workspace} />
+    </AppShell>
   );
 }

--- a/frontend/src/pages/WorkspaceSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/index.jsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import Sidebar from "@/components/Sidebar";
 import Workspace from "@/models/workspace";
 import PasswordModal, { usePasswordModal } from "@/components/Modals/Password";
 import { isMobile } from "react-device-detect";
 import { FullScreenLoader } from "@/components/Preloader";
+import AppShell from "@/layouts/AppShell";
 import {
   ArrowUUpLeft,
   ChatText,
@@ -76,8 +76,7 @@ function ShowWorkspaceChat() {
 
   const TabContent = TABS[tab];
   return (
-    <div className="w-screen h-screen overflow-hidden bg-theme-bg-container flex">
-      {!isMobile && <Sidebar />}
+    <AppShell>
       <div
         style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
         className="transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-[16px] bg-theme-bg-secondary w-full h-full overflow-y-scroll"
@@ -120,7 +119,7 @@ function ShowWorkspaceChat() {
           <TabContent slug={slug} workspace={workspace} />
         </div>
       </div>
-    </div>
+    </AppShell>
   );
 }
 


### PR DESCRIPTION
## Summary
- restyle sidebar with OneNew card wrapper and unified logo sizing
- simplify workspace navigation items with modern active and hover states
- add AppShell layout with optional content border

## Testing
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a222ee50648328998e391e10609b3b