### PR TITLE
Map Tailwind colors to OneNew variables

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,21 @@
 export default {
-  darkMode: "class",
+  darkMode: ["class"],
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-  theme: { extend: {} },
+  theme: {
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+        primary: "var(--primary)",
+        accent: "var(--accent)",
+        card: "var(--card)",
+        border: "var(--border)"
+      },
+      borderRadius: {
+        xl: "var(--radius)",
+        "2xl": "calc(var(--radius) + 8px)"
+      }
+    }
+  },
   plugins: []
 }


### PR DESCRIPTION
## Summary
- map Tailwind color utilities to OneNew CSS variables
- expose radius tokens via borderRadius utilities

## Testing
- `npx prettier tailwind.config.js --check`
- `yarn test` *(fails: jest encountered unexpected token in frontend/__tests__/jobStream.test.js and tests/theme.smoke.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a381b5c2f4832895eec95421bc799a