### PR TITLE
feat: improve focus states for chat controls

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/index.jsx
@@ -13,7 +13,7 @@ export default function StopGenerationButton() {
         onClick={emitHaltEvent}
         data-tooltip-id="stop-generation-button"
         data-tooltip-content="Stop generating response"
-        className="border-none text-white/60 cursor-pointer group -mr-1.5 mt-1.5"
+        className="border-none text-white cursor-pointer group -mr-1.5 mt-1.5 h-10 w-10 flex items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-chat"
         aria-label="Stop generating"
       >
         <svg

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/TextSizeMenu/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/TextSizeMenu/index.jsx
@@ -18,19 +18,20 @@ export default function TextSizeButton() {
 
   return (
     <>
-      <div
+      <button
         id="text-size-btn"
+        type="button"
         data-tooltip-id="tooltip-text-size-btn"
         aria-label={t("chat_window.text_size")}
         onClick={toggleTooltip}
-        className="border-none flex justify-center items-center opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60 cursor-pointer"
+        className="border-none flex justify-center items-center opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60 cursor-pointer h-10 w-10 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-chat"
       >
         <TextT
           color="var(--theme-sidebar-footer-icon-fill)"
           weight="fill"
           className="w-[22px] h-[22px] pointer-events-none text-white"
         />
-      </div>
+      </button>
       <Tooltip
         ref={tooltipRef}
         id="tooltip-text-size-btn"
@@ -72,7 +73,7 @@ function TextSizeMenu({ tooltipRef }) {
           e.preventDefault();
           handleTextSizeChange("small");
         }}
-        className={`border-none w-full hover:cursor-pointer px-2 py-2 rounded-md flex items-center group ${
+        className={`border-none w-full hover:cursor-pointer px-2 py-2 rounded-md flex items-center group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-primary ${
           selectedSize === "small"
             ? "bg-theme-action-menu-item-hover"
             : "hover:bg-theme-action-menu-item-hover"
@@ -88,7 +89,7 @@ function TextSizeMenu({ tooltipRef }) {
           e.preventDefault();
           handleTextSizeChange("normal");
         }}
-        className={`border-none w-full hover:cursor-pointer px-2 py-2 rounded-md flex items-center group ${
+        className={`border-none w-full hover:cursor-pointer px-2 py-2 rounded-md flex items-center group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-primary ${
           selectedSize === "normal"
             ? "bg-theme-action-menu-item-hover"
             : "hover:bg-theme-action-menu-item-hover"
@@ -104,7 +105,7 @@ function TextSizeMenu({ tooltipRef }) {
           e.preventDefault();
           handleTextSizeChange("large");
         }}
-        className={`border-none w-full hover:cursor-pointer px-2 py-2 rounded-md flex items-center group ${
+        className={`border-none w-full hover:cursor-pointer px-2 py-2 rounded-md flex items-center group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-primary ${
           selectedSize === "large"
             ? "bg-theme-action-menu-item-hover"
             : "hover:bg-theme-action-menu-item-hover"


### PR DESCRIPTION
## Summary
- ensure Stop Generation button has visible focus ring and 40x40 hit area
- convert text size icon to accessible button with focus styling

## Testing
- `node .yarn/releases/yarn-classic.cjs lint`
- `node .yarn/releases/yarn-classic.cjs test` *(fails: Jest encountered an unexpected token in frontend/__tests__/jobStream.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a2238a3380832890cb51e3b9658be8