### PR TITLE
Polish auxiliary theming components

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
@@ -54,7 +54,7 @@ function AttachmentItem({ attachment }) {
   if (isProcessingStatus(status)) {
     const label = STATUS_TEXT[status.toUpperCase()] || "Processing...";
     return (
-      <div className="relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-bg border-none w-[180px] group">
+      <div className="relative onenew-chip flex items-center gap-x-1 bg-theme-attachment-bg w-[180px] group">
         <div
           className={`bg-theme-attachment-icon-spinner-bg rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
         >
@@ -82,7 +82,7 @@ function AttachmentItem({ attachment }) {
         <div
           data-tooltip-id={`attachment-uid-${uid}-error`}
           data-tooltip-content={error}
-          className={`relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-error-bg border-none w-[180px] group`}
+          className={`relative onenew-chip flex items-center gap-x-1 bg-theme-attachment-error-bg w-[180px] group`}
         >
           <div className="invisible group-hover:visible absolute -top-[5px] -right-[5px] w-fit h-fit z-[10]">
             <button
@@ -137,7 +137,7 @@ function AttachmentItem({ attachment }) {
         <div
           data-tooltip-id={`attachment-uid-${uid}-success`}
           data-tooltip-content={`${file.name} will be attached to this prompt. It will not be embedded into the workspace permanently.`}
-          className={`relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-success-bg border-none w-[180px] group`}
+          className={`relative onenew-chip flex items-center gap-x-1 bg-theme-attachment-success-bg w-[180px] group`}
         >
           <div className="invisible group-hover:visible absolute -top-[5px] -right-[5px] w-fit h-fit z-[10]">
             <button
@@ -186,7 +186,7 @@ function AttachmentItem({ attachment }) {
         <div
           data-tooltip-id={`attachment-uid-${uid}-success`}
           data-tooltip-content={`${file.name} was uploaded and embedded into this workspace. It will be available for RAG chat now.`}
-          className={`relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-bg border-none w-[180px] group`}
+          className={`relative onenew-chip flex items-center gap-x-1 bg-theme-attachment-bg w-[180px] group`}
         >
           <div className="invisible group-hover:visible absolute -top-[5px] -right-[5px] w-fit h-fit z-[10]">
             <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -664,12 +664,36 @@ dialog::backdrop {
   }
 }
 
-.tooltip {
-  @apply !bg-black !text-white !py-2 !px-3 !rounded-md;
+.tooltip,
+.allm-tooltip {
+  @apply !py-2 !px-3 !rounded-md;
+  background: var(--surface-2) !important;
+  color: var(--text) !important;
+  border: 1px solid var(--border) !important;
 }
 
 .Toastify__toast-body {
   white-space: pre-line;
+}
+
+.Toastify__toast {
+  @apply onenew-card border-l-4;
+}
+
+.Toastify__toast--success {
+  border-left-color: var(--ok);
+}
+
+.Toastify__toast--warning {
+  border-left-color: var(--warn);
+}
+
+.Toastify__toast--error {
+  border-left-color: var(--danger);
+}
+
+.Toastify__toast--info {
+  border-left-color: var(--accent);
 }
 
 @keyframes slideDown {
@@ -690,6 +714,60 @@ dialog::backdrop {
 
 .input-label {
   @apply text-[14px] font-bold text-white;
+}
+
+@layer components {
+  .onenew-card {
+    @apply rounded-md border border-[var(--border)] bg-[var(--surface-1)] text-[var(--text)];
+  }
+
+  .onenew-chip {
+    @apply inline-flex items-center gap-1 rounded-full border border-[var(--border)] bg-[var(--surface-1)] text-[var(--text)] px-2 py-1 text-xs;
+  }
+
+  .empty-state {
+    @apply onenew-card p-8 text-center;
+  }
+
+  .empty-state a {
+    color: var(--accent);
+  }
+
+  .onenew-tabs [aria-selected="true"] {
+    color: var(--text);
+  }
+
+  .onenew-tabs .tab-indicator {
+    background: var(--accent);
+  }
+
+  .onenew-pagination [aria-current="page"] {
+    color: var(--text);
+  }
+
+  .onenew-pagination .indicator {
+    background: var(--accent);
+  }
+}
+
+@keyframes onenew-skeleton {
+  0% {
+    background-color: color-mix(in srgb, var(--text), transparent 92%);
+  }
+
+  50% {
+    background-color: color-mix(in srgb, var(--text), transparent 85%);
+  }
+
+  100% {
+    background-color: color-mix(in srgb, var(--text), transparent 92%);
+  }
+}
+
+.react-loading-skeleton,
+.onenew-skeleton {
+  background: color-mix(in srgb, var(--text), transparent 92%);
+  animation: onenew-skeleton 1.5s ease-in-out infinite;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Restyle tooltips and toast notifications with onenew card base and status-colored borders
- Introduce reusable onenew card and chip utilities for empty states, tabs and pagination
- Add skeleton animation using text-color mix and apply chip style to attachment file chips

## Testing
- `npx prettier src/index.css src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx --check`
- `yarn test` *(fails: Cannot find module 'uuid', 'dotenv', '@langchain/textsplitters', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2237d2e008328a0e76738a4152a87