### PR TITLE
Fix Chat Composer Overlap & Layout Issues

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -181,7 +181,7 @@ export default function ChatHistory({
 
   if (history.length === 0 && !hasAttachments) {
     return (
-      <div className="flex flex-col h-full md:mt-0 pb-44 md:pb-40 w-full justify-end items-center">
+      <div className="flex flex-col flex-1 min-h-0 md:mt-0 pb-44 md:pb-40 w-full justify-end items-center overflow-auto">
         <div className="flex flex-col items-center md:items-start md:max-w-[600px] w-full px-4">
           <p className="text-white/60 text-lg font-base py-4">
             {t("chat_window.welcome")}
@@ -221,7 +221,7 @@ export default function ChatHistory({
 
   return (
     <div
-      className={`markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} h-full md:h-[83%] pb-[100px] pt-6 md:pt-0 md:pb-20 md:mx-0 overflow-y-scroll flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
+      className={`markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} flex-1 min-h-0 overflow-auto pt-6 md:pt-0 md:mx-0 pb-4 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
       id="chat-history"
       ref={chatHistoryRef}
       onScroll={handleScroll}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
@@ -231,7 +231,7 @@ export default function DnDFileUploaderWrapper({ children }) {
 
   return (
     <div
-      className={`relative flex flex-col h-full w-full md:mt-0 mt-[40px] p-[1px]`}
+      className={`relative flex flex-col h-full min-h-0 w-full md:mt-0 mt-[40px] p-[1px]`}
       {...getRootProps()}
     >
       <div

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -239,7 +239,10 @@ export default function PromptInput({
   }
 
   return (
-    <div className="w-full fixed md:absolute bottom-0 left-0 z-10 md:z-0 flex justify-center items-center bg-[var(--surface)] border-t border-[var(--border)] p-3">
+    <div
+      className="w-full sticky bottom-0 left-0 z-20 flex justify-center items-center bg-[var(--surface)]/80 backdrop-blur-md border-t border-[var(--border)] p-3"
+      style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 12px)" }}
+    >
       <SlashCommands
         showing={showSlashCommand}
         setShowing={setShowSlashCommand}
@@ -276,7 +279,7 @@ export default function PromptInput({
                 }}
                 value={promptInput}
                 spellCheck={Appearance.get("enableSpellCheck")}
-                className={`onenew-input w-full resize-none max-h-[50vh] md:max-h-[350px] md:min-h-[40px] ${textSizeClass}`}
+                className={`onenew-input w-full resize-none max-h-[40vh] min-h-[40px] py-2 ${textSizeClass} focus:border-blue-400/60 focus:shadow-[0_0_0_2px_rgba(96,165,250,0.6)_inset]`}
                 placeholder={t("chat_window.send_message")}
               />
               {isStreaming ? (

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -274,7 +274,7 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
   return (
     <div
       style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
-      className="onenew-page transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg w-full h-full overflow-y-scroll no-scroll z-[2]"
+      className="onenew-page transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg w-full h-full flex flex-col min-h-0 z-[2]"
     >
       {isMobile && <SidebarMobileHeader />}
       <DnDFileUploaderWrapper>


### PR DESCRIPTION
## Summary
- refactor chat pane into flex column with sticky composer
- make textarea auto-resize with 40vh cap
- adjust z-index and dark mode focus styles

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a599ead97483289e0b9a8de28a887a