### PR TITLE
feat: polish chat layout and table styles

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -181,7 +181,7 @@ export default function ChatHistory({
 
   if (history.length === 0 && !hasAttachments) {
     return (
-      <div className="flex flex-col flex-1 min-h-0 md:mt-0 pb-44 md:pb-40 w-full justify-end items-center overflow-auto">
+      <div className="chat__messages flex flex-col md:mt-0 pb-44 md:pb-40 w-full justify-end items-center">
         <div className="flex flex-col items-center md:items-start md:max-w-[600px] w-full px-4">
           <p className="text-white/60 text-lg font-base py-4">
             {t("chat_window.welcome")}
@@ -221,14 +221,10 @@ export default function ChatHistory({
 
   return (
     <div
-      className={`chat-messages markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} flex-1 min-h-0 overflow-auto pt-6 md:pt-0 md:mx-0 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
+      className={`chat__messages chat-messages markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} pt-6 md:pt-0 md:mx-0 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
       id="chat-history"
       ref={chatHistoryRef}
       onScroll={handleScroll}
-      style={{
-        paddingBottom:
-          "calc(var(--composer-h, 0px) + env(safe-area-inset-bottom))",
-      }}
     >
       {compiledHistory.map((item, index) =>
         Array.isArray(item) ? renderStatusResponse(item, index) : item

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/index.jsx
@@ -42,7 +42,6 @@ export default function PromptInput({
   const { showSlashCommand, setShowSlashCommand } = useSlashCommands();
   const formRef = useRef(null);
   const textareaRef = useRef(null);
-  const composerRef = useRef(null);
   const [_, setFocused] = useState(false);
   const undoStack = useRef([]);
   const redoStack = useRef([]);
@@ -70,22 +69,6 @@ export default function PromptInput({
     resetTextAreaHeight();
   }, [isStreaming]);
 
-  useEffect(() => {
-    const el = composerRef.current;
-    if (!el) return;
-    const updateHeight = () => {
-      document.documentElement.style.setProperty(
-        "--composer-h",
-        `${el.offsetHeight}px`
-      );
-    };
-    updateHeight();
-    if (typeof ResizeObserver !== "undefined") {
-      const observer = new ResizeObserver(updateHeight);
-      observer.observe(el);
-      return () => observer.disconnect();
-    }
-  }, []);
 
   /**
    * Save the current state before changes
@@ -257,11 +240,7 @@ export default function PromptInput({
   }
 
   return (
-    <div
-      ref={composerRef}
-      className="w-full sticky bottom-0 left-0 z-20 flex justify-center items-center bg-[var(--surface)]/80 backdrop-blur-md border-t border-[var(--border)] p-3"
-      style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 12px)" }}
-    >
+    <div className="chat__composer">
       <SlashCommands
         showing={showSlashCommand}
         setShowing={setShowSlashCommand}
@@ -274,12 +253,9 @@ export default function PromptInput({
         sendCommand={sendCommand}
         promptRef={textareaRef}
       />
-      <form
-        onSubmit={handleSubmit}
-        className="md:w-3/4 w-full mx-auto max-w-xl"
-      >
+      <form onSubmit={handleSubmit} className="md:w-3/4 w-full mx-auto max-w-xl">
         <AttachmentManager attachments={attachments} />
-        <div className="chat-composer">
+        <div className="flex items-center gap-2">
           <textarea
             ref={textareaRef}
             onChange={handleChange}
@@ -296,7 +272,7 @@ export default function PromptInput({
             }}
             value={promptInput}
             spellCheck={Appearance.get("enableSpellCheck")}
-            className={`onenew-input resize-none max-h-[40vh] min-h-[40px] ${textSizeClass}`}
+            className={`chat__input onenew-input resize-none max-h-[40vh] ${textSizeClass}`}
             placeholder={t("chat_window.send_message")}
           />
           {isStreaming ? (

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -274,20 +274,22 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
   return (
     <div
       style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
-      className="onenew-page transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg w-full h-full flex flex-col min-h-0 z-[2]"
+      className="chat onenew-page transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg w-full h-full flex flex-col min-h-0 z-[2]"
     >
       {isMobile && <SidebarMobileHeader />}
       <DnDFileUploaderWrapper>
-        <MetricsProvider>
-          <ChatHistory
-            history={chatHistory}
-            workspace={workspace}
-            sendCommand={sendCommand}
-            updateHistory={setChatHistory}
-            regenerateAssistantMessage={regenerateAssistantMessage}
-            hasAttachments={files.length > 0}
-          />
-        </MetricsProvider>
+        <div className="chat__messages">
+          <MetricsProvider>
+            <ChatHistory
+              history={chatHistory}
+              workspace={workspace}
+              sendCommand={sendCommand}
+              updateHistory={setChatHistory}
+              regenerateAssistantMessage={regenerateAssistantMessage}
+              hasAttachments={files.length > 0}
+            />
+          </MetricsProvider>
+        </div>
         <PromptInput
           submit={handleSubmit}
           onChange={handleMessageChange}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,11 @@ body {
 }
 
 @import "./styles/overrides.css";
+@import "./styles/app-shell.css";
+@import "./styles/tables.css";
+@import "./styles/forms.css";
+@import "./styles/states.css";
+@import "./styles/chat.css";
+@import "./styles/misc.css";
+@import "./styles/buttons.css";
+@import "./pages/ui-preferences.css";

--- a/frontend/src/pages/GeneralSettings/Chats/ChatRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Chats/ChatRow/index.jsx
@@ -32,6 +32,8 @@ export default function ChatRow({ chat, onDelete }) {
     closeModal: closeResponseModal,
   } = useModal();
 
+  const responseText = parseText(chat.response);
+
   const handleDelete = async () => {
     if (
       !window.confirm(
@@ -61,15 +63,16 @@ export default function ChatRow({ chat, onDelete }) {
         </td>
         <td
           onClick={openResponseModal}
-          className="px-6 cursor-pointer transform transition-transform duration-200 hover:scale-105 hover:shadow-lg"
+          className="px-6 trunc cursor-pointer transform transition-transform duration-200 hover:scale-105 hover:shadow-lg"
+          title={responseText}
         >
-          {truncate(parseText(chat.response), 40)}
+          {responseText}
         </td>
         <td className="px-6">{chat.createdAt}</td>
-        <td className="px-6 flex items-center gap-x-6 h-full mt-1">
+        <td className="px-6 cell-actions">
           <button
             onClick={handleDelete}
-            className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
+            className="icon-btn text-white/80 light:text-foreground hover:text-red-300 light:hover:text-red-500"
           >
             <Trash className="h-5 w-5" />
           </button>

--- a/frontend/src/pages/ui-preferences.css
+++ b/frontend/src/pages/ui-preferences.css
@@ -1,0 +1,7 @@
+.pref-grid{ display:grid; gap:var(--gap-lg); grid-template-columns: repeat(12,1fr); }
+.pref-card{ grid-column: span 12; }
+.alignment-tiles{ grid-column: span 12; display:grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap:var(--gap); }
+.tile{ border-radius:14px; padding:18px; background:var(--card-bg); box-shadow:var(--elev); min-height:100px; }
+@media (min-width: 960px){
+  .pref-card{ grid-column: span 8; }
+}

--- a/frontend/src/styles/app-shell.css
+++ b/frontend/src/styles/app-shell.css
@@ -1,0 +1,16 @@
+:root{
+  --radius:14px; --gap:16px; --gap-lg:24px;
+  --card-bg: color-mix(in hsl, Canvas 96%, black 6%); /* light */
+  --card-bg-dark: color-mix(in hsl, Canvas 92%, white 6%); /* dark */
+  --elev: 0 6px 18px rgba(0,0,0,.08);
+}
+@media (prefers-color-scheme: dark){
+  :root{ --card-bg: var(--card-bg-dark); }
+}
+.app{
+  min-height:100dvh; display:grid; grid-template-columns: 264px 1fr;
+}
+.sidebar{ position:sticky; top:0; align-self:start; height:100dvh; overflow:auto; }
+.main{ padding: clamp(16px,2vw,32px); }
+.container{ max-width: 1200px; margin-inline:auto; }
+.card{ background:var(--card-bg); border-radius:var(--radius); box-shadow:var(--elev); }

--- a/frontend/src/styles/buttons.css
+++ b/frontend/src/styles/buttons.css
@@ -1,0 +1,3 @@
+.icon-btn{ display:inline-grid; place-items:center; width:32px; height:32px; border-radius:10px; }
+.icon-btn:hover{ background: color-mix(in hsl, CanvasText 8%, transparent); }
+.icon-btn:focus-visible{ outline:2px solid AccentColor; outline-offset:2px; }

--- a/frontend/src/styles/chat.css
+++ b/frontend/src/styles/chat.css
@@ -1,50 +1,15 @@
-.msg {
-  max-width: 68ch;
-  padding: 12px 14px;
-  border-radius: 14px;
-  overflow-wrap: anywhere;
+.chat{
+  min-height:100dvh; display:flex; flex-direction:column;
 }
-
-.msg.user {
-  background: #2a3340;
-  margin-left: auto;
+.chat__messages{
+  flex:1 1 auto; min-height:0; overflow:auto; padding:16px;
+  scroll-behavior:smooth; /* better feel */
 }
-
-.msg.bot {
-  background: #1c232c;
-  margin-right: auto;
+.chat__composer{
+  position:sticky; bottom:0; inset-inline:0;
+  background:Canvas; border-top:1px solid color-mix(in hsl, CanvasText 10%, transparent);
+  padding:12px clamp(12px, 2vw, 20px) max(12px, env(safe-area-inset-bottom));
 }
-
-.chat-composer {
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 8px;
-  background: var(--surface);
-  border-top: 1px solid var(--border);
-}
-
-.chat-composer .chat-input {
-  flex: 1;
-  height: 40px;
-  padding: 0 12px;
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  background: transparent;
-  color: var(--text);
-}
-
-.chat-composer .icon-btn {
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  color: var(--text);
+.chat__input{
+  width:100%; min-height:44px; max-height:172px; border-radius:14px; padding:10px 14px; resize:vertical; overflow:auto;
 }

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -1,19 +1,7 @@
-::placeholder {
-  color: var(--muted);
+.input, .select{
+  height:40px; border-radius:12px; padding:0 12px; border:1px solid color-mix(in hsl, currentColor 12%, transparent);
+  background:Canvas; color:CanvasText;
 }
-
-.select {
-  appearance: none;
-  background: var(--elev)
-    url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='currentColor'%20stroke-width='2'%20stroke-linecap='round'%20stroke-linejoin='round'%3E%3Cpath%20d='M4%206l4%204%204-4'%20/%3E%3C/svg%3E")
-    no-repeat right 12px center;
-  padding: 10px 36px 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  color: var(--fg-1);
-}
-
-.select:focus {
-  outline: none;
-  box-shadow: 0 0 0 var(--space-1) var(--brand);
-}
+.input:focus, .select:focus{ outline:2px solid color-mix(in hsl, AccentColor 60%, transparent); outline-offset:2px; }
+.dropdown{ position:relative; }
+.dropdown-menu{ position:absolute; inset-inline-start:0; top:calc(100% + 6px); z-index: 60; min-width: 220px; }

--- a/frontend/src/styles/misc.css
+++ b/frontend/src/styles/misc.css
@@ -1,0 +1,2 @@
+@supports (scrollbar-width:thin){ *{ scrollbar-width: thin; } }
+.main{ padding-bottom: max(24px, env(safe-area-inset-bottom)); }

--- a/frontend/src/styles/states.css
+++ b/frontend/src/styles/states.css
@@ -1,0 +1,5 @@
+.info-banner{ background: color-mix(in hsl, AccentColor 14%, Canvas); padding:16px; border-radius:12px; line-height:1.4; }
+.empty{
+  display:grid; place-items:center; min-height:240px; border-radius:12px; border:1px dashed color-mix(in hsl, currentColor 20%, transparent);
+  color: color-mix(in hsl, CanvasText 60%, transparent);
+}

--- a/frontend/src/styles/tables.css
+++ b/frontend/src/styles/tables.css
@@ -1,0 +1,7 @@
+.table{ width:100%; border-collapse:separate; border-spacing:0 8px; }
+.table th{ font-weight:600; font-size:13px; text-transform:uppercase; letter-spacing:.03em; }
+.table td,.table th{ padding:12px 14px; vertical-align:middle; }
+.table .mono{ font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.trunc{ max-width: 520px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.cell-actions{ display:flex; gap:10px; justify-content:flex-end; align-items:center; }
+.row{ background:var(--card-bg); border-radius:12px; }


### PR DESCRIPTION
## Summary
- add global layout and table styles
- make chat composer sticky and trim chat history rows
- normalize form inputs and buttons

## Testing
- `npm test` *(fails: Unexpected token 'export' in frontend/__tests__/jobStream.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b159ae248328b4f616a790c2685d