### PR TITLE
Fix chat composer overlap with safe-area padding

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -221,10 +221,14 @@ export default function ChatHistory({
 
   return (
     <div
-      className={`chat-messages markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} flex-1 min-h-0 overflow-auto pt-6 md:pt-0 md:mx-0 pb-4 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
+      className={`chat-messages markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} flex-1 min-h-0 overflow-auto pt-6 md:pt-0 md:mx-0 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
       id="chat-history"
       ref={chatHistoryRef}
       onScroll={handleScroll}
+      style={{
+        paddingBottom:
+          "calc(var(--composer-h, 0px) + env(safe-area-inset-bottom))",
+      }}
     >
       {compiledHistory.map((item, index) =>
         Array.isArray(item) ? renderStatusResponse(item, index) : item

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -42,6 +42,7 @@ export default function PromptInput({
   const { showSlashCommand, setShowSlashCommand } = useSlashCommands();
   const formRef = useRef(null);
   const textareaRef = useRef(null);
+  const composerRef = useRef(null);
   const [_, setFocused] = useState(false);
   const undoStack = useRef([]);
   const redoStack = useRef([]);
@@ -68,6 +69,23 @@ export default function PromptInput({
     if (!isStreaming && textareaRef.current) textareaRef.current.focus();
     resetTextAreaHeight();
   }, [isStreaming]);
+
+  useEffect(() => {
+    const el = composerRef.current;
+    if (!el) return;
+    const updateHeight = () => {
+      document.documentElement.style.setProperty(
+        "--composer-h",
+        `${el.offsetHeight}px`
+      );
+    };
+    updateHeight();
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(updateHeight);
+      observer.observe(el);
+      return () => observer.disconnect();
+    }
+  }, []);
 
   /**
    * Save the current state before changes
@@ -240,6 +258,7 @@ export default function PromptInput({
 
   return (
     <div
+      ref={composerRef}
       className="w-full sticky bottom-0 left-0 z-20 flex justify-center items-center bg-[var(--surface)]/80 backdrop-blur-md border-t border-[var(--border)] p-3"
       style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 12px)" }}
     >

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -7,4 +7,5 @@
   --space-8: 32px;
   --radius-sm: 8px;
   --radius-lg: 16px;
+  --composer-h: 0px;
 }


### PR DESCRIPTION
## Summary
- update chat history padding to account for composer height and safe-area
- track composer height dynamically to keep input pinned
- define CSS token for composer height

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5a1d639b08328a47fc1eac17a2c0e