### PR TITLE
style: update modal overlay and dialog styles

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@tremor/react": "^3.15.1",
     "dompurify": "^3.0.8",
     "file-saver": "^2.0.5",
+    "focus-trap-react": "^11.0.4",
     "he": "^1.2.0",
     "highlight.js": "^11.9.0",
     "i18next": "^23.11.3",

--- a/frontend/src/components/ModalWrapper/index.jsx
+++ b/frontend/src/components/ModalWrapper/index.jsx
@@ -1,4 +1,6 @@
 import { createPortal } from "react-dom";
+import { useEffect, useRef } from "react";
+import FocusTrap from "focus-trap-react";
 /**
  * @typedef {Object} ModalWrapperProps
  * @property {import("react").ReactComponentElement} children - The DOM/JSX to render
@@ -13,23 +15,39 @@ import { createPortal } from "react-dom";
  * @param {ModalWrapperProps} props - ModalWrapperProps to pass
  * @returns {import("react").ReactNode}
  *
- * @todo Add a closeModal prop to the ModalWrapper component so we can escape dismiss anywhere this is used
+ * Modal wrapper that provides a consistent overlay with focus trapping and ESC/overlay dismissal.
  */
-export default function ModalWrapper({ children, isOpen, noPortal = false }) {
+export default function ModalWrapper({
+  children,
+  isOpen,
+  noPortal = false,
+  onClose,
+}) {
+  const overlayRef = useRef(null);
+
+  useEffect(() => {
+    if (!onClose) return;
+    function handleKeydown(e) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeydown);
+    return () => document.removeEventListener("keydown", handleKeydown);
+  }, [onClose]);
+
   if (!isOpen) return null;
 
-  if (noPortal) {
-    return (
-      <div className="bg-black/60 backdrop-blur-sm fixed top-0 left-0 outline-none w-screen h-screen flex items-center justify-center z-99">
-        {children}
-      </div>
-    );
-  }
-
-  return createPortal(
-    <div className="bg-black/60 backdrop-blur-sm fixed top-0 left-0 outline-none w-screen h-screen flex items-center justify-center z-99">
-      {children}
-    </div>,
-    document.getElementById("root")
+  const overlay = (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 bg-black/50 backdrop-blur-[2px] z-50 flex items-center justify-center"
+      onMouseDown={(e) => {
+        if (e.target === overlayRef.current && onClose) onClose();
+      }}
+    >
+      <FocusTrap>{children}</FocusTrap>
+    </div>
   );
+
+  if (noPortal) return overlay;
+  return createPortal(overlay, document.getElementById("root"));
 }

--- a/frontend/src/components/Modals/DisplayRecoveryCodeModal/index.jsx
+++ b/frontend/src/components/Modals/DisplayRecoveryCodeModal/index.jsx
@@ -33,30 +33,27 @@ export default function RecoveryCodeModal({
   };
 
   return (
-    <ModalWrapper isOpen={true}>
-      <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
-        <div className="relative p-6 border-b rounded-t border-theme-modal-border">
-          <div className="w-full flex gap-x-2 items-center">
-            <Key size={24} className="text-white" weight="bold" />
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
-              Recovery Codes
-            </h3>
-          </div>
+    <ModalWrapper isOpen={true} onClose={handleClose}>
+      <div className="onenew-card p-5 shadow-2xl max-w-lg w-[90vw]">
+        <div className="flex gap-x-2 items-center mb-5">
+          <Key size={24} className="text-white" weight="bold" />
+          <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            Recovery Codes
+          </h3>
         </div>
         <div
           className="h-full w-full overflow-y-auto"
           style={{ maxHeight: "calc(100vh - 200px)" }}
         >
-          <div className="py-7 px-9 space-y-2 flex-col">
+          <div className="space-y-2 flex-col">
             <p className="text-sm text-white flex flex-col">
               In order to reset your password in the future, you will need these
-              recovery codes. Download or copy your recovery codes to save them.{" "}
+              recovery codes. Download or copy your recovery codes to save them{" "}
               <br />
               <b className="mt-4">These recovery codes are only shown once!</b>
             </p>
             <div
-              className="border-none bg-theme-settings-input-bg text-white hover:text-primary-button
-                   flex items-center justify-center rounded-md mt-6 cursor-pointer"
+              className="border-none bg-theme-settings-input-bg text-white hover:text-primary-button flex items-center justify-center rounded-md mt-6 cursor-pointer"
               onClick={handleCopyToClipboard}
             >
               <ul className="space-y-2 md:p-6 p-4">
@@ -68,10 +65,10 @@ export default function RecoveryCodeModal({
               </ul>
             </div>
           </div>
-          <div className="flex w-full justify-end items-center p-6 space-x-2 border-t border-theme-modal-border rounded-b">
+          <div className="flex w-full justify-end items-center mt-6">
             <button
               type="button"
-              className="transition-all duration-300 bg-white text-black hover:opacity-60 px-4 py-2 rounded-lg text-sm flex items-center gap-x-2"
+              className="onenew-btn flex items-center gap-x-2"
               onClick={downloadClicked ? handleClose : downloadRecoveryCodes}
             >
               {downloadClicked ? (

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/NewFolderModal/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/NewFolderModal/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { X } from "@phosphor-icons/react";
 import Document from "@/models/document";
+import ModalWrapper from "@/components/ModalWrapper";
 
 export default function NewFolderModal({ closeModal, files, setFiles }) {
   const [error, setError] = useState(null);
@@ -29,63 +30,48 @@ export default function NewFolderModal({ closeModal, files, setFiles }) {
   };
 
   return (
-    <div className="fixed inset-0 z-50 overflow-auto bg-black bg-opacity-50 flex items-center justify-center">
-      <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
-        <div className="relative p-6 border-b rounded-t border-theme-modal-border">
-          <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
-              Create New Folder
-            </h3>
-          </div>
-          <button
-            onClick={closeModal}
-            type="button"
-            className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-lg text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
-          >
+    <ModalWrapper isOpen={true} onClose={closeModal} noPortal>
+      <div className="onenew-card p-5 shadow-2xl max-w-lg w-[90vw]">
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            Create New Folder
+          </h3>
+          <button onClick={closeModal} type="button" className="onenew-btn">
             <X size={24} weight="bold" className="text-white" />
           </button>
         </div>
-        <div className="p-6">
-          <form onSubmit={handleCreate}>
-            <div className="space-y-4">
-              <div>
-                <label
-                  htmlFor="folderName"
-                  className="block mb-2 text-sm font-medium text-white"
-                >
-                  Folder Name
-                </label>
-                <input
-                  name="folderName"
-                  type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-                  placeholder="Enter folder name"
-                  required={true}
-                  autoComplete="off"
-                  value={folderName}
-                  onChange={(e) => setFolderName(e.target.value)}
-                />
-              </div>
-              {error && <p className="text-red-400 text-sm">Error: {error}</p>}
-            </div>
-            <div className="flex justify-between items-center mt-6 pt-6 border-t border-theme-modal-border">
-              <button
-                onClick={closeModal}
-                type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-lg text-sm"
+        <form onSubmit={handleCreate}>
+          <div className="space-y-4">
+            <div>
+              <label
+                htmlFor="folderName"
+                className="block mb-2 text-sm font-medium text-white"
               >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="transition-all duration-300 bg-white text-black hover:opacity-60 px-4 py-2 rounded-lg text-sm"
-              >
-                Create Folder
-              </button>
+                Folder Name
+              </label>
+              <input
+                name="folderName"
+                type="text"
+                className="onenew-input w-full"
+                placeholder="Enter folder name"
+                required={true}
+                autoComplete="off"
+                value={folderName}
+                onChange={(e) => setFolderName(e.target.value)}
+              />
             </div>
-          </form>
-        </div>
+            {error && <p className="text-red-400 text-sm">Error: {error}</p>}
+          </div>
+          <div className="flex justify-between items-center mt-6 pt-6 border-t border-theme-modal-border">
+            <button onClick={closeModal} type="button" className="onenew-btn">
+              Cancel
+            </button>
+            <button type="submit" className="onenew-btn">
+              Create Folder
+            </button>
+          </div>
+        </form>
       </div>
-    </div>
+    </ModalWrapper>
   );
 }

--- a/frontend/src/components/Modals/NewWorkspace.jsx
+++ b/frontend/src/components/Modals/NewWorkspace.jsx
@@ -24,19 +24,13 @@ export default function NewWorkspaceModal({ hideModal = noop }) {
   };
 
   return (
-    <ModalWrapper isOpen={true}>
-      <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
-        <div className="relative p-6 border-b rounded-t border-theme-modal-border">
-          <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
-              {t("new-workspace.title")}
-            </h3>
-          </div>
-          <button
-            onClick={hideModal}
-            type="button"
-            className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-lg text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
-          >
+    <ModalWrapper isOpen={true} onClose={hideModal}>
+      <div className="onenew-card p-5 shadow-2xl max-w-lg w-[90vw]">
+        <div className="flex items-center justify-between mb-5">
+          <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            {t("new-workspace.title")}
+          </h3>
+          <button onClick={hideModal} type="button" className="onenew-btn">
             <X size={24} weight="bold" className="text-white" />
           </button>
         </div>
@@ -45,7 +39,7 @@ export default function NewWorkspaceModal({ hideModal = noop }) {
           style={{ maxHeight: "calc(100vh - 200px)" }}
         >
           <form ref={formEl} onSubmit={handleCreate}>
-            <div className="py-7 px-9 space-y-2 flex-col">
+            <div className="space-y-2 flex-col">
               <div className="w-full flex flex-col gap-y-4">
                 <div>
                   <label
@@ -58,7 +52,7 @@ export default function NewWorkspaceModal({ hideModal = noop }) {
                     name="name"
                     type="text"
                     id="name"
-                    className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="onenew-input w-full"
                     placeholder={t("new-workspace.placeholder")}
                     required={true}
                     autoComplete="off"
@@ -70,11 +64,8 @@ export default function NewWorkspaceModal({ hideModal = noop }) {
                 )}
               </div>
             </div>
-            <div className="flex w-full justify-end items-center p-6 space-x-2 border-t border-theme-modal-border rounded-b">
-              <button
-                type="submit"
-                className="transition-all duration-300 bg-white text-black hover:opacity-60 px-4 py-2 rounded-lg text-sm"
-              >
+            <div className="flex w-full justify-end items-center mt-6">
+              <button type="submit" className="onenew-btn">
                 Save
               </button>
             </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1274,6 +1274,7 @@ __metadata:
     file-saver: "npm:^2.0.5"
     flow-bin: "npm:^0.217.0"
     flow-remove-types: "npm:^2.217.1"
+    focus-trap-react: "npm:^11.0.4"
     globals: "npm:^13.21.0"
     he: "npm:^1.2.0"
     hermes-eslint: "npm:^0.15.0"
@@ -2747,6 +2748,30 @@ __metadata:
     flow-node: flow-node
     flow-remove-types: flow-remove-types
   checksum: 10c0/d2dbf9322ee180cc1ed336694e73707a2367f2c26f0381e3799746cb8a606354c892b7354d08b8cfa9a8c17bb8841261645adf5eaccfc5a55d89867ed73e74ed
+  languageName: node
+  linkType: hard
+
+"focus-trap-react@npm:^11.0.4":
+  version: 11.0.4
+  resolution: "focus-trap-react@npm:11.0.4"
+  dependencies:
+    focus-trap: "npm:^7.6.5"
+    tabbable: "npm:^6.2.0"
+  peerDependencies:
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  checksum: 10c0/c1b5bd29e8b226715e697202c540f28fa2cd47974b88d15b144e84422bcd199dab1bc461a491d7d36c97744d91087fc949984ddf71ddc867f4f971af0bf0aa30
+  languageName: node
+  linkType: hard
+
+"focus-trap@npm:^7.6.5":
+  version: 7.6.5
+  resolution: "focus-trap@npm:7.6.5"
+  dependencies:
+    tabbable: "npm:^6.2.0"
+  checksum: 10c0/36cac0d9b05fe5824733675bb49792842dae4704286ef7e17c736ee0c9c14701e874e6821449e78b70c17e42ba1b2c98ef10434bfe644b9d7654d8ef7f1c8faf
   languageName: node
   linkType: hard
 
@@ -5619,7 +5644,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tabbable@npm:^6.0.1":
+"tabbable@npm:^6.0.1, tabbable@npm:^6.2.0":
   version: 6.2.0
   resolution: "tabbable@npm:6.2.0"
   checksum: 10c0/ced8b38f05f2de62cd46836d77c2646c42b8c9713f5bd265daf0e78ff5ac73d3ba48a7ca45f348bafeef29b23da7187c72250742d37627883ef89cbd7fa76898


### PR DESCRIPTION
## Summary
- add focus-trap-react for improved modal accessibility
- implement glass overlay and onenew dialog styling
- update modal components to use onenew utilities

## Testing
- `yarn --cwd frontend prettier --ignore-path ../.prettierignore --write src/components/ModalWrapper/index.jsx src/components/Modals/DisplayRecoveryCodeModal/index.jsx src/components/Modals/ManageWorkspace/Documents/Directory/NewFolderModal/index.jsx src/components/Modals/NewWorkspace.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68a22371080c832898da1615c679722c