### PR TITLE
feat: add card hover interaction

### DIFF
--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,0 +1,17 @@
+import React, { type HTMLAttributes } from "react";
+
+export default function Card({
+  className = "",
+  onClick,
+  children,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  const classes = ["card", onClick ? "clickable" : "", className]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div {...props} onClick={onClick} className={classes}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/styles/onenew-components.css
+++ b/frontend/src/styles/onenew-components.css
@@ -200,3 +200,18 @@
   background: linear-gradient(180deg, var(--brand), var(--brand));
   border-radius: var(--radius-lg);
 }
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  transition: box-shadow .2s, transform .2s;
+}
+.card:hover {
+  box-shadow: 0 12px 32px rgba(0,0,0,.35);
+  transform: translateY(-1px);
+}
+.clickable {
+  cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- add reusable Card component with optional clickable cursor
- style .card hover elevation and pointer feedback

## Testing
- `yarn lint` *(fails: yarn: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c1e2b5a883288b00884a3caf1eab