### PR TITLE
fix: update chat surfaces and icon colors

### DIFF
--- a/frontend/src/components/ChatBubble/index.jsx
+++ b/frontend/src/components/ChatBubble/index.jsx
@@ -3,15 +3,14 @@ import UserIcon from "../UserIcon";
 import { userFromStorage } from "@/utils/request";
 import renderMarkdown from "@/utils/chat/markdown";
 import DOMPurify from "@/utils/chat/purify";
+import { cn } from "@/lib/utils";
 
 export default function ChatBubble({ message, type, popMsg }) {
   const isUser = type === "user";
 
   return (
-    <div
-      className={`flex justify-center items-end w-full bg-theme-bg-secondary`}
-    >
-      <div className={`py-8 px-4 w-full flex gap-x-5 md:max-w-[80%] flex-col`}>
+    <div className="flex justify-center items-end w-full">
+      <div className="py-8 px-4 w-full flex gap-x-5 md:max-w-[80%] flex-col">
         <div className="flex gap-x-5">
           <UserIcon
             user={{ uid: isUser ? userFromStorage()?.username : "system" }}
@@ -19,7 +18,10 @@ export default function ChatBubble({ message, type, popMsg }) {
           />
 
           <div
-            className={`markdown whitespace-pre-line text-white font-normal text-sm md:text-sm flex flex-col gap-y-1 mt-2`}
+            className={cn(
+              "markdown whitespace-pre-line font-normal text-sm md:text-sm flex flex-col gap-y-1 mt-2 bubble",
+              isUser ? "bubble-user" : "bubble-assistant"
+            )}
             dangerouslySetInnerHTML={{
               __html: DOMPurify.sanitize(renderMarkdown(message)),
             }}

--- a/frontend/src/components/Footer/index.jsx
+++ b/frontend/src/components/Footer/index.jsx
@@ -54,16 +54,12 @@ export default function Footer() {
               to={paths.github()}
               target="_blank"
               rel="noreferrer"
-              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover"
+              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover text-[var(--theme-sidebar-footer-icon-fill)]"
               aria-label="Find us on GitHub"
               data-tooltip-id="footer-item"
               data-tooltip-content="View source code on GitHub"
             >
-              <GithubLogo
-                weight="fill"
-                className="h-5 w-5"
-                color="var(--theme-sidebar-footer-icon-fill)"
-              />
+              <GithubLogo weight="fill" className="h-5 w-5" />
             </Link>
           </div>
           <div className="flex w-fit">
@@ -71,16 +67,12 @@ export default function Footer() {
               to={paths.docs()}
               target="_blank"
               rel="noreferrer"
-              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover"
+              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover text-[var(--theme-sidebar-footer-icon-fill)]"
               aria-label="Docs"
               data-tooltip-id="footer-item"
               data-tooltip-content="Open OneNew help docs"
             >
-              <BookOpen
-                weight="fill"
-                className="h-5 w-5"
-                color="var(--theme-sidebar-footer-icon-fill)"
-              />
+              <BookOpen weight="fill" className="h-5 w-5" />
             </Link>
           </div>
           <div className="flex w-fit">
@@ -88,16 +80,12 @@ export default function Footer() {
               to={paths.discord()}
               target="_blank"
               rel="noreferrer"
-              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover"
+              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover text-[var(--theme-sidebar-footer-icon-fill)]"
               aria-label="Join our Discord server"
               data-tooltip-id="footer-item"
               data-tooltip-content="Join the OneNew Discord"
             >
-              <DiscordLogo
-                weight="fill"
-                className="h-5 w-5"
-                color="var(--theme-sidebar-footer-icon-fill)"
-              />
+              <DiscordLogo weight="fill" className="h-5 w-5" />
             </Link>
           </div>
           {!isMobile && <SettingsButton />}
@@ -121,14 +109,13 @@ export default function Footer() {
             href={item.url}
             target="_blank"
             rel="noreferrer"
-            className="transition-all duration-300 flex w-fit h-fit p-2 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover hover:border-slate-100"
+            className="transition-all duration-300 flex w-fit h-fit p-2 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover hover:border-slate-100 text-[var(--theme-sidebar-footer-icon-fill)]"
           >
             {React.createElement(
               ICON_COMPONENTS?.[item.icon] ?? ICON_COMPONENTS.Info,
               {
                 weight: "fill",
                 className: "h-5 w-5",
-                color: "var(--theme-sidebar-footer-icon-fill)",
               }
             )}
           </a>

--- a/frontend/src/components/SettingsButton/index.jsx
+++ b/frontend/src/components/SettingsButton/index.jsx
@@ -15,16 +15,12 @@ export default function SettingsButton() {
       <div className="flex w-fit">
         <Link
           to={paths.home()}
-          className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover"
+          className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover text-[var(--theme-sidebar-footer-icon-fill)]"
           aria-label="Home"
           data-tooltip-id="footer-item"
           data-tooltip-content="Back to workspaces"
         >
-          <ArrowUUpLeft
-            className="h-5 w-5"
-            weight="fill"
-            color="var(--theme-sidebar-footer-icon-fill)"
-          />
+          <ArrowUUpLeft className="h-5 w-5" weight="fill" />
         </Link>
       </div>
     );
@@ -33,16 +29,12 @@ export default function SettingsButton() {
     <div className="flex w-fit">
       <Link
         to={paths.settings.interface()}
-        className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover"
+        className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover text-[var(--theme-sidebar-footer-icon-fill)]"
         aria-label="Settings"
         data-tooltip-id="footer-item"
         data-tooltip-content="Open settings"
       >
-        <Wrench
-          className="h-5 w-5"
-          weight="fill"
-          color="var(--theme-sidebar-footer-icon-fill)"
-        />
+        <Wrench className="h-5 w-5" weight="fill" />
       </Link>
     </div>
   );

--- a/frontend/src/components/SettingsSidebar/MenuOption/index.jsx
+++ b/frontend/src/components/SettingsSidebar/MenuOption/index.jsx
@@ -60,22 +60,13 @@ export default function MenuOption({
   return (
     <div>
       <div
-        className={`
-          flex items-center justify-between w-full
-          transition-all duration-300
-          rounded-[6px]
-          ${
-            isActive
-              ? "bg-theme-sidebar-subitem-selected font-medium border-outline"
-              : "hover:bg-theme-sidebar-subitem-hover"
-          }
-        `}
+        className={`nav-item flex items-center justify-between w-full transition-all duration-300 rounded-[6px] ${
+          isActive ? "active font-medium" : ""
+        }`}
       >
         <Link
           to={href}
-          className={`flex flex-grow items-center px-[12px] h-[32px] font-medium ${
-            isChild ? "hover:text-white" : "text-white light:text-black"
-          }`}
+          className="flex flex-grow items-center px-[12px] h-[32px] font-medium"
           onClick={hasChildren ? handleClick : undefined}
         >
           {icon}
@@ -83,23 +74,18 @@ export default function MenuOption({
             className={`${
               isChild ? "text-xs" : "text-sm"
             } leading-loose whitespace-nowrap overflow-hidden ml-2 ${
-              isActive
-                ? "text-white font-semibold"
-                : "text-white light:text-black"
+              isActive ? "font-semibold" : ""
             } ${!icon && "pl-5"}`}
           >
             {btnText}
           </p>
         </Link>
         {hasChildren && (
-          <button onClick={handleClick} className="p-2 text-white">
+          <button onClick={handleClick} className="p-2">
             <CaretRight
               size={16}
               weight="bold"
-              // color={isExpanded ? "#000000" : "var(--theme-sidebar-subitem-icon)"}
-              className={`transition-transform text-white light:text-black ${
-                isExpanded ? "rotate-90" : ""
-              }`}
+              className={`transition-transform ${isExpanded ? "rotate-90" : ""}`}
             />
           </button>
         )}

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
@@ -97,10 +97,8 @@ export default function ActiveWorkspaces() {
                         ref={provided.innerRef}
                         {...provided.draggableProps}
                         className={cn(
-                          "group flex items-center gap-2 px-3 py-2 rounded-lg",
-                          "text-[var(--text)] hover:bg-[color-mix(in srgb,var(--accent),transparent 90%)]",
-                          isActive &&
-                            "bg-[color-mix(in srgb,var(--accent),transparent 86%)] font-semibold",
+                          "group nav-item flex items-center gap-2 px-3 py-2 rounded-lg",
+                          isActive && "active font-semibold",
                           snapshot.isDragging && "opacity-50"
                         )}
                         role="listitem"
@@ -112,8 +110,8 @@ export default function ActiveWorkspaces() {
                           >
                             <DotsSixVertical
                               size={20}
-                              color="var(--theme-sidebar-item-workspace-active)"
                               weight="bold"
+                              className="text-[var(--theme-sidebar-item-workspace-active)]"
                             />
                           </div>
                         )}
@@ -166,13 +164,12 @@ export default function ActiveWorkspaces() {
                               aria-label="General appearance settings"
                             >
                               <GearSix
-                                color={
+                                className={cn(
+                                  "h-[20px] w-[20px]",
                                   isInWorkspaceSettings &&
-                                  workspace.slug === slug
-                                    ? "#46C8FF"
-                                    : undefined
-                                }
-                                className="h-[20px] w-[20px]"
+                                    workspace.slug === slug &&
+                                    "text-[#46C8FF]"
+                                )}
                               />
                             </button>
                           </div>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/EditMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/EditMessage/index.jsx
@@ -56,11 +56,7 @@ export function EditMessageAction({ chatId = null, role, isEditing }) {
         className="border-none text-zinc-300"
         aria-label={`Edit ${role === "user" ? t("chat_window.edit_prompt") : t("chat_window.edit_response")}`}
       >
-        <Pencil
-          color="var(--theme-sidebar-footer-icon-fill)"
-          size={21}
-          className="mb-1"
-        />
+        <Pencil size={21} className="mb-1" />
       </button>
     </div>
   );

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/index.jsx
@@ -84,7 +84,6 @@ function FeedbackButton({
         aria-label={tooltipContent}
       >
         <IconComponent
-          color="var(--theme-sidebar-footer-icon-fill)"
           size={20}
           className="mb-1"
           weight={isSelected ? "fill" : "regular"}
@@ -109,17 +108,9 @@ function CopyMessage({ message }) {
           aria-label={t("chat_window.copy")}
         >
           {copied ? (
-            <Check
-              color="var(--theme-sidebar-footer-icon-fill)"
-              size={20}
-              className="mb-1"
-            />
+            <Check size={20} className="mb-1" />
           ) : (
-            <Copy
-              color="var(--theme-sidebar-footer-icon-fill)"
-              size={20}
-              className="mb-1"
-            />
+            <Copy size={20} className="mb-1" />
           )}
         </button>
       </div>
@@ -139,12 +130,7 @@ function RegenerateMessage({ regenerateMessage, chatId }) {
         className="border-none text-zinc-300"
         aria-label={t("chat_window.regenerate")}
       >
-        <ArrowsClockwise
-          color="var(--theme-sidebar-footer-icon-fill)"
-          size={20}
-          className="mb-1"
-          weight="fill"
-        />
+        <ArrowsClockwise size={20} className="mb-1" weight="fill" />
       </button>
     </div>
   );

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/AgentMenu/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/AgentMenu/index.jsx
@@ -20,10 +20,7 @@ export default function AvailableAgentsButton({ showing, setShowAgents }) {
         showing ? "!opacity-100" : ""
       }`}
     >
-      <At
-        color="var(--theme-sidebar-footer-icon-fill)"
-        className={`w-[22px] h-[22px] pointer-events-none text-theme-text-primary opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60`}
-      />
+      <At className="w-[22px] h-[22px] pointer-events-none opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60" />
       <Tooltip
         id="tooltip-agent-list-btn"
         place="top"

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/AttachItem/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/AttachItem/index.jsx
@@ -24,10 +24,7 @@ export default function AttachItem() {
         }}
         className={`border-none relative flex justify-center items-center opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60 cursor-pointer`}
       >
-        <PaperclipHorizontal
-          color="var(--theme-sidebar-footer-icon-fill)"
-          className="w-[22px] h-[22px] pointer-events-none text-white rotate-90 -scale-y-100"
-        />
+        <PaperclipHorizontal className="w-[22px] h-[22px] pointer-events-none rotate-90 -scale-y-100" />
       </button>
       <Tooltip
         id="attach-item-btn"

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/action.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/action.jsx
@@ -94,12 +94,12 @@ export default function LLMSelectorAction() {
         id="llm-selector-btn"
         data-tooltip-id="tooltip-llm-selector-btn"
         aria-label="LLM Selector"
-        className={`border-none relative flex justify-center items-center opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60 cursor-pointer`}
+        className={`border-none relative flex justify-center items-center opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60 cursor-pointer text-[var(--theme-sidebar-footer-icon-fill)]`}
       >
         {saved ? (
           <CheckCircle className="w-[22px] h-[22px] pointer-events-none text-green-400" />
         ) : (
-          <Brain className="w-[22px] h-[22px] pointer-events-none text-[var(--theme-sidebar-footer-icon-fill)]" />
+          <Brain className="w-[22px] h-[22px] pointer-events-none" />
         )}
       </div>
       <Tooltip

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/index.jsx
@@ -18,10 +18,7 @@ export default function SlashCommandsButton({ showing, setShowSlashCommand }) {
         showing ? "!opacity-100" : ""
       }`}
     >
-      <SlashCommandIcon
-        color="var(--theme-sidebar-footer-icon-fill)"
-        className={`w-[20px] h-[20px] pointer-events-none opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60`}
-      />
+      <SlashCommandIcon className="w-[20px] h-[20px] pointer-events-none opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60" />
       <Tooltip
         id="tooltip-slash-cmd-btn"
         place="top"

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SpeechToText/index.jsx
@@ -114,8 +114,7 @@ export default function SpeechToText({ sendCommand }) {
     >
       <Microphone
         weight="fill"
-        color="var(--theme-sidebar-footer-icon-fill)"
-        className={`w-[22px] h-[22px] pointer-events-none text-theme-text-primary ${
+        className={`w-[22px] h-[22px] pointer-events-none ${
           listening ? "animate-pulse-glow" : ""
         }`}
       />

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/index.jsx
@@ -13,33 +13,19 @@ export default function StopGenerationButton() {
         onClick={emitHaltEvent}
         data-tooltip-id="stop-generation-button"
         data-tooltip-content="Stop generating response"
-        className="border-none text-white cursor-pointer group -mr-1.5 mt-1.5 h-10 w-10 flex items-center justify-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-chat"
+        className="border-none cursor-pointer group -mr-1.5 mt-1.5 h-10 w-10 flex items-center justify-center rounded text-white group-hover:text-primary-button light:text-theme-text-secondary light:group-hover:text-primary-button focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-chat"
         aria-label="Stop generating"
       >
         <svg
           width="28"
           height="28"
           viewBox="0 0 28 28"
-          fill="none"
           xmlns="http://www.w3.org/2000/svg"
           style={{ transform: "scale(1.3)" }}
           className="opacity-60 group-hover:opacity-100 light:opacity-100 light:group-hover:opacity-60"
         >
-          <circle
-            cx="10"
-            cy="10.562"
-            r="9"
-            strokeWidth="2"
-            className="group-hover:stroke-primary-button stroke-white light:stroke-theme-text-secondary"
-          />
-          <rect
-            x="6.3999"
-            y="6.96204"
-            width="7.2"
-            height="7.2"
-            rx="2"
-            className="group-hover:fill-primary-button fill-white light:fill-theme-text-secondary"
-          />
+          <circle cx="10" cy="10.562" r="9" strokeWidth="2" fill="none" />
+          <rect x="6.3999" y="6.96204" width="7.2" height="7.2" rx="2" />
         </svg>
       </button>
       <Tooltip

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/stop.svg
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/stop.svg
@@ -1,4 +1,4 @@
 <svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="10.8984" cy="10.562" r="9" stroke="white" stroke-width="2"/>
-<rect x="7.29846" y="6.96204" width="7.2" height="7.2" rx="2" fill="white"/>
+<circle cx="10.8984" cy="10.562" r="9" stroke="currentColor" stroke-width="2"/>
+<rect x="7.29846" y="6.96204" width="7.2" height="7.2" rx="2" fill="currentColor"/>
 </svg>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/TextSizeMenu/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/TextSizeMenu/index.jsx
@@ -27,9 +27,8 @@ export default function TextSizeButton() {
         className="border-none flex justify-center items-center opacity-60 hover:opacity-100 light:opacity-100 light:hover:opacity-60 cursor-pointer h-10 w-10 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-chat"
       >
         <TextT
-          color="var(--theme-sidebar-footer-icon-fill)"
           weight="fill"
-          className="w-[22px] h-[22px] pointer-events-none text-white"
+          className="w-[22px] h-[22px] pointer-events-none"
         />
       </button>
       <Tooltip

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -276,7 +276,7 @@ export default function PromptInput({
                 }}
                 value={promptInput}
                 spellCheck={Appearance.get("enableSpellCheck")}
-                className={`onenew-input flex-grow resize-none max-h-[50vh] md:max-h-[350px] md:min-h-[40px] ${textSizeClass}`}
+                className={`onenew-input w-full resize-none max-h-[50vh] md:max-h-[350px] md:min-h-[40px] ${textSizeClass}`}
                 placeholder={t("chat_window.send_message")}
               />
               {isStreaming ? (
@@ -297,7 +297,6 @@ export default function PromptInput({
                     aria-label={t("chat_window.send")}
                   >
                     <PaperPlaneRight
-                      color="var(--theme-sidebar-footer-icon-fill)"
                       className="w-[22px] h-[22px] pointer-events-none group-disabled:opacity-[25%]"
                       weight="fill"
                     />

--- a/frontend/src/styles/onenew-components.css
+++ b/frontend/src/styles/onenew-components.css
@@ -1,11 +1,22 @@
 /* OneNew utility layer */
 .onenew-page {
-  background:
-    radial-gradient(1200px 1200px at -10% 10%,
-      color-mix(in srgb, var(--accent), transparent 82%), transparent 55%),
-    radial-gradient(1200px 1200px at 110% 10%,
-      color-mix(in srgb, var(--primary), transparent 92%), transparent 55%);
+  background: radial-gradient(
+      1200px 1200px at -10% 10%,
+      color-mix(in srgb, var(--accent), transparent 82%),
+      transparent 55%
+    ),
+    radial-gradient(
+      1200px 1200px at 110% 10%,
+      color-mix(in srgb, var(--primary), transparent 92%),
+      transparent 55%
+    );
   color: var(--text);
+}
+
+/* Ensure SVGs inherit text color */
+.theme-onenew svg {
+  fill: currentColor;
+  stroke: currentColor;
 }
 
 .onenew-card {
@@ -44,7 +55,9 @@
   background: var(--primary);
   color: #fff;
   border: 1px solid var(--primary);
-  transition: transform 60ms ease, box-shadow 200ms ease;
+  transition:
+    transform 60ms ease,
+    box-shadow 200ms ease;
   box-shadow: 0 2px 4px var(--shadow);
 }
 .onenew-btn:hover {
@@ -56,10 +69,54 @@
   cursor: not-allowed;
 }
 
+/* Chat bubbles */
+.bubble {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0.8rem 1rem;
+}
+
+.bubble-assistant {
+  background: color-mix(in srgb, var(--card-bg), #000 6%);
+  color: var(--text);
+}
+
+.bubble-user {
+  background: color-mix(in srgb, var(--primary), transparent 80%);
+  color: var(--text);
+}
+
+/* Sidebar navigation */
+.nav-item {
+  color: var(--muted-foreground);
+}
+
+.nav-item:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--card-bg), #000 8%);
+}
+
+.nav-item.active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--primary), transparent 88%);
+  border-left: 3px solid var(--primary);
+}
+
 /* Onboarding progress */
-.onb-progress { display: flex; gap: 8px; margin-bottom: 12px; }
-.onb-dot { width: 10px; height: 10px; border-radius: 999px; background: var(--border); }
-.onb-dot.active { background: var(--primary); }
+.onb-progress {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.onb-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: var(--border);
+}
+.onb-dot.active {
+  background: var(--primary);
+}
 
 .onenew-chip {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- make SVG icons follow text color and clean hard-coded fills
- add themed chat bubbles and visible composer input
- style sidebar navigation with consistent hover and active states

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a422de35f083289ba5fbfaa27b99d5