### PR TITLE
style: highlight active sidebar item

### DIFF
--- a/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
@@ -79,7 +79,7 @@ export default function ActiveWorkspaces() {
           <ul
             role="list"
             aria-label="Workspaces"
-            className="flex flex-col gap-y-2"
+            className="nav flex flex-col gap-y-2"
             ref={provided.innerRef}
             {...provided.droppableProps}
           >
@@ -97,7 +97,7 @@ export default function ActiveWorkspaces() {
                         ref={provided.innerRef}
                         {...provided.draggableProps}
                         className={cn(
-                          "group nav-item flex items-center gap-2 px-3 py-2 rounded-lg",
+                          "group nav-item item flex items-center gap-2 px-3 py-2 rounded-lg",
                           isActive && "active font-semibold",
                           snapshot.isDragging && "opacity-50"
                         )}

--- a/frontend/src/styles/onenew-components.css
+++ b/frontend/src/styles/onenew-components.css
@@ -120,19 +120,24 @@
 }
 
 /* Sidebar navigation */
-.nav-item {
+.nav .item {
   color: var(--muted);
 }
 
-.nav-item:hover {
+.nav .item:hover {
   color: var(--fg-1);
   background: color-mix(in srgb, var(--surface), var(--bg) 8%);
 }
 
-.nav-item.active {
+.nav .item.active {
   color: var(--fg-1);
-  background: color-mix(in srgb, var(--brand), transparent 88%);
+  background: rgba(106, 163, 255, 0.12);
   border-left: 3px solid var(--brand);
+}
+
+/* Indent nested navigation items */
+.nav .item .item {
+  margin-left: 1rem;
 }
 
 /* Onboarding progress */


### PR DESCRIPTION
## Summary
- emphasize active navigation item with brand-accented background and left border
- indent nested sidebar entries for clearer hierarchy

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token and missing initializer in const declaration)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b523d44083288476b1f9466ae184