### PR TITLE
feat: add global focus-visible outline

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import App from "@/App.jsx";
 import "@/index.css";
 import "./styles/onenew-components.css";
 import "./styles/forms.css";
+import "./styles/a11y.css";
 const isDev = process.env.NODE_ENV !== "production";
 const REACTWRAP = isDev ? React.Fragment : React.StrictMode;
 

--- a/frontend/src/styles/a11y.css
+++ b/frontend/src/styles/a11y.css
@@ -1,0 +1,4 @@
+:focus-visible {
+  outline: 2px solid var(--brand);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- Add global `:focus-visible` styles with brand outline for clearer keyboard navigation
- Import accessibility stylesheet in app entry point

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token in frontend tests and theme smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_68a4942fbfe08328b61eaee97836ad42