### PR TITLE
style: adjust placeholder color

### DIFF
--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -1,3 +1,7 @@
+::placeholder {
+  color: var(--muted);
+}
+
 .select {
   appearance: none;
   background: var(--elev)


### PR DESCRIPTION
## Summary
- soften placeholder text by applying the theme's muted color

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token parsing ESM and two suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4996f63a88328a78cc1fad3340caa