### PR TITLE
style: add sticky chat composer

### DIFF
--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -1,0 +1,43 @@
+import React, { useState, FormEvent } from "react";
+import {
+  PaperPlaneRight,
+  PaperclipHorizontal,
+  Microphone,
+} from "@phosphor-icons/react";
+import "@/styles/chat.css";
+
+interface ComposerProps {
+  onSend?: (message: string) => void;
+}
+
+export default function Composer({ onSend }: ComposerProps) {
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!message.trim()) return;
+    onSend?.(message);
+    setMessage("");
+  };
+
+  return (
+    <form className="chat-composer" onSubmit={handleSubmit}>
+      <button type="button" className="icon-btn" aria-label="Attach file">
+        <PaperclipHorizontal weight="bold" />
+      </button>
+      <input
+        type="text"
+        className="chat-input"
+        placeholder="Type a message or /command…"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+      />
+      <button type="button" className="icon-btn" aria-label="Start voice input">
+        <Microphone weight="bold" />
+      </button>
+      <button type="submit" className="icon-btn" aria-label="Send message">
+        <PaperPlaneRight weight="fill" />
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/styles/chat.css
+++ b/frontend/src/styles/chat.css
@@ -14,3 +14,37 @@
   background: #1c232c;
   margin-right: auto;
 }
+
+.chat-composer {
+  position: sticky;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+}
+
+.chat-composer .chat-input {
+  flex: 1;
+  height: 40px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  background: transparent;
+  color: var(--text);
+}
+
+.chat-composer .icon-btn {
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--text);
+}


### PR DESCRIPTION
## Summary
- add dedicated chat composer component with attach, mic, and send buttons
- style composer bar to stick to bottom and enlarge icon hit targets to 40px
- round message input with top border and new placeholder

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a4acb9094483289846dea5cde596ba