### PR TITLE
feat: theme documents view

### DIFF
--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
@@ -207,7 +207,7 @@ function Directory({
                 type="search"
                 placeholder={t("connectors.directory.search-document")}
                 onChange={handleSearch}
-                className="border-none search-input bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-lg pl-9 pr-2.5 py-2 w-[250px] h-[32px] light:border-theme-modal-border light:border"
+                className="onenew-input pl-9 w-[250px] h-[32px]"
               />
               <MagnifyingGlass
                 size={14}
@@ -216,7 +216,7 @@ function Directory({
               />
             </div>
             <button
-              className="border-none flex items-center gap-x-2 cursor-pointer px-[14px] py-[7px] -mr-[14px] rounded-lg hover:bg-theme-sidebar-subitem-hover z-20 relative"
+              className="onenew-btn onenew-btn-secondary flex items-center gap-x-2 px-[14px] py-[7px] -mr-[14px] z-20 relative"
               onClick={openFolderModal}
             >
               <Plus
@@ -277,7 +277,7 @@ function Directory({
                       onClick={moveToWorkspace}
                       onMouseEnter={() => setHighlightWorkspace(true)}
                       onMouseLeave={() => setHighlightWorkspace(false)}
-                      className="border-none text-sm font-semibold bg-white light:bg-[#E0F2FE] h-[30px] px-2.5 rounded-lg hover:bg-neutral-800/80 hover:text-white light:text-[#026AA2] light:hover:bg-[#026AA2] light:hover:text-white"
+                      className="onenew-btn onenew-btn-secondary h-[30px] px-2.5"
                     >
                       {t("connectors.directory.move-workspace")}
                     </button>
@@ -286,7 +286,7 @@ function Directory({
                         onClick={() =>
                           setShowFolderSelection(!showFolderSelection)
                         }
-                        className="border-none text-sm font-semibold bg-white light:bg-[#E0F2FE] h-[32px] w-[32px] rounded-lg text-dark-text hover:bg-neutral-800/80 hover:text-white light:text-[#026AA2] light:hover:bg-[#026AA2] light:hover:text-white flex justify-center items-center group"
+                        className="onenew-btn onenew-btn-secondary h-[32px] w-[32px] flex justify-center items-center group"
                       >
                         <MoveToFolderIcon className="text-dark-text light:text-[#026AA2] group-hover:text-white" />
                       </button>
@@ -302,7 +302,7 @@ function Directory({
                     </div>
                     <button
                       onClick={deleteFiles}
-                      className="border-none text-sm font-semibold bg-white light:bg-[#E0F2FE] h-[32px] w-[32px] rounded-lg text-dark-text hover:bg-neutral-800/80 hover:text-white light:text-[#026AA2] light:hover:bg-[#026AA2] light:hover:text-white flex justify-center items-center"
+                      className="onenew-btn onenew-btn-secondary h-[32px] w-[32px] flex justify-center items-center"
                     >
                       <Trash size={18} weight="bold" />
                     </button>

--- a/frontend/src/components/StatusBadge/index.jsx
+++ b/frontend/src/components/StatusBadge/index.jsx
@@ -7,23 +7,15 @@ export default function StatusBadge({ status }) {
   const label = DOCUMENT_STATUS_LABELS[upper] || upper;
 
   if (upper === "READY") {
-    return (
-      <span className="bg-green-600 text-white text-[10px] px-2 py-0.5 rounded-3xl">
-        {label}
-      </span>
-    );
+    return <span className="onenew-chip bg-green-600 text-white text-[10px] px-2 py-0.5">{label}</span>;
   }
   if (upper === "FAILED") {
-    return (
-      <span className="bg-red-600 text-white text-[10px] px-2 py-0.5 rounded-3xl">
-        {label}
-      </span>
-    );
+    return <span className="onenew-chip bg-red-600 text-white text-[10px] px-2 py-0.5">{label}</span>;
   }
 
   if (isProcessingStatus(upper)) {
     return (
-      <span className="flex items-center gap-1 text-[10px] text-white">
+      <span className="onenew-chip flex items-center gap-1 text-[10px] text-white">
         <CircleNotch size={10} className="animate-spin" />
         {label}
       </span>

--- a/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/manage/DocumentSyncQueueRow/index.jsx
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/manage/DocumentSyncQueueRow/index.jsx
@@ -33,7 +33,7 @@ export default function DocumentSyncQueueRow({ queue }) {
         <td className="px-6 py-4 flex items-center gap-x-6">
           <button
             onClick={handleDelete}
-            className="border-none font-medium px-2 py-1 rounded-lg text-theme-text-primary hover:text-red-500"
+            className="onenew-btn onenew-btn-secondary px-2 py-1"
           >
             <Trash className="h-5 w-5" />
           </button>

--- a/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/manage/index.jsx
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/manage/index.jsx
@@ -64,7 +64,7 @@ function WatchedDocumentsContainer() {
   }
 
   return (
-    <table className="w-full text-sm text-left rounded-lg mt-6 min-w-[640px]">
+    <table className="onenew-table w-full mt-6 min-w-[640px]">
       <thead className="text-theme-text-secondary text-xs leading-[18px] font-bold uppercase border-white/10 border-b">
         <tr>
           <th scope="col" className="px-6 py-3 rounded-tl-lg">


### PR DESCRIPTION
## Summary
- style documents directory with onenew inputs and buttons
- apply onenew chip to status badges
- theme live sync document table and actions

## Testing
- `yarn test` *(fails: Couldn't find a script named "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a22329132883288f76f1af3f5af391