### PR TITLE
feat: update app title and favicon

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OneNew | Your personal LLM trained on anything</title>
+    <title>OneNew — Dashboard</title>
 
     <meta name="title" content="OneNew | Your personal LLM trained on anything">
     <meta name="description" content="OneNew | Your personal LLM trained on anything">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from "react";
+import React, { lazy, Suspense, useEffect } from "react";
 import { Routes, Route } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
 import { ContextWrapper } from "@/AuthContext";
@@ -91,6 +91,14 @@ const SystemPromptVariables = lazy(
 );
 
 export default function App() {
+  useEffect(() => {
+    document.title = "OneNew — Dashboard";
+    const favicon = document.querySelector("link[rel='icon']");
+    if (favicon) {
+      favicon.setAttribute("href", "/favicon.png");
+    }
+  }, []);
+
   return (
     <div id="root" className="theme-onenew dark">
       <ThemeProvider>


### PR DESCRIPTION
## Summary
- update dashboard title to "OneNew — Dashboard"
- set title and favicon on app mount using existing asset
- revert favicon change to avoid committing binaries

## Testing
- `cd frontend && yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a581c8ceb88328b2c70cec7dc6a583