### PR TITLE
feat: wire Tailwind to OneNew theme

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,8 @@ import SimpleSSOPassthrough from "@/pages/Login/SSO/simple";
 import OnboardingFlow from "@/pages/OnboardingFlow";
 import i18n from "./i18n";
 
+import "./styles/onenew-theme-shim.css";
+
 import { PfpProvider } from "./PfpContext";
 import { LogoProvider } from "./LogoContext";
 import { FullScreenLoader } from "./components/Preloader";

--- a/frontend/src/styles/onenew-theme-shim.css
+++ b/frontend/src/styles/onenew-theme-shim.css
@@ -1,8 +1,30 @@
+/* Dark theme (default) */
 .theme-onenew {
+  --bg: #0b1220;
+  --text: #e6edf3;
+  --muted: #9aa9bd;
+  --border: #243045;
+  --primary: #14b8a6;
+  --accent: #7c9cff;
+  --card-bg: rgba(13, 19, 33, 0.65);
+  --shadow: rgba(0, 0, 0, 0.18);
+  --ring: color-mix(in srgb, var(--primary), transparent 60%);
+  --radius: 16px;
+
+  /* bridges to Tailwind tokens */
   --background: var(--bg);
-  --foreground: var(--fg-1);
-  --card: var(--surface);
-  --border: var(--border);
-  --primary: var(--brand);
-  --accent: var(--brand);
+  --foreground: var(--text);
+  --card: var(--card-bg);
+  --input: color-mix(in srgb, var(--bg), var(--border) 35%);
+}
+
+/* Light theme override */
+.theme-onenew.light {
+  --bg: #f7f9fc;
+  --text: #101623;
+  --muted: #5d6b80;
+  --border: #dbe3f1;
+  --card-bg: #fff;
+  --shadow: rgba(16, 22, 35, 0.08);
+  --ring: color-mix(in srgb, var(--primary), transparent 70%);
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,16 +2,6 @@ export default {
   darkMode: ["class"],
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    borderRadius: {
-      none: "0px",
-      sm: "var(--radius-sm)",
-      DEFAULT: "var(--radius-sm)",
-      md: "var(--radius-sm)",
-      lg: "var(--radius-lg)",
-      xl: "var(--radius-lg)",
-      "2xl": "var(--radius-lg)",
-      full: "9999px"
-    },
     extend: {
       colors: {
         background: "var(--background)",
@@ -20,6 +10,10 @@ export default {
         border: "var(--border)",
         primary: "var(--primary)",
         accent: "var(--accent)"
+      },
+      borderRadius: {
+        xl: "var(--radius)",
+        "2xl": "calc(var(--radius) + 8px)"
       },
       spacing: {
         1: "var(--space-1)",


### PR DESCRIPTION
## Summary
- map Tailwind colors and radii to OneNew design tokens
- add OneNew theme shim for dark/light palettes
- load theme shim in app root

## Testing
- `cd frontend && yarn lint`
- `cd frontend && yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e1511de88328bb9dd9ea80726da8