### PR TITLE
fix: define theme background utilities

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -219,6 +219,20 @@
   --theme-button-delete-hover-bg: #fee4e2;
 }
 
+@layer utilities {
+  .bg-theme-bg-primary {
+    background-color: var(--theme-bg-primary);
+  }
+
+  .bg-theme-bg-secondary {
+    background-color: var(--theme-bg-secondary);
+  }
+
+  .bg-theme-settings-input-bg {
+    background-color: var(--theme-settings-input-bg);
+  }
+}
+
 [data-theme="light"] .text-white {
   color: var(--theme-text-primary);
 }


### PR DESCRIPTION
## Summary
- add custom Tailwind utilities for theme background colors
- include `bg-theme-settings-input-bg` utility for settings inputs

## Testing
- `yarn build`
- `yarn prettier --check src/index.css`


------
https://chatgpt.com/codex/tasks/task_e_68a26359c54c832897208d1a0c382a87