### PR TITLE
feat: add branded select styling

### DIFF
--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -1,0 +1,9 @@
+import React, { type SelectHTMLAttributes } from "react";
+
+export default function Select({
+  className = "",
+  ...props
+}: SelectHTMLAttributes<HTMLSelectElement>) {
+  const classes = ["select", className].filter(Boolean).join(" ");
+  return <select {...props} className={classes} />;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router } from "react-router-dom";
 import App from "@/App.jsx";
 import "@/index.css";
 import "./styles/onenew-components.css";
+import "./styles/forms.css";
 const isDev = process.env.NODE_ENV !== "production";
 const REACTWRAP = isDev ? React.Fragment : React.StrictMode;
 

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -1,0 +1,15 @@
+.select {
+  appearance: none;
+  background: var(--elev)
+    url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='currentColor'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M4%206l4%204%204-4'%20/%3E%3C/svg%3E")
+    no-repeat right 12px center;
+  padding: 10px 36px 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--fg-1);
+}
+
+.select:focus {
+  outline: none;
+  box-shadow: 0 0 0 var(--space-1) var(--brand);
+}


### PR DESCRIPTION
## Summary
- add Select component that applies unified styling
- style native selects with branded focus ring and inline chevron SVG
- load new form styles in main entry

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a486efab548328bb5a52872fb9874f