### PR TITLE
feat: style general settings with OneNew theme

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -689,7 +689,7 @@ dialog::backdrop {
 }
 
 .input-label {
-  @apply text-[14px] font-bold text-white;
+  @apply text-[var(--text)] font-medium;
 }
 
 /**

--- a/frontend/src/pages/GeneralSettings/Settings/components/AutoSpeak/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/AutoSpeak/index.jsx
@@ -32,14 +32,14 @@ export default function AutoSpeak() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+    <div className="onenew-card p-5 mb-4">
+      <p className="text-[var(--text)] font-medium">
         {t("customization.chat.auto_speak.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-sm text-[var(--text-muted)]">
         {t("customization.chat.auto_speak.description")}
       </p>
-      <div className="flex items-center gap-x-4">
+      <div className="flex items-center gap-x-4 mt-2">
         <label className="relative inline-flex cursor-pointer items-center">
           <input
             id="auto_speak"
@@ -51,7 +51,7 @@ export default function AutoSpeak() {
             disabled={saving}
             className="peer sr-only"
           />
-          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-white after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+          <div className="h-6 w-11 rounded-full bg-[color-mix(in_srgb,var(--accent),transparent_85%)] peer-checked:bg-[var(--accent)] transition-colors peer-focus-visible:[box-shadow:0_0_0_3px_var(--ring)] after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-full"></div>
         </label>
       </div>
     </div>

--- a/frontend/src/pages/GeneralSettings/Settings/components/AutoSubmit/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/AutoSubmit/index.jsx
@@ -29,14 +29,14 @@ export default function AutoSubmit() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+    <div className="onenew-card p-5 mb-4">
+      <p className="text-[var(--text)] font-medium">
         {t("customization.chat.auto_submit.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-sm text-[var(--text-muted)]">
         {t("customization.chat.auto_submit.description")}
       </p>
-      <div className="flex items-center gap-x-4">
+      <div className="flex items-center gap-x-4 mt-2">
         <label className="relative inline-flex cursor-pointer items-center">
           <input
             id="auto_submit"
@@ -48,7 +48,7 @@ export default function AutoSubmit() {
             disabled={saving}
             className="peer sr-only"
           />
-          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-white after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+          <div className="h-6 w-11 rounded-full bg-[color-mix(in_srgb,var(--accent),transparent_85%)] peer-checked:bg-[var(--accent)] transition-colors peer-focus-visible:[box-shadow:0_0_0_3px_var(--ring)] after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-full"></div>
         </label>
       </div>
     </div>

--- a/frontend/src/pages/GeneralSettings/Settings/components/CustomAppName/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/CustomAppName/index.jsx
@@ -60,22 +60,22 @@ export default function CustomAppName() {
 
   return (
     <form
-      className="flex flex-col gap-y-0.5 mt-4"
+      className="onenew-card p-5 mb-4 flex flex-col gap-y-0.5"
       onSubmit={updateCustomAppName}
     >
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-[var(--text)] font-medium">
         {t("customization.items.app-name.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-sm text-[var(--text-muted)]">
         {t("customization.items.app-name.description")}
       </p>
       <div className="flex items-center gap-x-4">
         <input
           name="customAppName"
           type="text"
-          className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
+          className="onenew-input mt-2 w-fit"
           placeholder="OneNew"
-          required={true}
+          required
           autoComplete="off"
           onChange={handleChange}
           value={customAppName}
@@ -84,7 +84,7 @@ export default function CustomAppName() {
           <button
             type="button"
             onClick={(e) => updateCustomAppName(e, "")}
-            className="text-white text-base font-medium hover:text-opacity-60"
+            className="onenew-btn onenew-btn--secondary"
           >
             Clear
           </button>
@@ -93,7 +93,7 @@ export default function CustomAppName() {
       {hasChanges && (
         <button
           type="submit"
-          className="transition-all mt-2 w-fit duration-300 border border-slate-200 px-5 py-2.5 rounded-lg text-white text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"
+          className="onenew-btn onenew-btn--primary mt-2 w-fit"
         >
           Save
         </button>

--- a/frontend/src/pages/GeneralSettings/Settings/components/ShowScrollbar/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/ShowScrollbar/index.jsx
@@ -29,14 +29,14 @@ export default function ShowScrollbar() {
   }, []);
 
   return (
-    <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+    <div className="onenew-card p-5 mb-4">
+      <p className="text-[var(--text)] font-medium">
         {t("customization.items.show-scrollbar.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-sm text-[var(--text-muted)]">
         {t("customization.items.show-scrollbar.description")}
       </p>
-      <div className="flex items-center gap-x-4">
+      <div className="flex items-center gap-x-4 mt-2">
         <label className="relative inline-flex cursor-pointer items-center">
           <input
             id="show_scrollbar"
@@ -48,7 +48,7 @@ export default function ShowScrollbar() {
             disabled={saving}
             className="peer sr-only"
           />
-          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-white after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+          <div className="h-6 w-11 rounded-full bg-[color-mix(in_srgb,var(--accent),transparent_85%)] peer-checked:bg-[var(--accent)] transition-colors peer-focus-visible:[box-shadow:0_0_0_3px_var(--ring)] after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-full"></div>
         </label>
       </div>
     </div>

--- a/frontend/src/pages/GeneralSettings/Settings/components/SpellCheck/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/SpellCheck/index.jsx
@@ -23,14 +23,14 @@ export default function SpellCheck() {
   };
 
   return (
-    <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+    <div className="onenew-card p-5 mb-4">
+      <p className="text-[var(--text)] font-medium">
         {t("customization.chat.spellcheck.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-sm text-[var(--text-muted)]">
         {t("customization.chat.spellcheck.description")}
       </p>
-      <div className="flex items-center gap-x-4">
+      <div className="flex items-center gap-x-4 mt-2">
         <label className="relative inline-flex cursor-pointer items-center">
           <input
             id="spellcheck"
@@ -42,7 +42,7 @@ export default function SpellCheck() {
             disabled={saving}
             className="peer sr-only"
           />
-          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-white after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+          <div className="h-6 w-11 rounded-full bg-[color-mix(in_srgb,var(--accent),transparent_85%)] peer-checked:bg-[var(--accent)] transition-colors peer-focus-visible:[box-shadow:0_0_0_3px_var(--ring)] after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:h-5 after:w-5 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-full"></div>
         </label>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- restyle general settings labels using `input-label` class
- apply OneNew design to Auto Submit, Auto Speak, Spell Check, Show Scrollbar, and Custom App Name controls

## Testing
- `npx prettier src/index.css src/pages/GeneralSettings/Settings/components/AutoSpeak/index.jsx src/pages/GeneralSettings/Settings/components/AutoSubmit/index.jsx src/pages/GeneralSettings/Settings/components/CustomAppName/index.jsx src/pages/GeneralSettings/Settings/components/ShowScrollbar/index.jsx src/pages/GeneralSettings/Settings/components/SpellCheck/index.jsx --write`
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a22363cb948328b63df07b687b1bab