### PR TITLE
feat: add design token layer and style overrides

### DIFF
--- a/frontend/src/components/ModalWrapper/index.jsx
+++ b/frontend/src/components/ModalWrapper/index.jsx
@@ -1,5 +1,5 @@
 import { createPortal } from "react-dom";
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import FocusTrap from "focus-trap-react";
 /**
  * @typedef {Object} ModalWrapperProps
@@ -23,8 +23,6 @@ export default function ModalWrapper({
   noPortal = false,
   onClose,
 }) {
-  const overlayRef = useRef(null);
-
   useEffect(() => {
     if (!onClose) return;
     function handleKeydown(e) {
@@ -37,15 +35,12 @@ export default function ModalWrapper({
   if (!isOpen) return null;
 
   const overlay = (
-    <div
-      ref={overlayRef}
-      className="fixed inset-0 bg-black/50 backdrop-blur-[2px] z-50 flex items-center justify-center"
-      onMouseDown={(e) => {
-        if (e.target === overlayRef.current && onClose) onClose();
-      }}
-    >
-      <FocusTrap>{children}</FocusTrap>
-    </div>
+    <>
+      <div className="modal__backdrop" onMouseDown={onClose}></div>
+      <div className="modal">
+        <FocusTrap>{children}</FocusTrap>
+      </div>
+    </>
   );
 
   if (noPortal) return overlay;

--- a/frontend/src/components/UserMenu/AccountModal/index.jsx
+++ b/frontend/src/components/UserMenu/AccountModal/index.jsx
@@ -69,9 +69,9 @@ export default function AccountModal({ user, hideModal }) {
     }
   };
   return (
-    <ModalWrapper isOpen={true}>
-      <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
-        <div className="relative p-6 border-b rounded-t border-theme-modal-border">
+    <ModalWrapper isOpen={true} onClose={hideModal}>
+      <div className="modal__dialog">
+        <div className="modal__header relative">
           <div className="w-full flex gap-x-2 items-center">
             <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
               {t("profile_settings.edit_account")}
@@ -80,19 +80,16 @@ export default function AccountModal({ user, hideModal }) {
           <button
             onClick={hideModal}
             type="button"
-            className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
+            className="btn btn--ghost absolute top-4 right-4 p-1"
           >
             <X size={24} weight="bold" className="text-white" />
           </button>
         </div>
-        <div
-          className="h-full w-full overflow-y-auto"
-          style={{ maxHeight: "calc(100vh - 200px)" }}
-        >
-          <form onSubmit={handleUpdate} className="space-y-6">
+        <form onSubmit={handleUpdate}>
+          <div className="modal__body">
             <div className="flex flex-col md:flex-row items-center justify-center gap-8">
               <div className="flex flex-col items-center">
-                <label className="group w-48 h-48 flex flex-col items-center justify-center bg-theme-bg-primary hover:bg-theme-bg-secondary transition-colors duration-300 rounded-full mt-8 border-2 border-dashed border-white light:border-[#686C6F] light:bg-[#E0F2FE] light:hover:bg-transparent cursor-pointer hover:opacity-60">
+                <label className="profile-upload mt-8 cursor-pointer">
                   <input
                     id="logo-upload"
                     type="file"
@@ -104,7 +101,7 @@ export default function AccountModal({ user, hideModal }) {
                     <img
                       src={pfp}
                       alt="User profile picture"
-                      className="w-48 h-48 rounded-full object-cover bg-card"
+                      className="w-full h-full object-cover rounded-full"
                     />
                   ) : (
                     <div className="flex flex-col items-center justify-center p-3">
@@ -129,88 +126,70 @@ export default function AccountModal({ user, hideModal }) {
                 )}
               </div>
             </div>
-            <div className="flex flex-col gap-y-4 px-6">
-              <div>
-                <label
-                  htmlFor="username"
-                  className="block mb-2 text-sm font-medium text-theme-text-primary"
-                >
-                  {t("profile_settings.username")}
-                </label>
-                <input
-                  name="username"
-                  type="text"
-                  className="border-none bg-theme-settings-input-bg placeholder:text-theme-settings-input-placeholder border-gray-500 text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-                  placeholder="User's username"
-                  minLength={2}
-                  defaultValue={user.username}
-                  required
-                  autoComplete="off"
-                />
-                <p className="mt-2 text-xs text-white/60">
-                  {t("profile_settings.username_description")}
-                </p>
+            <div className="form-row">
+              <label htmlFor="username">{t("profile_settings.username")}</label>
+              <input
+                name="username"
+                type="text"
+                className="input"
+                placeholder="User's username"
+                minLength={2}
+                defaultValue={user.username}
+                required
+                autoComplete="off"
+              />
+              <p className="form-help">
+                {t("profile_settings.username_description")}
+              </p>
+            </div>
+            <div className="form-row">
+              <label htmlFor="password">
+                {t("profile_settings.new_password")}
+              </label>
+              <input
+                name="password"
+                type="text"
+                className="input"
+                placeholder={`${user.username}'s new password`}
+                minLength={8}
+              />
+              <p className="form-help">
+                {t("profile_settings.password_description")}
+              </p>
+            </div>
+            <div className="form-row">
+              <label htmlFor="bio">Bio</label>
+              <textarea
+                name="bio"
+                className="input"
+                placeholder="Tell us about yourself..."
+                defaultValue={user.bio}
+              />
+            </div>
+            <div className="flex gap-x-16">
+              <div className="flex flex-col gap-y-6">
+                <ThemePreference />
+                <LanguagePreference />
               </div>
-              <div>
-                <label
-                  htmlFor="password"
-                  className="block mb-2 text-sm font-medium text-white"
-                >
-                  {t("profile_settings.new_password")}
-                </label>
-                <input
-                  name="password"
-                  type="text"
-                  className="border-none bg-theme-settings-input-bg placeholder:text-theme-settings-input-placeholder border-gray-500 text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-                  placeholder={`${user.username}'s new password`}
-                  minLength={8}
-                />
-                <p className="mt-2 text-xs text-white/60">
-                  {t("profile_settings.password_description")}
-                </p>
-              </div>
-              <div>
-                <label
-                  htmlFor="bio"
-                  className="block mb-2 text-sm font-medium text-white"
-                >
-                  Bio
-                </label>
-                <textarea
-                  name="bio"
-                  className="border-none bg-theme-settings-input-bg placeholder:text-theme-settings-input-placeholder border-gray-500 text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 min-h-[100px] resize-y"
-                  placeholder="Tell us about yourself..."
-                  defaultValue={user.bio}
-                />
-              </div>
-              <div className="flex gap-x-16">
-                <div className="flex flex-col gap-y-6">
-                  <ThemePreference />
-                  <LanguagePreference />
-                </div>
-                <div className="flex flex-col gap-y-6">
-                  <AutoSubmitPreference />
-                  <AutoSpeakPreference />
-                </div>
+              <div className="flex flex-col gap-y-6">
+                <AutoSubmitPreference />
+                <AutoSpeakPreference />
               </div>
             </div>
-            <div className="flex justify-between items-center border-t border-theme-modal-border pt-4 p-6">
-              <button
-                onClick={hideModal}
-                type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
-              >
-                {t("profile_settings.cancel")}
-              </button>
-              <button
-                type="submit"
-                className="transition-all duration-300 bg-card text-foreground hover:opacity-60 px-4 py-2 rounded-sm text-sm"
-              >
-                {t("profile_settings.update_account")}
-              </button>
-            </div>
-          </form>
-        </div>
+          </div>
+          <div className="modal__footer flex justify-between">
+            <button
+              onClick={hideModal}
+              type="button"
+              className="btn btn--ghost"
+            >
+              {t("profile_settings.cancel")}
+            </button>
+            <button type="submit" className="btn btn--primary">
+              {t("profile_settings.update_account")}
+            </button>
+          </div>
+        </form>
       </div>
     </ModalWrapper>
   );

--- a/frontend/src/components/UserMenu/UserButton/index.jsx
+++ b/frontend/src/components/UserMenu/UserButton/index.jsx
@@ -57,50 +57,43 @@ export default function UserButton() {
   if (mode === null) return null;
   return (
     <div className="absolute top-3 right-4 md:top-9 md:right-10 w-fit h-fit z-40">
-      <button
-        ref={buttonRef}
-        onClick={() => setShowMenu(!showMenu)}
-        type="button"
-        className="uppercase transition-all duration-300 w-[35px] h-[35px] text-base font-semibold rounded-full flex items-center bg-theme-action-menu-bg hover:bg-theme-action-menu-item-hover justify-center text-[var(--text)] p-2 border border-transparent hover:border-[var(--border)]"
-      >
-        {mode === "multi" ? <UserDisplay /> : <Person size={14} />}
-      </button>
-
-      {showMenu && (
-        <div
-          ref={menuRef}
-          className="w-fit rounded-lg absolute top-12 right-0 bg-theme-action-menu-bg p-2 flex items-center-justify-center"
+      <div className="menu">
+        <button
+          ref={buttonRef}
+          onClick={() => setShowMenu(!showMenu)}
+          type="button"
+          className="uppercase transition-all duration-300 w-[35px] h-[35px] text-base font-semibold rounded-full flex items-center bg-theme-action-menu-bg hover:bg-theme-action-menu-item-hover justify-center text-[var(--text)] p-2 border border-transparent hover:border-[var(--border)]"
         >
-          <div className="flex flex-col gap-y-2">
-            {mode === "multi" && !!user && (
+          {mode === "multi" ? <UserDisplay /> : <Person size={14} />}
+        </button>
+
+        {showMenu && (
+          <div ref={menuRef} className="menu__popover">
+            <div className="flex flex-col gap-y-2">
+              {mode === "multi" && !!user && (
+                <button onClick={handleOpenAccountModal} className="menu__item">
+                  {t("profile_settings.account")}
+                </button>
+              )}
+              <a href={supportEmail} className="menu__item">
+                {t("profile_settings.support")}
+              </a>
               <button
-                onClick={handleOpenAccountModal}
-                className="border-none text-[var(--text)] hover:bg-theme-action-menu-item-hover w-full text-left px-4 py-1.5 rounded-md"
+                onClick={() => {
+                  window.localStorage.removeItem(AUTH_USER);
+                  window.localStorage.removeItem(AUTH_TOKEN);
+                  window.localStorage.removeItem(AUTH_TIMESTAMP);
+                  window.location.replace(paths.home());
+                }}
+                type="button"
+                className="menu__item"
               >
-                {t("profile_settings.account")}
+                {t("profile_settings.signout")}
               </button>
-            )}
-            <a
-              href={supportEmail}
-              className="text-[var(--text)] hover:bg-theme-action-menu-item-hover w-full text-left px-4 py-1.5 rounded-md"
-            >
-              {t("profile_settings.support")}
-            </a>
-            <button
-              onClick={() => {
-                window.localStorage.removeItem(AUTH_USER);
-                window.localStorage.removeItem(AUTH_TOKEN);
-                window.localStorage.removeItem(AUTH_TIMESTAMP);
-                window.location.replace(paths.home());
-              }}
-              type="button"
-              className="text-[var(--text)] hover:bg-theme-action-menu-item-hover w-full text-left px-4 py-1.5 rounded-md"
-            >
-              {t("profile_settings.signout")}
-            </button>
+            </div>
           </div>
-        </div>
-      )}
+        )}
+      </div>
       {user && showAccountSettings && (
         <AccountModal
           user={user}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -221,7 +221,7 @@ export default function ChatHistory({
 
   return (
     <div
-      className={`markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} flex-1 min-h-0 overflow-auto pt-6 md:pt-0 md:mx-0 pb-4 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
+      className={`chat-messages markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} flex-1 min-h-0 overflow-auto pt-6 md:pt-0 md:mx-0 pb-4 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
       id="chat-history"
       ref={chatHistoryRef}
       onScroll={handleScroll}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -257,81 +257,77 @@ export default function PromptInput({
       />
       <form
         onSubmit={handleSubmit}
-        className="flex flex-col gap-y-1 rounded-t-lg md:w-3/4 w-full mx-auto max-w-xl items-center"
+        className="md:w-3/4 w-full mx-auto max-w-xl"
       >
-        <div className="flex items-center rounded-lg md:mb-4 md:w-full">
-          <div className="w-[95vw] md:w-[635px] shadow-sm rounded-2xl flex flex-col px-2 overflow-hidden">
-            <AttachmentManager attachments={attachments} />
-            <div className="flex items-center mx-3">
-              <textarea
-                ref={textareaRef}
-                onChange={handleChange}
-                onKeyDown={captureEnterOrUndo}
-                onPaste={(e) => {
-                  saveCurrentState();
-                  handlePasteEvent(e);
-                }}
-                required={true}
-                onFocus={() => setFocused(true)}
-                onBlur={(e) => {
-                  setFocused(false);
-                  adjustTextArea(e);
-                }}
-                value={promptInput}
-                spellCheck={Appearance.get("enableSpellCheck")}
-                className={`onenew-input w-full resize-none max-h-[40vh] min-h-[40px] py-2 ${textSizeClass} focus:border-blue-400/60 focus:shadow-[0_0_0_2px_rgba(96,165,250,0.6)_inset]`}
-                placeholder={t("chat_window.send_message")}
+        <AttachmentManager attachments={attachments} />
+        <div className="chat-composer">
+          <textarea
+            ref={textareaRef}
+            onChange={handleChange}
+            onKeyDown={captureEnterOrUndo}
+            onPaste={(e) => {
+              saveCurrentState();
+              handlePasteEvent(e);
+            }}
+            required={true}
+            onFocus={() => setFocused(true)}
+            onBlur={(e) => {
+              setFocused(false);
+              adjustTextArea(e);
+            }}
+            value={promptInput}
+            spellCheck={Appearance.get("enableSpellCheck")}
+            className={`onenew-input resize-none max-h-[40vh] min-h-[40px] ${textSizeClass}`}
+            placeholder={t("chat_window.send_message")}
+          />
+          {isStreaming ? (
+            <StopGenerationButton />
+          ) : (
+            <>
+              <button
+                ref={formRef}
+                type="submit"
+                disabled={isDisabled}
+                className="chat__send btn btn--primary disabled:cursor-not-allowed group"
+                data-tooltip-id="send-prompt"
+                data-tooltip-content={
+                  isDisabled
+                    ? t("chat_window.attachments_processing")
+                    : t("chat_window.send")
+                }
+                aria-label={t("chat_window.send")}
+              >
+                <PaperPlaneRight
+                  className="w-[22px] h-[22px] pointer-events-none group-disabled:opacity-[25%]"
+                  weight="fill"
+                />
+                <span className="sr-only">Send message</span>
+              </button>
+              <Tooltip
+                id="send-prompt"
+                place="bottom"
+                delayShow={300}
+                className="tooltip !text-xs z-99"
               />
-              {isStreaming ? (
-                <StopGenerationButton />
-              ) : (
-                <>
-                  <button
-                    ref={formRef}
-                    type="submit"
-                    disabled={isDisabled}
-                    className="onenew-btn onenew-btn--primary ml-4 disabled:cursor-not-allowed group"
-                    data-tooltip-id="send-prompt"
-                    data-tooltip-content={
-                      isDisabled
-                        ? t("chat_window.attachments_processing")
-                        : t("chat_window.send")
-                    }
-                    aria-label={t("chat_window.send")}
-                  >
-                    <PaperPlaneRight
-                      className="w-[22px] h-[22px] pointer-events-none group-disabled:opacity-[25%]"
-                      weight="fill"
-                    />
-                    <span className="sr-only">Send message</span>
-                  </button>
-                  <Tooltip
-                    id="send-prompt"
-                    place="bottom"
-                    delayShow={300}
-                    className="tooltip !text-xs z-99"
-                  />
-                </>
-              )}
-            </div>
-            <div className="flex justify-between py-3.5 mx-3 mb-1">
-              <div className="flex gap-x-2">
-                <AttachItem />
-                <SlashCommandsButton
-                  showing={showSlashCommand}
-                  setShowSlashCommand={setShowSlashCommand}
-                />
-                <AvailableAgentsButton
-                  showing={showAgents}
-                  setShowAgents={setShowAgents}
-                />
-                <TextSizeButton />
-                <LLMSelectorAction />
-              </div>
-              <div className="flex gap-x-2">
-                <SpeechToText sendCommand={sendCommand} />
-              </div>
-            </div>
+            </>
+          )}
+        </div>
+        <div className="chat__toolbar flex justify-between">
+          <div className="flex gap-x-2">
+            <AttachItem />
+            <SlashCommandsButton
+              showing={showSlashCommand}
+              setShowSlashCommand={setShowSlashCommand}
+            />
+            <AvailableAgentsButton
+              showing={showAgents}
+              setShowAgents={setShowAgents}
+            />
+            <TextSizeButton />
+            <LLMSelectorAction />
+          </div>
+          <div className="flex gap-x-2">
+            <SpeechToText sendCommand={sendCommand} />
           </div>
         </div>
       </form>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,3 +9,5 @@ body {
   background: var(--bg);
   color: var(--fg-1);
 }
+
+@import "./styles/overrides.css";

--- a/frontend/src/styles/overrides.css
+++ b/frontend/src/styles/overrides.css
@@ -1,0 +1,272 @@
+:root {
+  /* spacing scale (8px base) */
+  --sp-1: .25rem;  /* 4  */
+  --sp-2: .5rem;   /* 8  */
+  --sp-3: .75rem;  /* 12 */
+  --sp-4: 1rem;    /* 16 */
+  --sp-5: 1.5rem;  /* 24 */
+  --sp-6: 2rem;    /* 32 */
+  --sp-7: 3rem;    /* 48 */
+
+  /* radius & shadow */
+  --radius-sm: .375rem;
+  --radius-md: .75rem;
+  --radius-lg: 1.25rem;
+  --shadow-1: 0 1px 2px rgba(0,0,0,.25);
+  --shadow-2: 0 6px 24px rgba(0,0,0,.28);
+
+  /* typography */
+  --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Inter, "Helvetica Neue", Arial, "Apple Color Emoji","Segoe UI Emoji";
+  --fs-12: .75rem;
+  --fs-14: .875rem;
+  --fs-16: 1rem;
+  --fs-18: 1.125rem;
+  --fs-20: 1.25rem;
+  --fs-24: 1.5rem;
+
+  /* dark theme */
+  --bg: #0d1117;
+  --bg-elev-1: #121821;
+  --bg-elev-2: #161c26;
+  --surface: #1b2230;
+  --text: #e6edf3;
+  --text-subtle: #9fb0c0;
+  --muted: #2a3342;
+  --border: #263142;
+  --primary: #5aa7ff;
+  --primary-600: #3f8ff0;
+  --danger: #ff6b6b;
+  --accent: #7ee787;
+  --focus: 0 0 0 2px rgba(90,167,255,.35);
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #f7f9fc;
+    --bg-elev-1: #fff;
+    --bg-elev-2: #f2f4f8;
+    --surface: #fff;
+    --text: #0f172a;
+    --text-subtle: #475569;
+    --muted: #e2e8f0;
+    --border: #e5e7eb;
+    --primary: #2563eb;
+    --primary-600: #1d4ed8;
+    --danger: #dc2626;
+    --accent: #16a34a;
+  }
+}
+
+/* Reset + base */
+*,
+*::before,
+*::after { box-sizing: border-box; }
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font: 400 var(--fs-16)/1.5 var(--font-sans);
+  color: var(--text);
+  background: radial-gradient(1200px 800px at 70% -20%, rgba(90,167,255,.08), transparent) , var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+/* Layout containers */
+.container,
+.page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--sp-6) var(--sp-5);
+}
+
+/* Headings hierarchy */
+h1 { font-size: var(--fs-24); margin: 0 0 var(--sp-4); }
+h2 { font-size: var(--fs-20); margin: var(--sp-5) 0 var(--sp-3); }
+h3 { font-size: var(--fs-18); margin: var(--sp-4) 0 var(--sp-2); }
+.section-title { font-weight: 600; letter-spacing: .2px; }
+
+/* Links */
+a { color: var(--primary); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Dividers and borders */
+.hr, .divider { height: 1px; background: var(--border); border: 0; }
+.card, .panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-1); }
+
+/* Focus visibility */
+:focus-visible { outline: none; box-shadow: var(--focus); border-radius: .25rem; }
+
+/* Hide questionable placeholder "AD" badge if it exists */
+.badge--ad, .ad-placeholder { display: none !important; }
+
+/* Sidebar */
+.sidebar {
+  width: 280px;
+  background: var(--bg-elev-2);
+  border-right: 1px solid var(--border);
+}
+
+.sidebar__search { padding: var(--sp-3) var(--sp-3) var(--sp-2); }
+.sidebar input[type="search"]{
+  width: 100%;
+  height: 40px;
+  padding: 0 var(--sp-3);
+  border-radius: var(--radius-md);
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  color: var(--text);
+}
+
+.workspace-item {
+  display: flex; align-items: center; gap: var(--sp-2);
+  padding: .5rem .75rem;
+  margin: .125rem .5rem;
+  border-radius: var(--radius-md);
+  color: var(--text-subtle);
+}
+.workspace-item--active,
+.workspace-item:hover {
+  background: linear-gradient(180deg, rgba(90,167,255,.07), transparent 70%);
+  color: var(--text);
+}
+
+/* Dropdown menu */
+.menu {
+  position: relative;
+}
+.menu__popover {
+  position: absolute;
+  right: 0; top: calc(100% + 8px);
+  min-width: 220px;
+  padding: var(--sp-2);
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-2);
+  z-index: 60;
+}
+.menu__item {
+  display: flex; align-items: center; gap: var(--sp-3);
+  padding: .625rem .75rem;
+  border-radius: var(--radius-md);
+  color: var(--text);
+  cursor: pointer;
+}
+.menu__item:hover { background: var(--muted); }
+.menu__section { padding: var(--sp-2) var(--sp-2) var(--sp-1); font-size: var(--fs-12); color: var(--text-subtle); text-transform: uppercase; }
+
+/* Modal system */
+.modal__backdrop {
+  position: fixed; inset: 0;
+  background: rgba(13,17,23,.55);
+  backdrop-filter: blur(6px);
+  z-index: 70;
+}
+.modal {
+  position: fixed; inset: 0;
+  display: grid; place-items: center;
+  padding: var(--sp-6);
+  z-index: 80;
+}
+.modal__dialog {
+  width: 640px; max-width: 92vw;
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+}
+.modal__header, .modal__footer { padding: var(--sp-4) var(--sp-5); }
+.modal__body   { padding: var(--sp-2) var(--sp-5) var(--sp-5); display: grid; gap: var(--sp-4); }
+
+.profile-upload {
+  display: grid; place-items: center;
+  width: 140px; height: 140px; border-radius: 50%;
+  background: var(--bg-elev-2); border: 1px dashed var(--border);
+  color: var(--text-subtle);
+}
+.form-row { display: grid; gap: var(--sp-2); }
+textarea { min-height: 110px; resize: vertical; }
+
+/* Buttons */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: .5rem;
+  height: 40px; padding: 0 14px;
+  font-weight: 600; font-size: var(--fs-14);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-elev-2);
+  color: var(--text);
+  cursor: pointer;
+}
+.btn:hover { background: var(--muted); }
+.btn--primary {
+  background: linear-gradient(180deg, var(--primary), var(--primary-600));
+  border-color: transparent; color: #fff;
+}
+.btn--primary:hover { filter: brightness(.97); }
+.btn--danger { background: linear-gradient(180deg, var(--danger), #d94b4b); color: #fff; border-color: transparent; }
+.btn--ghost { background: transparent; border-color: var(--border); }
+
+/* Forms */
+label { font-size: var(--fs-12); color: var(--text-subtle); }
+.input, input[type="text"], input[type="password"], input[type="email"], select {
+  width: 100%;
+  height: 42px;
+  padding: 0 var(--sp-3);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-elev-2);
+  color: var(--text);
+}
+.input:focus { box-shadow: var(--focus); border-color: var(--primary); }
+.form-help { font-size: var(--fs-12); color: var(--text-subtle); margin-top: .25rem; }
+
+/* Cards & dashboard blocks */
+.card {
+  padding: var(--sp-5);
+}
+.card__title { font-size: var(--fs-18); font-weight: 600; margin-bottom: var(--sp-2); }
+.card__subtitle { color: var(--text-subtle); margin-bottom: var(--sp-4); }
+.grid-3 {
+  display: grid; gap: var(--sp-5);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+@media (max-width: 1024px) { .grid-3 { grid-template-columns: 1fr; } }
+
+/* Chat composer */
+.chat-composer {
+  display: grid; grid-template-columns: 1fr auto;
+  align-items: center; gap: var(--sp-3);
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-3);
+  margin-top: var(--sp-4);
+}
+.chat-composer textarea {
+  min-height: 48px; max-height: 160px; overflow: auto;
+  border: 0; background: transparent; color: var(--text);
+}
+.chat__toolbar { display: flex; align-items: center; gap: var(--sp-3); padding-top: var(--sp-2); color: var(--text-subtle); }
+.chat__send { width: 48px; height: 48px; border-radius: 12px; }
+.chat-messages { padding-bottom: 96px; }
+
+/* Empty states */
+.empty {
+  padding: var(--sp-6);
+  text-align: center;
+  color: var(--text-subtle);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(180deg, rgba(255,255,255,.02), transparent);
+}
+.empty .actions { margin-top: var(--sp-4); display: flex; gap: var(--sp-3); justify-content: center; }
+
+/* Micro-utilities */
+.mt-0{margin-top:0}.mt-1{margin-top:var(--sp-1)}.mt-2{margin-top:var(--sp-2)}.mt-3{margin-top:var(--sp-3)}.mt-4{margin-top:var(--sp-4)}.mb-2{margin-bottom:var(--sp-2)}.mb-4{margin-bottom:var(--sp-4)}
+.p-3{padding:var(--sp-3)}.p-4{padding:var(--sp-4)}.p-5{padding:var(--sp-5)}
+.round-sm{border-radius:var(--radius-sm)}.round-md{border-radius:var(--radius-md)}.round-lg{border-radius:var(--radius-lg)}
+.text-subtle{color:var(--text-subtle)}
+.hidden{display:none!important}
+.z-50{z-index:50}.z-60{z-index:60}.z-70{z-index:70}.z-80{z-index:80}


### PR DESCRIPTION
## Summary
- add global design tokens and UI overrides
- align user menu, modals and chat composer with new styles
- pad chat history to avoid composer overlap

## Testing
- `yarn test` *(fails: Jest encountered unexpected token)*
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59dfa9504832891193217a85e9daa