### PR TITLE
Default to light theme on onboarding

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,6 +31,12 @@
   </head>
 
   <body>
+    <script>
+      const storedTheme = localStorage.getItem("theme");
+      const theme = storedTheme === "default" ? "dark" : storedTheme || "light";
+      document.documentElement.setAttribute("data-theme", theme);
+      if (theme === "light") document.body.classList.add("light");
+    </script>
     <div id="root" class="h-screen"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/frontend/src/LogoContext.jsx
+++ b/frontend/src/LogoContext.jsx
@@ -13,7 +13,7 @@ export function LogoProvider({ children }) {
   const [loginLogo, setLoginLogo] = useState("");
   const [isCustomLogo, setIsCustomLogo] = useState(false);
   const DefaultLoginLogo =
-    localStorage.getItem("theme") !== "default"
+    localStorage.getItem("theme") === "light"
       ? DefaultLoginLogoDark
       : DefaultLoginLogoLight;
 
@@ -25,14 +25,14 @@ export function LogoProvider({ children }) {
         setLoginLogo(isCustomLogo ? logoURL : DefaultLoginLogo);
         setIsCustomLogo(isCustomLogo);
       } else {
-        localStorage.getItem("theme") !== "default"
+        localStorage.getItem("theme") === "light"
           ? setLogo(OneNewDark)
           : setLogo(OneNew);
         setLoginLogo(DefaultLoginLogo);
         setIsCustomLogo(false);
       }
     } catch (err) {
-      localStorage.getItem("theme") !== "default"
+      localStorage.getItem("theme") === "light"
         ? setLogo(OneNewDark)
         : setLogo(OneNew);
       setLoginLogo(DefaultLoginLogo);

--- a/frontend/src/hooks/useTheme.js
+++ b/frontend/src/hooks/useTheme.js
@@ -12,19 +12,19 @@ const availableThemes = {
  */
 export function useTheme() {
   const [theme, _setTheme] = useState(() => {
-    return localStorage.getItem("theme") || "default";
+    return localStorage.getItem("theme") || "light";
   });
 
   useEffect(() => {
     if (localStorage.getItem("theme") !== null) return;
-    if (!window.matchMedia) return;
-    if (window.matchMedia("(prefers-color-scheme: light)").matches)
-      return _setTheme("light");
-    _setTheme("default");
+    _setTheme("light");
   }, []);
 
   useEffect(() => {
-    document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.setAttribute(
+      "data-theme",
+      theme === "default" ? "dark" : theme
+    );
     document.body.classList.toggle("light", theme === "light");
     localStorage.setItem("theme", theme);
     window.dispatchEvent(new Event(REFETCH_LOGO_EVENT));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -252,12 +252,12 @@
 
 /*
 This is to override the default border color for the select and input elements
-in the onboarding flow when the theme is not light. This only applies to the
+in the onboarding flow when the theme is dark. This only applies to the
 onboarding flow since its background is dark and is the same fill as the inputs.
 */
-[data-layout="onboarding"] > * select:not([data-theme="light"]),
-[data-layout="onboarding"] > * input:not([data-theme="light"]),
-[data-layout="onboarding"] > * textarea:not([data-theme="light"]) {
+[data-theme="dark"] [data-layout="onboarding"] > * select,
+[data-theme="dark"] [data-layout="onboarding"] > * input,
+[data-theme="dark"] [data-layout="onboarding"] > * textarea {
   border: 1px solid #ffffff;
 }
 
@@ -278,7 +278,7 @@ body {
     Droid Sans,
     Helvetica Neue,
     sans-serif;
-  background-color: white;
+  background-color: var(--theme-bg-primary);
 }
 
 a {

--- a/frontend/src/models/system.js
+++ b/frontend/src/models/system.js
@@ -350,7 +350,7 @@ const System = {
     const url = new URL(`${fullApiUrl()}/system/logo`);
     url.searchParams.append(
       "theme",
-      localStorage.getItem("theme") || "default"
+      localStorage.getItem("theme") || "light"
     );
 
     return await fetch(url, {

--- a/frontend/src/utils/toast.js
+++ b/frontend/src/utils/toast.js
@@ -4,7 +4,7 @@ import { toast } from "react-toastify";
 // You can also pass valid ReactToast params to override the defaults.
 // clear: false, // Will dismiss all visible toasts before rendering next toast
 const showToast = (message, type = "default", opts = {}) => {
-  const theme = localStorage?.getItem("theme") || "default";
+  const theme = localStorage?.getItem("theme") || "light";
   const options = {
     position: "bottom-center",
     autoClose: 5000,
@@ -12,7 +12,7 @@ const showToast = (message, type = "default", opts = {}) => {
     closeOnClick: true,
     pauseOnHover: true,
     draggable: true,
-    theme: theme === "default" ? "dark" : "light",
+    theme: theme === "light" ? "light" : "dark",
     ...opts,
   };
 

--- a/tests/theme.smoke.spec.ts
+++ b/tests/theme.smoke.spec.ts
@@ -6,7 +6,11 @@ test('Login: loads, no console errors, themed', async ({ page }) => {
   await page.goto('/');
   await expect(page.locator('body')).toBeVisible();
   await expect(page).toHaveScreenshot('login-light.png', { fullPage: true });
-  await page.evaluate(() => { document.documentElement.classList.add('dark'); localStorage.setItem('theme','dark'); });
+  await page.evaluate(() => {
+    document.documentElement.setAttribute('data-theme','dark');
+    document.body.classList.remove('light');
+    localStorage.setItem('theme','default');
+  });
   await page.reload();
   await expect(page).toHaveScreenshot('login-dark.png', { fullPage: true });
   expect(errors, `Console errors: ${errors.join('\n')}`).toEqual([]);
@@ -17,7 +21,11 @@ test('Chat: composer & message bubbles present', async ({ page }) => {
   await expect(page.locator('footer:has-text("Send")')).toBeVisible();
   await expect(page.locator('.onenew-card').first()).toBeVisible();
   await expect(page).toHaveScreenshot('chat-light.png', { fullPage: true });
-  await page.evaluate(() => { document.documentElement.classList.add('dark'); localStorage.setItem('theme','dark'); });
+  await page.evaluate(() => {
+    document.documentElement.setAttribute('data-theme','dark');
+    document.body.classList.remove('light');
+    localStorage.setItem('theme','default');
+  });
   await page.reload();
   await expect(page).toHaveScreenshot('chat-dark.png', { fullPage: true });
 });


### PR DESCRIPTION
## Summary
- default onboarding to light by setting theme before app load
- ensure theme hook and utilities treat light as default and only apply dark when explicitly chosen
- tie onboarding styles and global background to theme variables

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a34abc7fd0832897eb3942c2d4951f