### PR TITLE
feat(chat): style user and assistant messages

### DIFF
--- a/frontend/src/components/chat/Message.tsx
+++ b/frontend/src/components/chat/Message.tsx
@@ -1,0 +1,11 @@
+import React, { ReactNode } from "react";
+import "@/styles/chat.css";
+
+type MessageProps = {
+  sender: "user" | "bot";
+  children: ReactNode;
+};
+
+export default function Message({ sender, children }: MessageProps) {
+  return <div className={`msg ${sender}`}>{children}</div>;
+}

--- a/frontend/src/styles/chat.css
+++ b/frontend/src/styles/chat.css
@@ -1,0 +1,16 @@
+.msg {
+  max-width: 68ch;
+  padding: 12px 14px;
+  border-radius: 14px;
+  overflow-wrap: anywhere;
+}
+
+.msg.user {
+  background: #2a3340;
+  margin-left: auto;
+}
+
+.msg.bot {
+  background: #1c232c;
+  margin-right: auto;
+}


### PR DESCRIPTION
## Summary
- add Message component with user/bot styling
- introduce chat.css with bubble alignment colors

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token in frontend/__tests__/jobStream.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a7de6f548328897daa412fef6d2d