### PR TITLE
refactor: replace hardcoded colors with theme tokens

### DIFF
--- a/frontend/src/components/ChangeWarning/index.jsx
+++ b/frontend/src/components/ChangeWarning/index.jsx
@@ -19,7 +19,7 @@ export default function ChangeWarningModal({
           type="button"
           className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
         >
-          <X size={24} weight="bold" className="text-white" />
+          <X size={24} weight="bold" className="text-foreground" />
         </button>
       </div>
       <div
@@ -27,7 +27,7 @@ export default function ChangeWarningModal({
         style={{ maxHeight: "calc(100vh - 200px)" }}
       >
         <div className="py-7 px-9 space-y-2 flex-col">
-          <p className="text-white">
+          <p className="text-foreground">
             {warningText.split("\\n").map((line, index) => (
               <span key={index}>
                 {line}
@@ -44,14 +44,14 @@ export default function ChangeWarningModal({
         <button
           onClick={onClose}
           type="button"
-          className="transition-all duration-300 bg-transparent text-white hover:opacity-60 px-4 py-2 rounded-sm text-sm border-none"
+          className="transition-all duration-300 bg-transparent text-foreground hover:opacity-60 px-4 py-2 rounded-sm text-sm border-none"
         >
           Cancel
         </button>
         <button
           onClick={onConfirm}
           type="submit"
-          className="transition-all duration-300 bg-red-500 light:text-white text-white hover:opacity-60 px-4 py-2 rounded-sm text-sm border-none"
+          className="transition-all duration-300 bg-red-500 light:text-foreground text-foreground hover:opacity-60 px-4 py-2 rounded-sm text-sm border-none"
         >
           Confirm
         </button>

--- a/frontend/src/components/CommunityHub/PublishEntityModal/AgentFlows/index.jsx
+++ b/frontend/src/components/CommunityHub/PublishEntityModal/AgentFlows/index.jsx
@@ -127,7 +127,7 @@ export default function AgentFlows({ entity }) {
             <label className="block text-sm font-semibold text-theme-text-primary mb-1">
               {t("community_hub.publish.agent_flow.description_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.agent_flow.description_description")}
             </div>
             <textarea
@@ -139,14 +139,14 @@ export default function AgentFlows({ entity }) {
               placeholder={t(
                 "community_hub.publish.agent_flow.description_description"
               )}
-              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-white text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[80px] placeholder:text-theme-text-placeholder"
+              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-foreground text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[80px] placeholder:text-theme-text-placeholder"
             />
           </div>
           <div>
-            <label className="block text-sm font-semibold text-white mb-1">
+            <label className="block text-sm font-semibold text-foreground mb-1">
               {t("community_hub.publish.agent_flow.tags_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.agent_flow.tags_description")}
             </div>
             <div className="flex flex-wrap gap-2 p-2 bg-theme-bg-secondary rounded-lg min-h-[42px]">
@@ -178,7 +178,7 @@ export default function AgentFlows({ entity }) {
             </div>
           </div>
           <div>
-            <label className="block text-sm font-semibold text-white">
+            <label className="block text-sm font-semibold text-foreground">
               {t("community_hub.publish.agent_flow.visibility_label")}
             </label>
             <span className="text-xs text-theme-text-secondary">
@@ -191,7 +191,7 @@ export default function AgentFlows({ entity }) {
             <label className="block text-sm font-semibold text-theme-text-primary mb-1">
               Flow Steps
             </label>
-            <div className="text-xs text-white/60">
+            <div className="text-xs text-foreground/60">
               The steps the agent will follow when the flow is triggered.
             </div>
           </div>

--- a/frontend/src/components/CommunityHub/PublishEntityModal/SlashCommands/index.jsx
+++ b/frontend/src/components/CommunityHub/PublishEntityModal/SlashCommands/index.jsx
@@ -125,7 +125,7 @@ export default function SlashCommands({ entity }) {
             <label className="block text-sm font-semibold text-theme-text-primary mb-1">
               {t("community_hub.publish.slash_command.description_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.slash_command.description_description")}
             </div>
             <textarea
@@ -137,14 +137,14 @@ export default function SlashCommands({ entity }) {
               placeholder={t(
                 "community_hub.publish.slash_command.description_description"
               )}
-              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-white text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[80px] placeholder:text-theme-text-placeholder"
+              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-foreground text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[80px] placeholder:text-theme-text-placeholder"
             />
           </div>
           <div>
-            <label className="block text-sm font-semibold text-white mb-1">
+            <label className="block text-sm font-semibold text-foreground mb-1">
               {t("community_hub.publish.slash_command.tags_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.slash_command.tags_description")}
             </div>
             <div className="flex flex-wrap gap-2 p-2 bg-theme-bg-secondary rounded-lg min-h-[42px]">
@@ -177,10 +177,10 @@ export default function SlashCommands({ entity }) {
           </div>
 
           <div>
-            <label className="block text-sm font-semibold text-white mb-1">
+            <label className="block text-sm font-semibold text-foreground mb-1">
               {t("community_hub.publish.slash_command.visibility_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {visibility === "public"
                 ? t("community_hub.publish.slash_command.public_description")
                 : t("community_hub.publish.slash_command.private_description")}
@@ -223,10 +223,10 @@ export default function SlashCommands({ entity }) {
 
         <div className="w-1/2 p-6 pt-0 space-y-4">
           <div>
-            <label className="block text-sm font-semibold text-white mb-1">
+            <label className="block text-sm font-semibold text-foreground mb-1">
               {t("community_hub.publish.slash_command.prompt_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.slash_command.prompt_description")}
             </div>
             <textarea
@@ -237,7 +237,7 @@ export default function SlashCommands({ entity }) {
               placeholder={t(
                 "community_hub.publish.slash_command.prompt_placeholder"
               )}
-              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-white text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[300px] placeholder:text-theme-text-placeholder"
+              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-foreground text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[300px] placeholder:text-theme-text-placeholder"
             />
           </div>
 

--- a/frontend/src/components/CommunityHub/PublishEntityModal/SystemPrompts/index.jsx
+++ b/frontend/src/components/CommunityHub/PublishEntityModal/SystemPrompts/index.jsx
@@ -120,7 +120,7 @@ export default function SystemPrompts({ entity }) {
             <label className="block text-sm font-semibold text-theme-text-primary mb-1">
               {t("community_hub.publish.system_prompt.description_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.system_prompt.description_description")}
             </div>
             <textarea
@@ -131,14 +131,14 @@ export default function SystemPrompts({ entity }) {
               placeholder={t(
                 "community_hub.publish.system_prompt.description_description"
               )}
-              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-white text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[80px] placeholder:text-theme-text-placeholder"
+              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-foreground text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[80px] placeholder:text-theme-text-placeholder"
             />
           </div>
           <div>
-            <label className="block text-sm font-semibold text-white mb-1">
+            <label className="block text-sm font-semibold text-foreground mb-1">
               {t("community_hub.publish.system_prompt.tags_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.system_prompt.tags_description")}
             </div>
             <div className="flex flex-wrap gap-2 p-2 bg-theme-bg-secondary rounded-lg min-h-[42px]">
@@ -171,10 +171,10 @@ export default function SystemPrompts({ entity }) {
           </div>
 
           <div>
-            <label className="block text-sm font-semibold text-white mb-1">
+            <label className="block text-sm font-semibold text-foreground mb-1">
               {t("community_hub.publish.system_prompt.visibility_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {visibility === "public"
                 ? t("community_hub.publish.system_prompt.public_description")
                 : t("community_hub.publish.system_prompt.private_description")}
@@ -217,10 +217,10 @@ export default function SystemPrompts({ entity }) {
 
         <div className="w-1/2 p-6 pt-0 space-y-4">
           <div>
-            <label className="block text-sm font-semibold text-white mb-1">
+            <label className="block text-sm font-semibold text-foreground mb-1">
               {t("community_hub.publish.system_prompt.prompt_label")}
             </label>
-            <div className="text-xs text-white/60 mb-2">
+            <div className="text-xs text-foreground/60 mb-2">
               {t("community_hub.publish.system_prompt.prompt_description")}
             </div>
             <textarea
@@ -231,7 +231,7 @@ export default function SystemPrompts({ entity }) {
               placeholder={t(
                 "community_hub.publish.system_prompt.prompt_placeholder"
               )}
-              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-white text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[300px] placeholder:text-theme-text-placeholder"
+              className="border-none w-full bg-theme-bg-secondary rounded-sm p-2 text-foreground text-sm focus:outline-primary-button active:outline-primary-button outline-none min-h-[300px] placeholder:text-theme-text-placeholder"
             />
           </div>
 

--- a/frontend/src/components/CommunityHub/PublishEntityModal/index.jsx
+++ b/frontend/src/components/CommunityHub/PublishEntityModal/index.jsx
@@ -39,7 +39,7 @@ export default function PublishEntityModal({
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={18} weight="bold" className="text-white" />
+            <X size={18} weight="bold" className="text-foreground" />
           </button>
         </div>
         {renderEntityForm()}

--- a/frontend/src/components/CommunityHub/UnauthenticatedHubModal/index.jsx
+++ b/frontend/src/components/CommunityHub/UnauthenticatedHubModal/index.jsx
@@ -17,13 +17,13 @@ export default function UnauthenticatedHubModal({ show, onClose }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={18} weight="bold" className="text-white" />
+            <X size={18} weight="bold" className="text-foreground" />
           </button>
           <div className="flex flex-col items-center justify-center gap-y-4">
-            <h3 className="text-lg font-semibold text-white">
+            <h3 className="text-lg font-semibold text-foreground">
               {t("community_hub.publish.generic.unauthenticated.title")}
             </h3>
-            <p className="text-lg text-white text-center max-w-[300px]">
+            <p className="text-lg text-foreground text-center max-w-[300px]">
               {t("community_hub.publish.generic.unauthenticated.description")}
             </p>
             <Link

--- a/frontend/src/components/DataConnectorOption/index.jsx
+++ b/frontend/src/components/DataConnectorOption/index.jsx
@@ -4,18 +4,18 @@ export default function DataConnectorOption({ slug }) {
 
   return (
     <a href={path}>
-      <label className="transition-all duration-300 inline-flex flex-col h-full w-60 cursor-pointer items-start justify-between rounded-2xl bg-preference-gradient border-2 border-transparent shadow-md px-5 py-4 text-white hover:bg-selected-preference-gradient hover:border-white/60 peer-checked:border-white peer-checked:border-opacity-90 peer-checked:bg-selected-preference-gradient">
+      <label className="transition-all duration-300 inline-flex flex-col h-full w-60 cursor-pointer items-start justify-between rounded-2xl bg-preference-gradient border-2 border-transparent shadow-md px-5 py-4 text-foreground hover:bg-selected-preference-gradient hover:border-border/60 peer-checked:border-border peer-checked:border-opacity-90 peer-checked:bg-selected-preference-gradient">
         <div className="flex items-center">
           <img src={image} alt={name} className="h-10 w-10 rounded" />
           <div className="ml-4 text-sm font-semibold">{name}</div>
         </div>
-        <div className="mt-2 text-xs font-base text-white tracking-wide">
+        <div className="mt-2 text-xs font-base text-foreground tracking-wide">
           {description}
         </div>
         <a
           href={link}
           target="_blank"
-          className="mt-2 text-xs text-white font-medium underline"
+          className="mt-2 text-xs text-foreground font-medium underline"
         >
           {link}
         </a>

--- a/frontend/src/components/EditingChatBubble/index.jsx
+++ b/frontend/src/components/EditingChatBubble/index.jsx
@@ -19,7 +19,7 @@ export default function EditingChatBubble({
   return (
     <div>
       <p
-        className={`text-xs text-white light:text-foreground ${isUser ? "text-right" : ""}`}
+        className={`text-xs text-foreground light:text-foreground ${isUser ? "text-right" : ""}`}
       >
         {isUser
           ? t("common.user")
@@ -31,7 +31,7 @@ export default function EditingChatBubble({
         }`}
       >
         <button
-          className={`transition-all duration-300 absolute z-10 text-white rounded-full hover:bg-neutral-700 light:hover:invert hover:border-white border-transparent border shadow-lg ${
+          className={`transition-all duration-300 absolute z-10 text-foreground rounded-full hover:bg-neutral-700 light:hover:invert hover:border-border border-transparent border shadow-lg ${
             isUser ? "right-0 mr-2" : "ml-2"
           }`}
           style={{ top: "6px", [isUser ? "right" : "left"]: "290px" }}
@@ -41,7 +41,7 @@ export default function EditingChatBubble({
         </button>
         <div
           className={`p-2 max-w-full md:w-[290px] text-foreground rounded-sm ${
-            isUser ? "bg-[#41444C] text-white" : "bg-[#2E3036] text-white"
+            isUser ? "bg-[#41444C] text-foreground" : "bg-[#2E3036] text-foreground"
           }
         }`}
           onDoubleClick={() => setIsEditing(true)}
@@ -55,8 +55,8 @@ export default function EditingChatBubble({
                 setIsEditing(false);
               }}
               autoFocus
-              className={`w-full light:text-white ${
-                isUser ? "bg-[#41444C] text-white" : "bg-[#2E3036] text-white"
+              className={`w-full light:text-foreground ${
+                isUser ? "bg-[#41444C] text-foreground" : "bg-[#2E3036] text-foreground"
               }`}
             />
           ) : (

--- a/frontend/src/components/EmbeddingSelection/AzureAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/AzureAiOptions/index.jsx
@@ -3,13 +3,13 @@ export default function AzureAiOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Azure Service Endpoint
           </label>
           <input
             type="url"
             name="AzureOpenAiEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="https://my-azure.openai.azure.com"
             defaultValue={settings?.AzureOpenAiEndpoint}
             required={true}
@@ -19,13 +19,13 @@ export default function AzureAiOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="AzureOpenAiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Azure OpenAI API Key"
             defaultValue={settings?.AzureOpenAiKey ? "*".repeat(20) : ""}
             required={true}
@@ -35,13 +35,13 @@ export default function AzureAiOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Embedding Deployment Name
           </label>
           <input
             type="text"
             name="AzureOpenAiEmbeddingModelPref"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Azure OpenAI embedding model deployment name"
             defaultValue={settings?.AzureOpenAiEmbeddingModelPref}
             required={true}

--- a/frontend/src/components/EmbeddingSelection/CohereOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/CohereOptions/index.jsx
@@ -3,13 +3,13 @@ export default function CohereEmbeddingOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="CohereApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Cohere API Key"
             defaultValue={settings?.CohereApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -18,13 +18,13 @@ export default function CohereEmbeddingOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Model Preference
           </label>
           <select
             name="EmbeddingModelPref"
             required={true}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
           >
             <optgroup label="Available embedding models">
               {[

--- a/frontend/src/components/EmbeddingSelection/EmbedderItem/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/EmbedderItem/index.jsx
@@ -28,7 +28,7 @@ export default function EmbedderItem({
           className="w-10 h-10 rounded-md"
         />
         <div className="flex flex-col">
-          <div className="text-sm font-semibold text-white">{name}</div>
+          <div className="text-sm font-semibold text-foreground">{name}</div>
           <div className="mt-1 text-xs text-description">{description}</div>
         </div>
       </div>

--- a/frontend/src/components/EmbeddingSelection/GeminiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/GeminiOptions/index.jsx
@@ -18,13 +18,13 @@ export default function GeminiOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="GeminiEmbeddingApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Gemini API Key"
             defaultValue={settings?.GeminiEmbeddingApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -33,13 +33,13 @@ export default function GeminiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Model Preference
           </label>
           <select
             name="EmbeddingModelPref"
             required={true}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
           >
             <optgroup label="Available embedding models">
               {DEFAULT_MODELS.map((model) => {

--- a/frontend/src/components/EmbeddingSelection/GenericOpenAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/GenericOpenAiOptions/index.jsx
@@ -7,13 +7,13 @@ export default function GenericOpenAiEmbeddingOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5 flex-wrap">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Base URL
           </label>
           <input
             type="url"
             name="EmbeddingBasePath"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="https://api.openai.com/v1"
             defaultValue={settings?.EmbeddingBasePath}
             required={true}
@@ -22,13 +22,13 @@ export default function GenericOpenAiEmbeddingOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Embedding Model
           </label>
           <input
             type="text"
             name="EmbeddingModelPref"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="text-embedding-ada-002"
             defaultValue={settings?.EmbeddingModelPref}
             required={true}
@@ -37,13 +37,13 @@ export default function GenericOpenAiEmbeddingOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Max embedding chunk length
           </label>
           <input
             type="number"
             name="EmbeddingModelMaxChunkLength"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="8192"
             min={1}
             onScroll={(e) => e.target.blur()}
@@ -56,14 +56,14 @@ export default function GenericOpenAiEmbeddingOptions({ settings }) {
       <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
           <div className="flex flex-col gap-y-1 mb-4">
-            <label className="text-white text-sm font-semibold flex items-center gap-x-2">
+            <label className="text-foreground text-sm font-semibold flex items-center gap-x-2">
               API Key <p className="!text-xs !italic !font-thin">optional</p>
             </label>
           </div>
           <input
             type="password"
             name="GenericOpenAiEmbeddingApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="sk-mysecretkey"
             defaultValue={
               settings?.GenericOpenAiEmbeddingApiKey ? "*".repeat(20) : ""
@@ -93,7 +93,7 @@ export default function GenericOpenAiEmbeddingOptions({ settings }) {
         <div className="w-full flex items-start gap-4">
           <div className="flex flex-col w-60">
             <div className="flex flex-col gap-y-1 mb-4">
-              <label className="text-white text-sm font-semibold flex items-center gap-x-2">
+              <label className="text-foreground text-sm font-semibold flex items-center gap-x-2">
                 Max concurrent Chunks
                 <p className="!text-xs !italic !font-thin">optional</p>
               </label>
@@ -101,7 +101,7 @@ export default function GenericOpenAiEmbeddingOptions({ settings }) {
             <input
               type="number"
               name="GenericOpenAiEmbeddingMaxConcurrentChunks"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="500"
               min={1}
               onScroll={(e) => e.target.blur()}

--- a/frontend/src/components/EmbeddingSelection/LMStudioOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/LMStudioOptions/index.jsx
@@ -32,13 +32,13 @@ export default function LMStudioEmbeddingOptions({ settings }) {
       <div className="w-full flex items-start gap-[36px] mt-1.5">
         <LMStudioModelSelection settings={settings} basePath={basePath.value} />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             Max Embedding Chunk Length
           </label>
           <input
             type="number"
             name="EmbeddingModelMaxChunkLength"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="8192"
             min={1}
             value={maxChunkLength}
@@ -47,7 +47,7 @@ export default function LMStudioEmbeddingOptions({ settings }) {
             required={true}
             autoComplete="off"
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Maximum length of text chunks for embedding.
           </p>
         </div>
@@ -73,7 +73,7 @@ export default function LMStudioEmbeddingOptions({ settings }) {
         <div className="w-full flex items-start gap-4">
           <div className="flex flex-col w-60">
             <div className="flex justify-between items-center mb-2">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 LM Studio Base URL
               </label>
               {loading ? (
@@ -83,7 +83,7 @@ export default function LMStudioEmbeddingOptions({ settings }) {
                   {!basePathValue.value && (
                     <button
                       onClick={handleAutoDetectClick}
-                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                     >
                       Auto-Detect
                     </button>
@@ -94,7 +94,7 @@ export default function LMStudioEmbeddingOptions({ settings }) {
             <input
               type="url"
               name="EmbeddingBasePath"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="http://localhost:1234/v1"
               value={basePathValue.value}
               required={true}
@@ -103,7 +103,7 @@ export default function LMStudioEmbeddingOptions({ settings }) {
               onChange={basePath.onChange}
               onBlur={basePath.onBlur}
             />
-            <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
               Enter the URL where LM Studio is running.
             </p>
           </div>
@@ -144,13 +144,13 @@ function LMStudioModelSelection({ settings, basePath = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           LM Studio Embedding Model
         </label>
         <select
           name="EmbeddingModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {!!basePath
@@ -158,7 +158,7 @@ function LMStudioModelSelection({ settings, basePath = null }) {
               : "Enter LM Studio URL first"}
           </option>
         </select>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
           Select the LM Studio model for embeddings. Models will load after
           entering a valid LM Studio URL.
         </p>
@@ -168,13 +168,13 @@ function LMStudioModelSelection({ settings, basePath = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         LM Studio Embedding Model
       </label>
       <select
         name="EmbeddingModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">
@@ -192,7 +192,7 @@ function LMStudioModelSelection({ settings, basePath = null }) {
           </optgroup>
         )}
       </select>
-      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+      <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
         Choose the LM Studio model you want to use for generating embeddings.
       </p>
     </div>

--- a/frontend/src/components/EmbeddingSelection/LiteLLMOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/LiteLLMOptions/index.jsx
@@ -13,13 +13,13 @@ export default function LiteLLMOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Base URL
           </label>
           <input
             type="url"
             name="LiteLLMBasePath"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="http://127.0.0.1:4000"
             defaultValue={settings?.LiteLLMBasePath}
             required={true}
@@ -35,13 +35,13 @@ export default function LiteLLMOptions({ settings }) {
           apiKey={apiKey}
         />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Max embedding chunk length
           </label>
           <input
             type="number"
             name="EmbeddingModelMaxChunkLength"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="8192"
             min={1}
             onScroll={(e) => e.target.blur()}
@@ -54,14 +54,14 @@ export default function LiteLLMOptions({ settings }) {
       <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
           <div className="flex flex-col gap-y-1 mb-4">
-            <label className="text-white text-sm font-semibold flex items-center gap-x-2">
+            <label className="text-foreground text-sm font-semibold flex items-center gap-x-2">
               API Key <p className="!text-xs !italic !font-thin">optional</p>
             </label>
           </div>
           <input
             type="password"
             name="LiteLLMAPIKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="sk-mysecretkey"
             defaultValue={settings?.LiteLLMAPIKey ? "*".repeat(20) : ""}
             autoComplete="off"
@@ -101,13 +101,13 @@ function LiteLLMModelSelection({ settings, basePath = null, apiKey = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Embedding Model Selection
         </label>
         <select
           name="EmbeddingModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {basePath?.includes("/v1")
@@ -122,7 +122,7 @@ function LiteLLMModelSelection({ settings, basePath = null, apiKey = null }) {
   return (
     <div className="flex flex-col w-60">
       <div className="flex items-center">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Embedding Model Selection
         </label>
         <EmbeddingModelTooltip />
@@ -130,7 +130,7 @@ function LiteLLMModelSelection({ settings, basePath = null, apiKey = null }) {
       <select
         name="EmbeddingModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">

--- a/frontend/src/components/EmbeddingSelection/LocalAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/LocalAiOptions/index.jsx
@@ -30,13 +30,13 @@ export default function LocalAiOptions({ settings }) {
           basePath={basePath.value}
         />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             Max embedding chunk length
           </label>
           <input
             type="number"
             name="EmbeddingModelMaxChunkLength"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="1000"
             min={1}
             onScroll={(e) => e.target.blur()}
@@ -47,7 +47,7 @@ export default function LocalAiOptions({ settings }) {
         </div>
         <div className="flex flex-col w-60">
           <div className="flex flex-col gap-y-1 mb-2">
-            <label className="text-white text-sm font-semibold flex items-center gap-x-2">
+            <label className="text-foreground text-sm font-semibold flex items-center gap-x-2">
               Local AI API Key{" "}
               <p className="!text-xs !italic !font-thin">optional</p>
             </label>
@@ -55,7 +55,7 @@ export default function LocalAiOptions({ settings }) {
           <input
             type="password"
             name="LocalAiApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="sk-mysecretkey"
             defaultValue={settings?.LocalAiApiKey ? "*".repeat(20) : ""}
             autoComplete="off"
@@ -85,7 +85,7 @@ export default function LocalAiOptions({ settings }) {
         <div className="w-full flex items-center gap-4">
           <div className="flex flex-col w-60">
             <div className="flex justify-between items-center mb-2">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 LocalAI Base URL
               </label>
               {loading ? (
@@ -95,7 +95,7 @@ export default function LocalAiOptions({ settings }) {
                   {!basePathValue.value && (
                     <button
                       onClick={handleAutoDetectClick}
-                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                     >
                       Auto-Detect
                     </button>
@@ -106,7 +106,7 @@ export default function LocalAiOptions({ settings }) {
             <input
               type="url"
               name="EmbeddingBasePath"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="http://localhost:8080/v1"
               value={basePathValue.value}
               required={true}
@@ -148,13 +148,13 @@ function LocalAIModelSelection({ settings, apiKey = null, basePath = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           Embedding Model Name
         </label>
         <select
           name="EmbeddingModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {basePath?.includes("/v1")
@@ -168,13 +168,13 @@ function LocalAIModelSelection({ settings, apiKey = null, basePath = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         Embedding Model Name
       </label>
       <select
         name="EmbeddingModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">

--- a/frontend/src/components/EmbeddingSelection/MistralAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/MistralAiOptions/index.jsx
@@ -3,13 +3,13 @@ export default function MistralAiOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="MistralApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Mistral AI API Key"
             defaultValue={settings?.MistralApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -18,14 +18,14 @@ export default function MistralAiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Model Preference
           </label>
           <select
             name="EmbeddingModelPref"
             required={true}
             defaultValue={settings?.EmbeddingModelPref}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
           >
             <optgroup label="Available embedding models">
               {["mistral-embed"].map((model) => {

--- a/frontend/src/components/EmbeddingSelection/NativeEmbeddingOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/NativeEmbeddingOptions/index.jsx
@@ -38,14 +38,14 @@ export default function NativeEmbeddingOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex flex-col mt-1.5">
         <div className="flex flex-col w-96">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Model Preference
           </label>
           <select
             name="EmbeddingModelPref"
             required={true}
             defaultValue={selectedModel}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-theme-text-primary text-sm rounded-sm block w-60 p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-theme-text-primary text-sm rounded-sm block w-60 p-2.5"
             onChange={(e) => setSelectedModel(e.target.value)}
           >
             {loading ? (

--- a/frontend/src/components/EmbeddingSelection/OllamaOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/OllamaOptions/index.jsx
@@ -35,13 +35,13 @@ export default function OllamaEmbeddingOptions({ settings }) {
           basePath={basePath.value}
         />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             Max Embedding Chunk Length
           </label>
           <input
             type="number"
             name="EmbeddingModelMaxChunkLength"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="8192"
             min={1}
             value={maxChunkLength}
@@ -50,7 +50,7 @@ export default function OllamaEmbeddingOptions({ settings }) {
             required={true}
             autoComplete="off"
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Maximum length of text chunks for embedding.
           </p>
         </div>
@@ -76,7 +76,7 @@ export default function OllamaEmbeddingOptions({ settings }) {
         <div className="w-full flex items-start gap-4">
           <div className="flex flex-col w-60">
             <div className="flex justify-between items-center mb-2">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 Ollama Base URL
               </label>
               {loading ? (
@@ -86,7 +86,7 @@ export default function OllamaEmbeddingOptions({ settings }) {
                   {!basePathValue.value && (
                     <button
                       onClick={handleAutoDetectClick}
-                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                     >
                       Auto-Detect
                     </button>
@@ -97,7 +97,7 @@ export default function OllamaEmbeddingOptions({ settings }) {
             <input
               type="url"
               name="EmbeddingBasePath"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="http://127.0.0.1:11434"
               value={basePathValue.value}
               required={true}
@@ -106,7 +106,7 @@ export default function OllamaEmbeddingOptions({ settings }) {
               onChange={basePath.onChange}
               onBlur={basePath.onBlur}
             />
-            <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
               Enter the URL where Ollama is running.
             </p>
           </div>
@@ -143,13 +143,13 @@ function OllamaEmbeddingModelSelection({ settings, basePath = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           Ollama Embedding Model
         </label>
         <select
           name="EmbeddingModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {!!basePath
@@ -157,7 +157,7 @@ function OllamaEmbeddingModelSelection({ settings, basePath = null }) {
               : "Enter Ollama URL first"}
           </option>
         </select>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
           Select the Ollama model for embeddings. Models will load after
           entering a valid Ollama URL.
         </p>
@@ -167,13 +167,13 @@ function OllamaEmbeddingModelSelection({ settings, basePath = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         Ollama Embedding Model
       </label>
       <select
         name="EmbeddingModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">
@@ -191,7 +191,7 @@ function OllamaEmbeddingModelSelection({ settings, basePath = null }) {
           </optgroup>
         )}
       </select>
-      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+      <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
         Choose the Ollama model you want to use for generating embeddings.
       </p>
     </div>

--- a/frontend/src/components/EmbeddingSelection/OpenAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/OpenAiOptions/index.jsx
@@ -3,13 +3,13 @@ export default function OpenAiOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="OpenAiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="OpenAI API Key"
             defaultValue={settings?.OpenAiKey ? "*".repeat(20) : ""}
             required={true}
@@ -18,13 +18,13 @@ export default function OpenAiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Model Preference
           </label>
           <select
             name="EmbeddingModelPref"
             required={true}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
           >
             <optgroup label="Available embedding models">
               {[

--- a/frontend/src/components/EmbeddingSelection/VoyageAiOptions/index.jsx
+++ b/frontend/src/components/EmbeddingSelection/VoyageAiOptions/index.jsx
@@ -3,13 +3,13 @@ export default function VoyageAiOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="VoyageAiApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Voyage AI API Key"
             defaultValue={settings?.VoyageAiApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -18,14 +18,14 @@ export default function VoyageAiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Model Preference
           </label>
           <select
             name="EmbeddingModelPref"
             required={true}
             defaultValue={settings?.EmbeddingModelPref}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
           >
             <optgroup label="Available embedding models">
               {[

--- a/frontend/src/components/KeyboardShortcutsHelp/index.jsx
+++ b/frontend/src/components/KeyboardShortcutsHelp/index.jsx
@@ -27,12 +27,12 @@ export default function KeyboardShortcutsHelp() {
     <div className="fixed inset-0 z-50 overflow-auto bg-black bg-opacity-50 flex items-center justify-center">
       <div className="relative bg-theme-bg-secondary rounded-lg p-6 max-w-2xl w-full mx-4">
         <div className="flex justify-between items-center mb-6">
-          <h2 className="text-xl font-semibold text-white">
+          <h2 className="text-xl font-semibold text-foreground">
             {t("keyboard-shortcuts.title")}
           </h2>
           <button
             onClick={() => setIsOpen(false)}
-            className="text-white hover:text-gray-300"
+            className="text-foreground hover:text-foreground"
             aria-label="Close"
           >
             <X size={24} />
@@ -45,10 +45,10 @@ export default function KeyboardShortcutsHelp() {
               key={key}
               className="flex items-center justify-between p-3 bg-theme-bg-hover rounded-lg"
             >
-              <span className="text-white">
+              <span className="text-foreground">
                 {t(`keyboard-shortcuts.shortcuts.${shortcut.translationKey}`)}
               </span>
-              <kbd className="px-2 py-1 bg-theme-bg-secondary text-white rounded border border-gray-600">
+              <kbd className="px-2 py-1 bg-theme-bg-secondary text-foreground rounded border border-border">
                 {isMac ? key : key.replace("⌘", "Ctrl")}
               </kbd>
             </div>

--- a/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AnthropicAiOptions/index.jsx
@@ -11,13 +11,13 @@ export default function AnthropicAiOptions({ settings }) {
     <div className="w-full flex flex-col">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Anthropic API Key
           </label>
           <input
             type="password"
             name="AnthropicApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Anthropic Claude-2 API Key"
             defaultValue={settings?.AnthropicApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -98,13 +98,13 @@ function AnthropicModelSelection({ apiKey, settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="AnthropicModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -116,13 +116,13 @@ function AnthropicModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="AnthropicModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {models.map((model) => (
           <option

--- a/frontend/src/components/LLMSelection/ApiPieOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/ApiPieOptions/index.jsx
@@ -6,13 +6,13 @@ export default function ApiPieLLMOptions({ settings }) {
     <div className="flex flex-col gap-y-4 mt-1.5">
       <div className="flex gap-[36px]">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             APIpie API Key
           </label>
           <input
             type="password"
             name="ApipieLLMApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="APIpie API Key"
             defaultValue={settings?.ApipieLLMApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -54,13 +54,13 @@ function APIPieModelSelection({ settings }) {
   if (loading || Object.keys(groupedModels).length === 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="ApipieLLMModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -72,13 +72,13 @@ function APIPieModelSelection({ settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="ApipieLLMModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
       >
         {Object.keys(groupedModels)
           .sort()

--- a/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
@@ -11,7 +11,7 @@ export default function AwsBedrockLLMOptions({ settings }) {
   return (
     <div className="w-full flex flex-col">
       {!settings?.credentialsOnly && (
-        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
           <div className="gap-x-2 flex items-center">
             <Info size={40} />
             <p className="text-base">
@@ -49,7 +49,7 @@ export default function AwsBedrockLLMOptions({ settings }) {
           value={connectionMethod}
           required={true}
           onChange={(e) => setConnectionMethod(e.target.value)}
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit p-2.5"
         >
           <option value="iam">IAM (Explicit Credentials)</option>
           <option value="sessionToken">
@@ -63,13 +63,13 @@ export default function AwsBedrockLLMOptions({ settings }) {
         {["iam", "sessionToken"].includes(connectionMethod) && (
           <>
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-3">
+              <label className="text-foreground text-sm font-semibold block mb-3">
                 AWS Bedrock IAM Access ID
               </label>
               <input
                 type="password"
                 name="AwsBedrockLLMAccessKeyId"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="AWS Bedrock IAM User Access ID"
                 defaultValue={
                   settings?.AwsBedrockLLMAccessKeyId ? "*".repeat(20) : ""
@@ -80,13 +80,13 @@ export default function AwsBedrockLLMOptions({ settings }) {
               />
             </div>
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-3">
+              <label className="text-foreground text-sm font-semibold block mb-3">
                 AWS Bedrock IAM Access Key
               </label>
               <input
                 type="password"
                 name="AwsBedrockLLMAccessKey"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="AWS Bedrock IAM User Access Key"
                 defaultValue={
                   settings?.AwsBedrockLLMAccessKey ? "*".repeat(20) : ""
@@ -118,14 +118,14 @@ export default function AwsBedrockLLMOptions({ settings }) {
           </div>
         )}
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             AWS region
           </label>
           <select
             name="AwsBedrockLLMRegion"
             defaultValue={settings?.AwsBedrockLLMRegion || "us-west-2"}
             required={true}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           >
             {AWS_REGIONS.map((region) => {
               return (
@@ -142,13 +142,13 @@ export default function AwsBedrockLLMOptions({ settings }) {
         {!settings?.credentialsOnly && (
           <>
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-3">
+              <label className="text-foreground text-sm font-semibold block mb-3">
                 Model ID
               </label>
               <input
                 type="text"
                 name="AwsBedrockLLMModel"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="Model id from AWS eg: meta.llama3.1-v0.1"
                 defaultValue={settings?.AwsBedrockLLMModel}
                 required={true}
@@ -157,13 +157,13 @@ export default function AwsBedrockLLMOptions({ settings }) {
               />
             </div>
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-3">
+              <label className="text-foreground text-sm font-semibold block mb-3">
                 Model context window
               </label>
               <input
                 type="number"
                 name="AwsBedrockLLMTokenLimit"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="Content window limit (eg: 8192)"
                 min={1}
                 onScroll={(e) => e.target.blur()}
@@ -173,13 +173,13 @@ export default function AwsBedrockLLMOptions({ settings }) {
               />
             </div>
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-3">
+              <label className="text-foreground text-sm font-semibold block mb-3">
                 Model max output tokens
               </label>
               <input
                 type="number"
                 name="AwsBedrockLLMMaxOutputTokens"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="Max output tokens (eg: 4096)"
                 min={1}
                 onScroll={(e) => e.target.blur()}

--- a/frontend/src/components/LLMSelection/AzureAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AzureAiOptions/index.jsx
@@ -7,13 +7,13 @@ export default function AzureAiOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7 mt-1.5">
       <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             {t("llm.providers.azure_openai.azure_service_endpoint")}
           </label>
           <input
             type="url"
             name="AzureOpenAiEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="https://my-azure.openai.azure.com"
             defaultValue={settings?.AzureOpenAiEndpoint}
             required={true}
@@ -23,13 +23,13 @@ export default function AzureAiOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             {t("llm.providers.azure_openai.api_key")}
           </label>
           <input
             type="password"
             name="AzureOpenAiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Azure OpenAI API Key"
             defaultValue={settings?.AzureOpenAiKey ? "*".repeat(20) : ""}
             required={true}
@@ -39,13 +39,13 @@ export default function AzureAiOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             {t("llm.providers.azure_openai.chat_deployment_name")}
           </label>
           <input
             type="text"
             name="AzureOpenAiModelPref"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Azure OpenAI chat model deployment name"
             defaultValue={settings?.AzureOpenAiModelPref}
             required={true}
@@ -57,13 +57,13 @@ export default function AzureAiOptions({ settings }) {
 
       <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             {t("llm.providers.azure_openai.chat_model_token_limit")}
           </label>
           <select
             name="AzureOpenAiTokenLimit"
             defaultValue={settings?.AzureOpenAiTokenLimit || 4096}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             required={true}
           >
             <option value={4096}>4,096 (gpt-3.5-turbo)</option>
@@ -79,13 +79,13 @@ export default function AzureAiOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             {t("llm.providers.azure_openai.model_type")}
           </label>
           <select
             name="AzureOpenAiModelType"
             defaultValue={settings?.AzureOpenAiModelType || "default"}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             required={true}
           >
             <option value="default">

--- a/frontend/src/components/LLMSelection/CohereAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/CohereAiOptions/index.jsx
@@ -3,13 +3,13 @@ export default function CohereAiOptions({ settings }) {
     <div className="w-full flex flex-col">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Cohere API Key
           </label>
           <input
             type="password"
             name="CohereApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Cohere API Key"
             defaultValue={settings?.CohereApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -18,14 +18,14 @@ export default function CohereAiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Chat Model Selection
           </label>
           <select
             name="CohereModelPref"
             defaultValue={settings?.CohereModelPref || "command-r"}
             required={true}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
           >
             {[
               "command-r",

--- a/frontend/src/components/LLMSelection/DPAISOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/DPAISOptions/index.jsx
@@ -32,13 +32,13 @@ export default function DellProAIStudioOptions({
               basePath={basePath.value}
             />
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-2">
+              <label className="text-foreground text-sm font-semibold block mb-2">
                 Token context window
               </label>
               <input
                 type="number"
                 name="DellProAiStudioTokenLimit"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="4096"
                 min={1}
                 onScroll={(e) => e.target.blur()}
@@ -70,7 +70,7 @@ export default function DellProAIStudioOptions({
         <div className="w-full flex items-center gap-4">
           <div className="flex flex-col w-fit">
             <div className="flex justify-between items-center mb-2 gap-x-2">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 Dell Pro AI Studio Base URL
               </label>
               {loading ? (
@@ -80,7 +80,7 @@ export default function DellProAIStudioOptions({
                   {!basePathValue.value && (
                     <button
                       onClick={handleAutoDetectClick}
-                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                     >
                       Auto-Detect
                     </button>
@@ -91,7 +91,7 @@ export default function DellProAIStudioOptions({
             <input
               type="url"
               name="DellProAiStudioBasePath"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="http://localhost:8553/v1"
               value={basePathValue.value}
               required={true}
@@ -134,13 +134,13 @@ function DellProAiStudioModelSelection({ settings, basePath = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           Chat Model Selection
         </label>
         <select
           name="DellProAiStudioModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -152,13 +152,13 @@ function DellProAiStudioModelSelection({ settings, basePath = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         Chat Model Selection
       </label>
       <select
         name="DellProAiStudioModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">

--- a/frontend/src/components/LLMSelection/DeepSeekOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/DeepSeekOptions/index.jsx
@@ -10,13 +10,13 @@ export default function DeepSeekOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           API Key
         </label>
         <input
           type="password"
           name="DeepSeekApiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="DeepSeek API Key"
           defaultValue={settings?.DeepSeekApiKey ? "*".repeat(20) : ""}
           required={true}
@@ -59,13 +59,13 @@ function DeepSeekModelSelection({ apiKey, settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="DeepSeekModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -77,13 +77,13 @@ function DeepSeekModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="DeepSeekModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {models.map((model) => (
           <option

--- a/frontend/src/components/LLMSelection/FireworksAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/FireworksAiOptions/index.jsx
@@ -5,13 +5,13 @@ export default function FireworksAiOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Fireworks AI API Key
         </label>
         <input
           type="password"
           name="FireworksAiLLMApiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="Fireworks AI API Key"
           defaultValue={settings?.FireworksAiLLMApiKey ? "*".repeat(20) : ""}
           required={true}
@@ -52,13 +52,13 @@ function FireworksAiModelSelection({ settings }) {
   if (loading || Object.keys(groupedModels).length === 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="FireworksAiLLMModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -70,13 +70,13 @@ function FireworksAiModelSelection({ settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="FireworksAiLLMModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {Object.keys(groupedModels)
           .sort()

--- a/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/GeminiLLMOptions/index.jsx
@@ -9,13 +9,13 @@ export default function GeminiLLMOptions({ settings }) {
     <div className="w-full flex flex-col">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Google AI API Key
           </label>
           <input
             type="password"
             name="GeminiLLMApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Google Gemini API Key"
             defaultValue={settings?.GeminiLLMApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -35,7 +35,7 @@ export default function GeminiLLMOptions({ settings }) {
             We are not using the generativeAPI endpoint and therefore cannot set the safety threshold.
 
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-3">
+              <label className="text-foreground text-sm font-semibold block mb-3">
                 Safety Setting
               </label>
               <select
@@ -44,7 +44,7 @@ export default function GeminiLLMOptions({ settings }) {
                   settings?.GeminiSafetySetting || "BLOCK_MEDIUM_AND_ABOVE"
                 }
                 required={true}
-                className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
               >
                 <option value="BLOCK_NONE">None</option>
                 <option value="BLOCK_ONLY_HIGH">Block few</option>
@@ -87,13 +87,13 @@ function GeminiModelSelection({ apiKey, settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="GeminiLLMModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -105,13 +105,13 @@ function GeminiModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="GeminiLLMModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {Object.keys(groupedModels)
           .sort((a, b) => {

--- a/frontend/src/components/LLMSelection/GenericOpenAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/GenericOpenAiOptions/index.jsx
@@ -3,13 +3,13 @@ export default function GenericOpenAiOptions({ settings }) {
     <div className="flex flex-col gap-y-7">
       <div className="flex gap-[36px] mt-1.5 flex-wrap">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Base URL
           </label>
           <input
             type="url"
             name="GenericOpenAiBasePath"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="eg: https://proxy.openai.com"
             defaultValue={settings?.GenericOpenAiBasePath}
             required={true}
@@ -18,13 +18,13 @@ export default function GenericOpenAiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="GenericOpenAiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Generic service API Key"
             defaultValue={settings?.GenericOpenAiKey ? "*".repeat(20) : ""}
             required={false}
@@ -33,13 +33,13 @@ export default function GenericOpenAiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Chat Model Name
           </label>
           <input
             type="text"
             name="GenericOpenAiModelPref"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Model id used for chat requests"
             defaultValue={settings?.GenericOpenAiModelPref}
             required={true}
@@ -49,13 +49,13 @@ export default function GenericOpenAiOptions({ settings }) {
       </div>
       <div className="flex gap-[36px] flex-wrap">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Token context window
           </label>
           <input
             type="number"
             name="GenericOpenAiTokenLimit"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Content window limit (eg: 4096)"
             min={1}
             onScroll={(e) => e.target.blur()}
@@ -65,13 +65,13 @@ export default function GenericOpenAiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Max Tokens
           </label>
           <input
             type="number"
             name="GenericOpenAiMaxTokens"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Max tokens per request (eg: 1024)"
             min={1}
             defaultValue={settings?.GenericOpenAiMaxTokens || 1024}

--- a/frontend/src/components/LLMSelection/GroqAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/GroqAiOptions/index.jsx
@@ -8,13 +8,13 @@ export default function GroqAiOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Groq API Key
         </label>
         <input
           type="password"
           name="GroqApiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="Groq API Key"
           defaultValue={settings?.GroqApiKey ? "*".repeat(20) : ""}
           required={true}
@@ -61,19 +61,19 @@ function GroqAIModelSelection({ apiKey, settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="GroqModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             --loading available models--
           </option>
         </select>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
           Enter a valid API key to view all available models for your account.
         </p>
       </div>
@@ -82,13 +82,13 @@ function GroqAIModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="GroqModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Available models">
@@ -106,7 +106,7 @@ function GroqAIModelSelection({ apiKey, settings }) {
           </optgroup>
         )}
       </select>
-      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+      <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
         Select the GroqAI model you want to use for your conversations.
       </p>
     </div>

--- a/frontend/src/components/LLMSelection/HuggingFaceOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/HuggingFaceOptions/index.jsx
@@ -3,13 +3,13 @@ export default function HuggingFaceOptions({ settings }) {
     <div className="w-full flex flex-col">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             HuggingFace Inference Endpoint
           </label>
           <input
             type="url"
             name="HuggingFaceLLMEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="https://example.endpoints.huggingface.cloud"
             defaultValue={settings?.HuggingFaceLLMEndpoint}
             required={true}
@@ -18,13 +18,13 @@ export default function HuggingFaceOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             HuggingFace Access Token
           </label>
           <input
             type="password"
             name="HuggingFaceLLMAccessToken"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="HuggingFace Access Token"
             defaultValue={
               settings?.HuggingFaceLLMAccessToken ? "*".repeat(20) : ""
@@ -35,13 +35,13 @@ export default function HuggingFaceOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Model Token Limit
           </label>
           <input
             type="number"
             name="HuggingFaceLLMTokenLimit"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="4096"
             min={1}
             onScroll={(e) => e.target.blur()}

--- a/frontend/src/components/LLMSelection/KoboldCPPOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/KoboldCPPOptions/index.jsx
@@ -42,13 +42,13 @@ export default function KoboldCPPOptions({ settings }) {
           basePath={basePath.value}
         />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             Token context window
           </label>
           <input
             type="number"
             name="KoboldCPPTokenLimit"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="4096"
             min={1}
             value={tokenLimit}
@@ -57,18 +57,18 @@ export default function KoboldCPPOptions({ settings }) {
             required={true}
             autoComplete="off"
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Maximum number of tokens for context and response.
           </p>
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             Max response tokens
           </label>
           <input
             type="number"
             name="KoboldCPPMaxTokens"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="2048"
             min={1}
             value={maxTokens}
@@ -77,7 +77,7 @@ export default function KoboldCPPOptions({ settings }) {
             required={true}
             autoComplete="off"
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Maximum number of tokens for the response.
           </p>
         </div>
@@ -103,7 +103,7 @@ export default function KoboldCPPOptions({ settings }) {
         <div className="w-full flex items-start gap-4">
           <div className="flex flex-col w-60">
             <div className="flex justify-between items-center mb-2">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 KoboldCPP Base URL
               </label>
               {loading ? (
@@ -113,7 +113,7 @@ export default function KoboldCPPOptions({ settings }) {
                   {!basePathValue.value && (
                     <button
                       onClick={handleAutoDetectClick}
-                      className="border-none bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      className="border-none bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                     >
                       Auto-Detect
                     </button>
@@ -124,7 +124,7 @@ export default function KoboldCPPOptions({ settings }) {
             <input
               type="url"
               name="KoboldCPPBasePath"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="http://127.0.0.1:5000/v1"
               value={basePathValue.value}
               required={true}
@@ -133,7 +133,7 @@ export default function KoboldCPPOptions({ settings }) {
               onChange={basePath.onChange}
               onBlur={basePath.onBlur}
             />
-            <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
               Enter the URL where KoboldCPP is running.
             </p>
           </div>
@@ -174,13 +174,13 @@ function KoboldCPPModelSelection({ settings, basePath = null }) {
   if (loading || customModels.length === 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           KoboldCPP Model
         </label>
         <select
           name="KoboldCPPModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {basePath?.includes("/v1")
@@ -188,7 +188,7 @@ function KoboldCPPModelSelection({ settings, basePath = null }) {
               : "Enter KoboldCPP URL first"}
           </option>
         </select>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
           Select the KoboldCPP model you want to use. Models will load after
           entering a valid KoboldCPP URL.
         </p>
@@ -198,13 +198,13 @@ function KoboldCPPModelSelection({ settings, basePath = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         KoboldCPP Model
       </label>
       <select
         name="KoboldCPPModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.map((model) => (
           <option
@@ -216,7 +216,7 @@ function KoboldCPPModelSelection({ settings, basePath = null }) {
           </option>
         ))}
       </select>
-      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+      <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
         Choose the KoboldCPP model you want to use for your conversations.
       </p>
     </div>

--- a/frontend/src/components/LLMSelection/LLMItem/index.jsx
+++ b/frontend/src/components/LLMSelection/LLMItem/index.jsx
@@ -28,7 +28,7 @@ export default function LLMItem({
           className="w-10 h-10 rounded-md"
         />
         <div className="flex flex-col">
-          <div className="text-sm font-semibold text-white">{name}</div>
+          <div className="text-sm font-semibold text-foreground">{name}</div>
           <div className="mt-1 text-xs text-description">{description}</div>
         </div>
       </div>

--- a/frontend/src/components/LLMSelection/LLMProviderOption/index.jsx
+++ b/frontend/src/components/LLMSelection/LLMProviderOption/index.jsx
@@ -17,17 +17,17 @@ export default function LLMProviderOption({
         readOnly={true}
         formNoValidate={true}
       />
-      <label className="transition-all duration-300 inline-flex flex-col h-full w-60 cursor-pointer items-start justify-between rounded-2xl bg-preference-gradient border-2 border-transparent shadow-md px-5 py-4 text-white hover:bg-selected-preference-gradient hover:border-white/60 peer-checked:border-white peer-checked:border-opacity-90 peer-checked:bg-selected-preference-gradient">
+      <label className="transition-all duration-300 inline-flex flex-col h-full w-60 cursor-pointer items-start justify-between rounded-2xl bg-preference-gradient border-2 border-transparent shadow-md px-5 py-4 text-foreground hover:bg-selected-preference-gradient hover:border-border/60 peer-checked:border-border peer-checked:border-opacity-90 peer-checked:bg-selected-preference-gradient">
         <div className="flex items-center">
           <img src={image} alt={name} className="h-10 w-10 rounded" />
           <div className="ml-4 text-sm font-semibold">{name}</div>
         </div>
-        <div className="mt-2 text-xs font-base text-white tracking-wide">
+        <div className="mt-2 text-xs font-base text-foreground tracking-wide">
           {description}
         </div>
         <a
           href={`https://${link}`}
-          className="mt-2 text-xs text-white font-medium underline"
+          className="mt-2 text-xs text-foreground font-medium underline"
         >
           {link}
         </a>

--- a/frontend/src/components/LLMSelection/LMStudioOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/LMStudioOptions/index.jsx
@@ -31,7 +31,7 @@ export default function LMStudioOptions({ settings, showAlert = false }) {
   return (
     <div className="w-full flex flex-col gap-y-7">
       {showAlert && (
-        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-6 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-6 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
           <div className="gap-x-2 flex items-center">
             <Info size={12} className="hidden md:visible" />
             <p className="text-sm md:text-base">
@@ -50,13 +50,13 @@ export default function LMStudioOptions({ settings, showAlert = false }) {
       <div className="w-full flex items-start gap-[36px] mt-1.5">
         <LMStudioModelSelection settings={settings} basePath={basePath.value} />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             Max Tokens
           </label>
           <input
             type="number"
             name="LMStudioTokenLimit"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="4096"
             defaultChecked="4096"
             min={1}
@@ -66,7 +66,7 @@ export default function LMStudioOptions({ settings, showAlert = false }) {
             required={true}
             autoComplete="off"
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Maximum number of tokens for context and response.
           </p>
         </div>
@@ -92,7 +92,7 @@ export default function LMStudioOptions({ settings, showAlert = false }) {
         <div className="w-full flex items-start gap-4">
           <div className="flex flex-col w-60">
             <div className="flex justify-between items-center mb-2">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 LM Studio Base URL
               </label>
               {loading ? (
@@ -102,7 +102,7 @@ export default function LMStudioOptions({ settings, showAlert = false }) {
                   {!basePathValue.value && (
                     <button
                       onClick={handleAutoDetectClick}
-                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                     >
                       Auto-Detect
                     </button>
@@ -113,7 +113,7 @@ export default function LMStudioOptions({ settings, showAlert = false }) {
             <input
               type="url"
               name="LMStudioBasePath"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="http://localhost:1234/v1"
               value={basePathValue.value}
               required={true}
@@ -122,7 +122,7 @@ export default function LMStudioOptions({ settings, showAlert = false }) {
               onChange={basePath.onChange}
               onBlur={basePath.onBlur}
             />
-            <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+            <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
               Enter the URL where LM Studio is running.
             </p>
           </div>
@@ -163,13 +163,13 @@ function LMStudioModelSelection({ settings, basePath = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           LM Studio Model
         </label>
         <select
           name="LMStudioModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {!!basePath
@@ -177,7 +177,7 @@ function LMStudioModelSelection({ settings, basePath = null }) {
               : "Enter LM Studio URL first"}
           </option>
         </select>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
           Select the LM Studio model you want to use. Models will load after
           entering a valid LM Studio URL.
         </p>
@@ -187,13 +187,13 @@ function LMStudioModelSelection({ settings, basePath = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         LM Studio Model
       </label>
       <select
         name="LMStudioModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">
@@ -211,7 +211,7 @@ function LMStudioModelSelection({ settings, basePath = null }) {
           </optgroup>
         )}
       </select>
-      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+      <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
         Choose the LM Studio model you want to use for your conversations.
       </p>
     </div>

--- a/frontend/src/components/LLMSelection/LiteLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/LiteLLMOptions/index.jsx
@@ -11,13 +11,13 @@ export default function LiteLLMOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7 mt-1.5">
       <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Base URL
           </label>
           <input
             type="url"
             name="LiteLLMBasePath"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="http://127.0.0.1:4000"
             defaultValue={settings?.LiteLLMBasePath}
             required={true}
@@ -33,13 +33,13 @@ export default function LiteLLMOptions({ settings }) {
           apiKey={apiKey}
         />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Token context window
           </label>
           <input
             type="number"
             name="LiteLLMTokenLimit"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="4096"
             min={1}
             onScroll={(e) => e.target.blur()}
@@ -52,14 +52,14 @@ export default function LiteLLMOptions({ settings }) {
       <div className="w-full flex items-center gap-[36px]">
         <div className="flex flex-col w-60">
           <div className="flex flex-col gap-y-1 mb-4">
-            <label className="text-white text-sm font-semibold flex items-center gap-x-2">
+            <label className="text-foreground text-sm font-semibold flex items-center gap-x-2">
               API Key <p className="!text-xs !italic !font-thin">optional</p>
             </label>
           </div>
           <input
             type="password"
             name="LiteLLMAPIKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="sk-mysecretkey"
             defaultValue={settings?.LiteLLMAPIKey ? "*".repeat(20) : ""}
             autoComplete="off"
@@ -99,13 +99,13 @@ function LiteLLMModelSelection({ settings, basePath = null, apiKey = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="LiteLLMModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {basePath?.includes("/v1")
@@ -119,13 +119,13 @@ function LiteLLMModelSelection({ settings, basePath = null, apiKey = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="LiteLLMModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">

--- a/frontend/src/components/LLMSelection/LocalAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/LocalAiOptions/index.jsx
@@ -25,7 +25,7 @@ export default function LocalAiOptions({ settings, showAlert = false }) {
   return (
     <div className="w-full flex flex-col gap-y-7">
       {showAlert && (
-        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-6 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-6 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
           <div className="gap-x-2 flex items-center">
             <Info size={12} className="hidden md:visible" />
             <p className="text-sm md:text-base">
@@ -50,13 +50,13 @@ export default function LocalAiOptions({ settings, showAlert = false }) {
               apiKey={apiKey}
             />
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-2">
+              <label className="text-foreground text-sm font-semibold block mb-2">
                 Token context window
               </label>
               <input
                 type="number"
                 name="LocalAiTokenLimit"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="4096"
                 min={1}
                 onScroll={(e) => e.target.blur()}
@@ -69,7 +69,7 @@ export default function LocalAiOptions({ settings, showAlert = false }) {
         )}
         <div className="flex flex-col w-60">
           <div className="flex flex-col gap-y-1 mb-2">
-            <label className="text-white text-sm font-semibold flex items-center gap-x-2">
+            <label className="text-foreground text-sm font-semibold flex items-center gap-x-2">
               Local AI API Key{" "}
               <p className="!text-xs !italic !font-thin">optional</p>
             </label>
@@ -77,7 +77,7 @@ export default function LocalAiOptions({ settings, showAlert = false }) {
           <input
             type="password"
             name="LocalAiApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="sk-mysecretkey"
             defaultValue={settings?.LocalAiApiKey ? "*".repeat(20) : ""}
             autoComplete="off"
@@ -107,7 +107,7 @@ export default function LocalAiOptions({ settings, showAlert = false }) {
         <div className="w-full flex items-center gap-4">
           <div className="flex flex-col w-60">
             <div className="flex justify-between items-center mb-2">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 Local AI Base URL
               </label>
               {loading ? (
@@ -117,7 +117,7 @@ export default function LocalAiOptions({ settings, showAlert = false }) {
                   {!basePathValue.value && (
                     <button
                       onClick={handleAutoDetectClick}
-                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                      className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                     >
                       Auto-Detect
                     </button>
@@ -128,7 +128,7 @@ export default function LocalAiOptions({ settings, showAlert = false }) {
             <input
               type="url"
               name="LocalAiBasePath"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
               placeholder="http://localhost:8080/v1"
               value={basePathValue.value}
               required={true}
@@ -170,13 +170,13 @@ function LocalAIModelSelection({ settings, basePath = null, apiKey = null }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           Chat Model Selection
         </label>
         <select
           name="LocalAiModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {basePath?.includes("/v1")
@@ -190,13 +190,13 @@ function LocalAIModelSelection({ settings, basePath = null, apiKey = null }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         Chat Model Selection
       </label>
       <select
         name="LocalAiModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">

--- a/frontend/src/components/LLMSelection/MistralOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/MistralOptions/index.jsx
@@ -8,13 +8,13 @@ export default function MistralOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Mistral API Key
         </label>
         <input
           type="password"
           name="MistralApiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="Mistral API Key"
           defaultValue={settings?.MistralApiKey ? "*".repeat(20) : ""}
           required={true}
@@ -56,13 +56,13 @@ function MistralModelSelection({ apiKey, settings }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="MistralModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {!!apiKey
@@ -76,13 +76,13 @@ function MistralModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="MistralModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Available Mistral Models">

--- a/frontend/src/components/LLMSelection/MoonshotAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/MoonshotAiOptions/index.jsx
@@ -10,13 +10,13 @@ export default function MoonshotAiOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           API Key
         </label>
         <input
           type="password"
           name="MoonshotAiApiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="Moonshot AI API Key"
           defaultValue={settings?.MoonshotAiApiKey ? "*".repeat(20) : ""}
           required={true}
@@ -57,13 +57,13 @@ function MoonshotAiModelSelection({ apiKey, settings }) {
   if (!apiKey) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="MoonshotAiModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- Enter API key --
@@ -76,13 +76,13 @@ function MoonshotAiModelSelection({ apiKey, settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="MoonshotAiModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -94,13 +94,13 @@ function MoonshotAiModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="MoonshotAiModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {models.map((model) => (
           <option

--- a/frontend/src/components/LLMSelection/NvidiaNimOptions/remote.jsx
+++ b/frontend/src/components/LLMSelection/NvidiaNimOptions/remote.jsx
@@ -25,7 +25,7 @@ export default function RemoteNvidiaNimOptions({ settings }) {
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
         <div className="flex justify-between items-center mb-2">
-          <label className="text-white text-sm font-semibold">
+          <label className="text-foreground text-sm font-semibold">
             NVIDIA Nim Base URL
           </label>
           {loading ? (
@@ -35,7 +35,7 @@ export default function RemoteNvidiaNimOptions({ settings }) {
               {!basePathValue.value && (
                 <button
                   onClick={handleAutoDetectClick}
-                  className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                  className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                 >
                   Auto-Detect
                 </button>
@@ -46,7 +46,7 @@ export default function RemoteNvidiaNimOptions({ settings }) {
         <input
           type="url"
           name="NvidiaNimLLMBasePath"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="http://localhost:8000/v1"
           value={basePathValue.value}
           required={true}
@@ -55,7 +55,7 @@ export default function RemoteNvidiaNimOptions({ settings }) {
           onChange={basePath.onChange}
           onBlur={basePath.onBlur}
         />
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
           Enter the URL where NVIDIA NIM is running.
         </p>
       </div>
@@ -89,13 +89,13 @@ function NvidiaNimModelSelection({ settings, basePath }) {
   if (loading || models.length === 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="NvidiaNimLLMModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -107,13 +107,13 @@ function NvidiaNimModelSelection({ settings, basePath }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="NvidiaNimLLMModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {models.map((model) => (
           <option

--- a/frontend/src/components/LLMSelection/OllamaLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/OllamaLLMOptions/index.jsx
@@ -37,13 +37,13 @@ export default function OllamaLLMOptions({ settings }) {
           authToken={authToken.value}
         />
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             Max Tokens
           </label>
           <input
             type="number"
             name="OllamaLLMTokenLimit"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="4096"
             defaultChecked="4096"
             min={1}
@@ -53,7 +53,7 @@ export default function OllamaLLMOptions({ settings }) {
             required={true}
             autoComplete="off"
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Maximum number of tokens for context and response.
           </p>
         </div>
@@ -80,7 +80,7 @@ export default function OllamaLLMOptions({ settings }) {
           <div className="w-full flex items-start gap-4">
             <div className="flex flex-col w-60">
               <div className="flex justify-between items-center mb-2">
-                <label className="text-white text-sm font-semibold">
+                <label className="text-foreground text-sm font-semibold">
                   Ollama Base URL
                 </label>
                 {loading ? (
@@ -90,7 +90,7 @@ export default function OllamaLLMOptions({ settings }) {
                     {!basePathValue.value && (
                       <button
                         onClick={handleAutoDetectClick}
-                        className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-white shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+                        className="bg-primary-button text-xs font-medium px-2 py-1 rounded-sm hover:bg-secondary hover:text-foreground shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
                       >
                         Auto-Detect
                       </button>
@@ -101,7 +101,7 @@ export default function OllamaLLMOptions({ settings }) {
               <input
                 type="url"
                 name="OllamaLLMBasePath"
-                className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 placeholder="http://127.0.0.1:11434"
                 value={basePathValue.value}
                 required={true}
@@ -110,30 +110,30 @@ export default function OllamaLLMOptions({ settings }) {
                 onChange={basePath.onChange}
                 onBlur={basePath.onBlur}
               />
-              <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+              <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
                 Enter the URL where Ollama is running.
               </p>
             </div>
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold mb-2 flex items-center">
+              <label className="text-foreground text-sm font-semibold mb-2 flex items-center">
                 Performance Mode
                 <Info
                   size={16}
-                  className="ml-2 text-white"
+                  className="ml-2 text-foreground"
                   data-tooltip-id="performance-mode-tooltip"
                 />
               </label>
               <select
                 name="OllamaLLMPerformanceMode"
                 required={true}
-                className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
                 value={performanceMode}
                 onChange={(e) => setPerformanceMode(e.target.value)}
               >
                 <option value="base">Base (Default)</option>
                 <option value="maximum">Maximum</option>
               </select>
-              <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+              <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
                 Choose the performance mode for the Ollama model.
               </p>
               <Tooltip
@@ -162,13 +162,13 @@ export default function OllamaLLMOptions({ settings }) {
               </Tooltip>
             </div>
             <div className="flex flex-col w-60">
-              <label className="text-white text-sm font-semibold block mb-2">
+              <label className="text-foreground text-sm font-semibold block mb-2">
                 Ollama Keep Alive
               </label>
               <select
                 name="OllamaLLMKeepAliveSeconds"
                 required={true}
-                className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
                 defaultValue={settings?.OllamaLLMKeepAliveSeconds ?? "300"}
               >
                 <option value="0">No cache</option>
@@ -176,7 +176,7 @@ export default function OllamaLLMOptions({ settings }) {
                 <option value="3600">1 hour</option>
                 <option value="-1">Forever</option>
               </select>
-              <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+              <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
                 Choose how long Ollama should keep your model in memory before
                 unloading.
                 <a
@@ -193,10 +193,10 @@ export default function OllamaLLMOptions({ settings }) {
           </div>
           <div className="w-full flex items-start gap-4">
             <div className="flex flex-col w-100">
-              <label className="text-white text-sm font-semibold">
+              <label className="text-foreground text-sm font-semibold">
                 Auth Token
               </label>
-              <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+              <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
                 Enter a <code>Bearer</code> Auth Token for interacting with your
                 Ollama server.
                 <br />
@@ -206,7 +206,7 @@ export default function OllamaLLMOptions({ settings }) {
               <input
                 type="password"
                 name="OllamaLLMAuthToken"
-                className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm outline-none block w-full p-2.5"
+                className="border-none bg-theme-settings-input-bg mt-2 text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm outline-none block w-full p-2.5"
                 placeholder="Ollama Auth Token"
                 defaultValue={
                   settings?.OllamaLLMAuthToken ? "*".repeat(20) : ""
@@ -261,13 +261,13 @@ function OllamaLLMModelSelection({
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-2">
+        <label className="text-foreground text-sm font-semibold block mb-2">
           Ollama Model
         </label>
         <select
           name="OllamaLLMModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {!!basePath
@@ -275,7 +275,7 @@ function OllamaLLMModelSelection({
               : "Enter Ollama URL first"}
           </option>
         </select>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
           Select the Ollama model you want to use. Models will load after
           entering a valid Ollama URL.
         </p>
@@ -285,13 +285,13 @@ function OllamaLLMModelSelection({
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-2">
+      <label className="text-foreground text-sm font-semibold block mb-2">
         Ollama Model
       </label>
       <select
         name="OllamaLLMModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Your loaded models">
@@ -309,7 +309,7 @@ function OllamaLLMModelSelection({
           </optgroup>
         )}
       </select>
-      <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+      <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
         Choose the Ollama model you want to use for your conversations.
       </p>
     </div>

--- a/frontend/src/components/LLMSelection/OpenAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/OpenAiOptions/index.jsx
@@ -8,13 +8,13 @@ export default function OpenAiOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           API Key
         </label>
         <input
           type="password"
           name="OpenAiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="OpenAI API Key"
           defaultValue={settings?.OpenAiKey ? "*".repeat(20) : ""}
           required={true}
@@ -60,13 +60,13 @@ function OpenAIModelSelection({ apiKey, settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="OpenAiModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -78,13 +78,13 @@ function OpenAIModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="OpenAiModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {Object.keys(groupedModels)
           .sort()

--- a/frontend/src/components/LLMSelection/OpenRouterOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/OpenRouterOptions/index.jsx
@@ -7,13 +7,13 @@ export default function OpenRouterOptions({ settings }) {
     <div className="flex flex-col gap-y-4 mt-1.5">
       <div className="flex gap-[36px]">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             OpenRouter API Key
           </label>
           <input
             type="password"
             name="OpenRouterApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="OpenRouter API Key"
             defaultValue={settings?.OpenRouterApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -38,7 +38,7 @@ function AdvancedControls({ settings }) {
       <button
         type="button"
         onClick={() => setShowAdvancedControls(!showAdvancedControls)}
-        className="border-none text-white hover:text-white/70 flex items-center text-sm"
+        className="border-none text-foreground hover:text-foreground/70 flex items-center text-sm"
       >
         {showAdvancedControls ? "Hide" : "Show"} advanced controls
         {showAdvancedControls ? (
@@ -49,13 +49,13 @@ function AdvancedControls({ settings }) {
       </button>
       <div hidden={!showAdvancedControls}>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Stream Timeout (ms)
           </label>
           <input
             type="number"
             name="OpenRouterTimeout"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Timeout value between token responses to auto-timeout the stream"
             defaultValue={settings?.OpenRouterTimeout ?? 500}
             autoComplete="off"
@@ -95,13 +95,13 @@ function OpenRouterModelSelection({ settings }) {
   if (loading || Object.keys(groupedModels).length === 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="OpenRouterModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -113,13 +113,13 @@ function OpenRouterModelSelection({ settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="OpenRouterModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {Object.keys(groupedModels)
           .sort()

--- a/frontend/src/components/LLMSelection/PerplexityOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/PerplexityOptions/index.jsx
@@ -5,13 +5,13 @@ export default function PerplexityOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Perplexity API Key
         </label>
         <input
           type="password"
           name="PerplexityApiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="Perplexity API Key"
           defaultValue={settings?.PerplexityApiKey ? "*".repeat(20) : ""}
           required={true}
@@ -43,13 +43,13 @@ function PerplexityModelSelection({ settings }) {
   if (loading || customModels.length == 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="PerplexityModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -61,13 +61,13 @@ function PerplexityModelSelection({ settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="PerplexityModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {customModels.length > 0 && (
           <optgroup label="Available Perplexity Models">

--- a/frontend/src/components/LLMSelection/TextGenWebUIOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/TextGenWebUIOptions/index.jsx
@@ -2,13 +2,13 @@ export default function TextGenWebUIOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5 flex-wrap">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Base URL
         </label>
         <input
           type="url"
           name="TextGenWebUIBasePath"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="http://127.0.0.1:5000/v1"
           defaultValue={settings?.TextGenWebUIBasePath}
           required={true}
@@ -17,13 +17,13 @@ export default function TextGenWebUIOptions({ settings }) {
         />
       </div>
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Token context window
         </label>
         <input
           type="number"
           name="TextGenWebUITokenLimit"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="Content window limit (eg: 4096)"
           min={1}
           onScroll={(e) => e.target.blur()}
@@ -33,13 +33,13 @@ export default function TextGenWebUIOptions({ settings }) {
         />
       </div>
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           API Key (Optional)
         </label>
         <input
           type="password"
           name="TextGenWebUIAPIKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="TextGen Web UI API Key"
           defaultValue={settings?.TextGenWebUIAPIKey ? "*".repeat(20) : ""}
           autoComplete="off"

--- a/frontend/src/components/LLMSelection/TogetherAiOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/TogetherAiOptions/index.jsx
@@ -8,13 +8,13 @@ export default function TogetherAiOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Together AI API Key
         </label>
         <input
           type="password"
           name="TogetherAiApiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="Together AI API Key"
           defaultValue={settings?.TogetherAiApiKey ? "*".repeat(20) : ""}
           required={true}
@@ -67,13 +67,13 @@ function TogetherAiModelSelection({ settings, apiKey }) {
   if (loading || Object.keys(groupedModels).length === 0) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="TogetherAiModelPref"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -85,13 +85,13 @@ function TogetherAiModelSelection({ settings, apiKey }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="TogetherAiModelPref"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {Object.keys(groupedModels)
           .sort()

--- a/frontend/src/components/LLMSelection/XAiLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/XAiLLMOptions/index.jsx
@@ -8,7 +8,7 @@ export default function XAILLMOptions({ settings }) {
   return (
     <div className="flex gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           xAI API Key
         </label>
         <input

--- a/frontend/src/components/Modals/DisplayRecoveryCodeModal/index.jsx
+++ b/frontend/src/components/Modals/DisplayRecoveryCodeModal/index.jsx
@@ -36,8 +36,8 @@ export default function RecoveryCodeModal({
     <ModalWrapper isOpen={true} onClose={handleClose}>
       <div className="onenew-card p-5 shadow-2xl max-w-lg w-[90vw]">
         <div className="flex gap-x-2 items-center mb-5">
-          <Key size={24} className="text-white" weight="bold" />
-          <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+          <Key size={24} className="text-foreground" weight="bold" />
+          <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
             Recovery Codes
           </h3>
         </div>
@@ -46,14 +46,14 @@ export default function RecoveryCodeModal({
           style={{ maxHeight: "calc(100vh - 200px)" }}
         >
           <div className="space-y-2 flex-col">
-            <p className="text-sm text-white flex flex-col">
+            <p className="text-sm text-foreground flex flex-col">
               In order to reset your password in the future, you will need these
               recovery codes. Download or copy your recovery codes to save them{" "}
               <br />
               <b className="mt-4">These recovery codes are only shown once!</b>
             </p>
             <div
-              className="border-none bg-theme-settings-input-bg text-white hover:text-primary-button flex items-center justify-center rounded-md mt-6 cursor-pointer"
+              className="border-none bg-theme-settings-input-bg text-foreground hover:text-primary-button flex items-center justify-center rounded-md mt-6 cursor-pointer"
               onClick={handleCopyToClipboard}
             >
               <ul className="space-y-2 md:p-6 p-4">

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/ConnectorOption/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/ConnectorOption/index.jsx
@@ -15,9 +15,9 @@ export default function ConnectorOption({
     >
       <img src={image} alt={name} className="w-[40px] h-[40px] rounded-md" />
       <div className="flex flex-col">
-        <div className="text-white font-bold text-[14px]">{name}</div>
+        <div className="text-foreground font-bold text-[14px]">{name}</div>
         <div>
-          <p className="text-[12px] text-white/60">{description}</p>
+          <p className="text-[12px] text-foreground/60">{description}</p>
         </div>
       </div>
     </button>

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Confluence/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Confluence/index.jsx
@@ -61,7 +61,7 @@ export default function ConfluenceOptions() {
             <div className="w-full flex flex-col gap-4">
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold flex gap-x-2 items-center">
+                  <label className="text-foreground text-sm font-bold flex gap-x-2 items-center">
                     <p className="font-bold text-theme-text-primary">
                       {t("connectors.confluence.deployment_type")}
                     </p>
@@ -72,7 +72,7 @@ export default function ConfluenceOptions() {
                 </div>
                 <select
                   name="isCloud"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   required={true}
                   autoComplete="off"
                   spellCheck={false}
@@ -85,8 +85,8 @@ export default function ConfluenceOptions() {
 
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold flex gap-x-2 items-center">
-                    <p className="font-bold text-white">
+                  <label className="text-foreground text-sm font-bold flex gap-x-2 items-center">
+                    <p className="font-bold text-foreground">
                       {t("connectors.confluence.base_url")}
                     </p>
                   </label>
@@ -97,7 +97,7 @@ export default function ConfluenceOptions() {
                 <input
                   type="url"
                   name="baseUrl"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="eg: https://example.atlassian.net, http://localhost:8211, etc..."
                   required={true}
                   autoComplete="off"
@@ -106,7 +106,7 @@ export default function ConfluenceOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.confluence.space_key")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -116,7 +116,7 @@ export default function ConfluenceOptions() {
                 <input
                   type="text"
                   name="spaceKey"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="eg: ~7120208c08555d52224113949698b933a3bb56"
                   required={true}
                   autoComplete="off"
@@ -125,7 +125,7 @@ export default function ConfluenceOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.confluence.auth_type")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -134,7 +134,7 @@ export default function ConfluenceOptions() {
                 </div>
                 <select
                   name="accessType"
-                  className="border-none bg-theme-settings-input-bg w-fit mt-2 px-4 border-gray-500 text-white text-sm rounded-sm block py-2"
+                  className="border-none bg-theme-settings-input-bg w-fit mt-2 px-4 border-border text-foreground text-sm rounded-sm block py-2"
                   defaultValue={accessType}
                   onChange={(e) => setAccessType(e.target.value)}
                 >
@@ -160,7 +160,7 @@ export default function ConfluenceOptions() {
                 <>
                   <div className="flex flex-col pr-10">
                     <div className="flex flex-col gap-y-1 mb-4">
-                      <label className="text-white text-sm font-bold">
+                      <label className="text-foreground text-sm font-bold">
                         {t("connectors.confluence.username")}
                       </label>
                       <p className="text-xs font-normal text-theme-text-secondary">
@@ -170,7 +170,7 @@ export default function ConfluenceOptions() {
                     <input
                       type="text"
                       name="username"
-                      className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                       placeholder="jdoe@example.com"
                       required={true}
                       autoComplete="off"
@@ -179,8 +179,8 @@ export default function ConfluenceOptions() {
                   </div>
                   <div className="flex flex-col pr-10">
                     <div className="flex flex-col gap-y-1 mb-4">
-                      <label className="text-white text-sm font-bold flex gap-x-2 items-center">
-                        <p className="font-bold text-white">
+                      <label className="text-foreground text-sm font-bold flex gap-x-2 items-center">
+                        <p className="font-bold text-foreground">
                           {t("connectors.confluence.token")}
                         </p>
                         <Warning
@@ -217,7 +217,7 @@ export default function ConfluenceOptions() {
                     <input
                       type="password"
                       name="accessToken"
-                      className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                       placeholder="abcd1234"
                       required={true}
                       autoComplete="off"
@@ -229,7 +229,7 @@ export default function ConfluenceOptions() {
               {accessType === "personalToken" && (
                 <div className="flex flex-col pr-10">
                   <div className="flex flex-col gap-y-1 mb-4">
-                    <label className="text-white text-sm font-bold">
+                    <label className="text-foreground text-sm font-bold">
                       {t("connectors.confluence.pat_token")}
                     </label>
                     <p className="text-xs font-normal text-theme-text-secondary">
@@ -239,7 +239,7 @@ export default function ConfluenceOptions() {
                   <input
                     type="password"
                     name="personalAccessToken"
-                    className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     placeholder="abcd1234"
                     required={true}
                     autoComplete="off"
@@ -254,7 +254,7 @@ export default function ConfluenceOptions() {
             <button
               type="submit"
               disabled={loading}
-              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-white text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
+              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-foreground text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
             >
               {loading ? "Collecting pages..." : "Submit"}
             </button>

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/DrupalWiki/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/DrupalWiki/index.jsx
@@ -62,8 +62,8 @@ export default function DrupalWikiOptions() {
             <div className="w-full flex flex-col gap-4">
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold flex gap-x-2 items-center">
-                    <p className="font-bold text-white">Drupal Wiki base URL</p>
+                  <label className="text-foreground text-sm font-bold flex gap-x-2 items-center">
+                    <p className="font-bold text-foreground">Drupal Wiki base URL</p>
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
                     This is the base URL of your&nbsp;
@@ -81,7 +81,7 @@ export default function DrupalWikiOptions() {
                 <input
                   type="url"
                   name="baseUrl"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="eg: https://mywiki.drupal-wiki.net, https://drupalwiki.mycompany.tld, etc..."
                   required={true}
                   autoComplete="off"
@@ -90,7 +90,7 @@ export default function DrupalWikiOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     Drupal Wiki Space IDs
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -111,7 +111,7 @@ export default function DrupalWikiOptions() {
                 <input
                   type="text"
                   name="spaceIds"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="eg: 12,34,69"
                   required={true}
                   autoComplete="off"
@@ -120,8 +120,8 @@ export default function DrupalWikiOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold flex gap-x-2 items-center">
-                    <p className="font-bold text-white">
+                  <label className="text-foreground text-sm font-bold flex gap-x-2 items-center">
+                    <p className="font-bold text-foreground">
                       Drupal Wiki API Token
                     </p>
                     <Warning
@@ -158,7 +158,7 @@ export default function DrupalWikiOptions() {
                 <input
                   type="password"
                   name="accessToken"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="pat:123"
                   required={true}
                   autoComplete="off"
@@ -172,7 +172,7 @@ export default function DrupalWikiOptions() {
             <button
               type="submit"
               disabled={loading}
-              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-white text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
+              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-foreground text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
             >
               {loading ? "Collecting pages..." : "Submit"}
             </button>

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Github/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Github/index.jsx
@@ -69,7 +69,7 @@ export default function GithubOptions() {
             <div className="w-full flex flex-col gap-4">
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.github.URL")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -79,7 +79,7 @@ export default function GithubOptions() {
                 <input
                   type="url"
                   name="repo"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="https://github.com/Mintplex-Labs/anything-llm"
                   required={true}
                   autoComplete="off"
@@ -90,8 +90,8 @@ export default function GithubOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white font-bold text-sm flex gap-x-2 items-center">
-                    <p className="font-bold text-white">
+                  <label className="text-foreground font-bold text-sm flex gap-x-2 items-center">
+                    <p className="font-bold text-foreground">
                       {t("connectors.github.token")}
                     </p>{" "}
                     <p className="text-xs font-light flex items-center">
@@ -108,7 +108,7 @@ export default function GithubOptions() {
                 <input
                   type="text"
                   name="accessToken"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="github_pat_1234_abcdefg"
                   required={false}
                   autoComplete="off"
@@ -125,8 +125,8 @@ export default function GithubOptions() {
 
             <div className="flex flex-col w-full py-4 pr-10">
               <div className="flex flex-col gap-y-1 mb-4">
-                <label className="text-white text-sm flex gap-x-2 items-center">
-                  <p className="text-white text-sm font-bold">
+                <label className="text-foreground text-sm flex gap-x-2 items-center">
+                  <p className="text-foreground text-sm font-bold">
                     {t("connectors.github.ignores")}
                   </p>
                 </label>
@@ -142,7 +142,7 @@ export default function GithubOptions() {
                 classNames={{
                   tag: "bg-theme-settings-input-bg light:bg-black/10 bg-blue-300/10 text-zinc-800",
                   input:
-                    "flex p-1 !bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none",
+                    "flex p-1 !bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none",
                 }}
               />
             </div>
@@ -153,12 +153,12 @@ export default function GithubOptions() {
             <button
               type="submit"
               disabled={loading}
-              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-white text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
+              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-foreground text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
             >
               {loading ? "Collecting files..." : "Submit"}
             </button>
             {loading && (
-              <p className="text-xs text-white/50">
+              <p className="text-xs text-foreground/50">
                 {t("connectors.github.task_explained")}
               </p>
             )}
@@ -197,7 +197,7 @@ function GitHubBranchSelection({ repo, accessToken }) {
     return (
       <div className="flex flex-col w-60">
         <div className="flex flex-col gap-y-1 mb-4">
-          <label className="text-white text-sm font-bold">Branch</label>
+          <label className="text-foreground text-sm font-bold">Branch</label>
           <p className="text-xs font-normal text-theme-text-secondary">
             {t("connectors.github.branch")}
           </p>
@@ -205,7 +205,7 @@ function GitHubBranchSelection({ repo, accessToken }) {
         <select
           name="branch"
           required={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {t("connectors.github.branch_loading")}
@@ -218,7 +218,7 @@ function GitHubBranchSelection({ repo, accessToken }) {
   return (
     <div className="flex flex-col w-60">
       <div className="flex flex-col gap-y-1 mb-4">
-        <label className="text-white text-sm font-bold">Branch</label>
+        <label className="text-foreground text-sm font-bold">Branch</label>
         <p className="text-xs font-normal text-theme-text-secondary">
           {t("connectors.github.branch_explained")}
         </p>
@@ -226,7 +226,7 @@ function GitHubBranchSelection({ repo, accessToken }) {
       <select
         name="branch"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
       >
         {allBranches.map((branch) => {
           return (
@@ -244,7 +244,7 @@ function PATAlert({ accessToken }) {
   const { t } = useTranslation();
   if (!!accessToken) return null;
   return (
-    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
       <div className="gap-x-2 flex items-center">
         <Info className="shrink-0" size={25} />
         <p className="text-sm">

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Gitlab/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Gitlab/index.jsx
@@ -70,7 +70,7 @@ export default function GitlabOptions() {
             <div className="w-full flex flex-col gap-4">
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.gitlab.URL")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -80,7 +80,7 @@ export default function GitlabOptions() {
                 <input
                   type="url"
                   name="repo"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="https://gitlab.com/gitlab-org/gitlab"
                   required={true}
                   autoComplete="off"
@@ -91,8 +91,8 @@ export default function GitlabOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white font-bold text-sm flex gap-x-2 items-center">
-                    <p className="font-bold text-white">
+                  <label className="text-foreground font-bold text-sm flex gap-x-2 items-center">
+                    <p className="font-bold text-foreground">
                       {t("connectors.gitlab.token")}
                     </p>{" "}
                     <p className="text-xs font-light flex items-center">
@@ -109,7 +109,7 @@ export default function GitlabOptions() {
                 <input
                   type="text"
                   name="accessToken"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="glpat-XXXXXXXXXXXXXXXXXXXX"
                   required={false}
                   autoComplete="off"
@@ -120,10 +120,10 @@ export default function GitlabOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white font-bold text-sm flex gap-x-2 items-center">
-                    <p className="font-bold text-white">Settings</p>
+                  <label className="text-foreground font-bold text-sm flex gap-x-2 items-center">
+                    <p className="font-bold text-foreground">Settings</p>
                   </label>
-                  <p className="text-xs font-normal text-white">
+                  <p className="text-xs font-normal text-foreground">
                     {t("connectors.gitlab.token_description")}
                   </p>
                 </div>
@@ -135,8 +135,8 @@ export default function GitlabOptions() {
                       value={true}
                       className="peer sr-only"
                     />
-                    <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
-                    <span className="ml-3 text-sm font-medium text-white">
+                    <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+                    <span className="ml-3 text-sm font-medium text-foreground">
                       {t("connectors.gitlab.fetch_issues")}
                     </span>
                   </label>
@@ -149,8 +149,8 @@ export default function GitlabOptions() {
                       value={true}
                       className="peer sr-only"
                     />
-                    <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
-                    <span className="ml-3 text-sm font-medium text-white">
+                    <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+                    <span className="ml-3 text-sm font-medium text-foreground">
                       Fetch Wikis as Documents
                     </span>
                   </label>
@@ -164,8 +164,8 @@ export default function GitlabOptions() {
 
             <div className="flex flex-col w-full py-4 pr-10">
               <div className="flex flex-col gap-y-1 mb-4">
-                <label className="text-white text-sm flex gap-x-2 items-center">
-                  <p className="text-white text-sm font-bold">
+                <label className="text-foreground text-sm flex gap-x-2 items-center">
+                  <p className="text-foreground text-sm font-bold">
                     {t("connectors.gitlab.ignores")}
                   </p>
                 </label>
@@ -181,7 +181,7 @@ export default function GitlabOptions() {
                 classNames={{
                   tag: "bg-theme-settings-input-bg light:bg-black/10 bg-blue-300/10 text-zinc-800",
                   input:
-                    "flex p-1 !bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none",
+                    "flex p-1 !bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none",
                 }}
               />
             </div>
@@ -192,12 +192,12 @@ export default function GitlabOptions() {
             <button
               type="submit"
               disabled={loading}
-              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-white text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
+              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-foreground text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
             >
               {loading ? "Collecting files..." : "Submit"}
             </button>
             {loading && (
-              <p className="text-xs text-white/50">
+              <p className="text-xs text-foreground/50">
                 {t("connectors.gitlab.task_explained")}
               </p>
             )}
@@ -236,7 +236,7 @@ function GitLabBranchSelection({ repo, accessToken }) {
     return (
       <div className="flex flex-col w-60">
         <div className="flex flex-col gap-y-1 mb-4">
-          <label className="text-white text-sm font-bold">
+          <label className="text-foreground text-sm font-bold">
             {t("connectors.gitlab.branch")}
           </label>
           <p className="text-xs font-normal text-theme-text-secondary">
@@ -246,7 +246,7 @@ function GitLabBranchSelection({ repo, accessToken }) {
         <select
           name="branch"
           required={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {t("connectors.gitlab.branch_loading")}
@@ -259,7 +259,7 @@ function GitLabBranchSelection({ repo, accessToken }) {
   return (
     <div className="flex flex-col w-60">
       <div className="flex flex-col gap-y-1 mb-4">
-        <label className="text-white text-sm font-bold">Branch</label>
+        <label className="text-foreground text-sm font-bold">Branch</label>
         <p className="text-xs font-normal text-theme-text-secondary">
           {t("connectors.gitlab.branch_explained")}
         </p>
@@ -267,7 +267,7 @@ function GitLabBranchSelection({ repo, accessToken }) {
       <select
         name="branch"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground focus:outline-primary-button active:outline-primary-button outline-none text-sm rounded-sm block w-full p-2.5"
       >
         {allBranches.map((branch) => {
           return (
@@ -285,7 +285,7 @@ function PATAlert({ accessToken }) {
   const { t } = useTranslation();
   if (!!accessToken) return null;
   return (
-    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
       <div className="gap-x-2 flex items-center">
         <Info className="shrink-0" size={25} />
         <p className="text-sm">

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Obsidian/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Obsidian/index.jsx
@@ -93,7 +93,7 @@ export default function ObsidianOptions() {
         <form className="w-full" onSubmit={handleSubmit}>
           <div className="w-full flex flex-col py-2">
             <div className="w-full flex flex-col gap-4">
-              <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+              <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
                 <div className="gap-x-2 flex items-center">
                   <Info className="shrink-0" size={25} />
                   <p className="text-sm">
@@ -104,7 +104,7 @@ export default function ObsidianOptions() {
 
               <div className="flex flex-col">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.obsidian.vault_location")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -117,13 +117,13 @@ export default function ObsidianOptions() {
                     value={vaultPath}
                     onChange={(e) => setVaultPath(e.target.value)}
                     placeholder="/path/to/your/vault"
-                    className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     required={true}
                     autoComplete="off"
                     spellCheck={false}
                     readOnly
                   />
-                  <label className="px-3 py-2 bg-theme-settings-input-bg border border-none rounded-lg text-white hover:bg-theme-settings-input-bg/80 cursor-pointer">
+                  <label className="px-3 py-2 bg-theme-settings-input-bg border border-none rounded-lg text-foreground hover:bg-theme-settings-input-bg/80 cursor-pointer">
                     <FolderOpen size={20} />
                     <input
                       type="file"
@@ -135,14 +135,14 @@ export default function ObsidianOptions() {
                 </div>
                 {selectedFiles.length > 0 && (
                   <>
-                    <p className="text-xs text-white mt-2 font-bold">
+                    <p className="text-xs text-foreground mt-2 font-bold">
                       {t("connectors.obsidian.selected_files", {
                         count: selectedFiles.length,
                       })}
                     </p>
 
                     {selectedFiles.map((file, i) => (
-                      <p key={i} className="text-xs text-white mt-2">
+                      <p key={i} className="text-xs text-foreground mt-2">
                         {file.webkitRelativePath}
                       </p>
                     ))}
@@ -156,14 +156,14 @@ export default function ObsidianOptions() {
             <button
               type="submit"
               disabled={loading || selectedFiles.length === 0}
-              className="border-none mt-2 w-full justify-center px-4 py-2 rounded-sm text-dark-text light:text-white text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
+              className="border-none mt-2 w-full justify-center px-4 py-2 rounded-sm text-dark-text light:text-foreground text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
             >
               {loading
                 ? t("connectors.obsidian.importing")
                 : t("connectors.obsidian.import_vault")}
             </button>
             {loading && (
-              <p className="text-xs text-white/50">
+              <p className="text-xs text-foreground/50">
                 {t("connectors.obsidian.processing_time")}
               </p>
             )}

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/WebsiteDepth/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/WebsiteDepth/index.jsx
@@ -56,7 +56,7 @@ export default function WebsiteDepthOptions() {
             <div className="w-full flex flex-col gap-4">
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.website-depth.URL")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -66,7 +66,7 @@ export default function WebsiteDepthOptions() {
                 <input
                   type="url"
                   name="url"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="https://example.com"
                   required={true}
                   autoComplete="off"
@@ -75,7 +75,7 @@ export default function WebsiteDepthOptions() {
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {" "}
                     {t("connectors.website-depth.depth")}
                   </label>
@@ -88,14 +88,14 @@ export default function WebsiteDepthOptions() {
                   name="depth"
                   min="1"
                   max="5"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   required={true}
                   defaultValue="1"
                 />
               </div>
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.website-depth.max_pages")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -106,7 +106,7 @@ export default function WebsiteDepthOptions() {
                   type="number"
                   name="maxLinks"
                   min="1"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   required={true}
                   defaultValue="20"
                 />
@@ -118,7 +118,7 @@ export default function WebsiteDepthOptions() {
             <button
               type="submit"
               disabled={loading}
-              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-white text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
+              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-foreground text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
             >
               {loading ? "Scraping website..." : "Submit"}
             </button>

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Youtube/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Youtube/index.jsx
@@ -51,7 +51,7 @@ export default function YoutubeOptions() {
             <div className="w-full flex flex-col gap-4">
               <div className="flex flex-col pr-10">
                 <div className="flex flex-col gap-y-1 mb-4">
-                  <label className="text-white text-sm font-bold">
+                  <label className="text-foreground text-sm font-bold">
                     {t("connectors.youtube.URL")}
                   </label>
                   <p className="text-xs font-normal text-theme-text-secondary">
@@ -71,7 +71,7 @@ export default function YoutubeOptions() {
                 <input
                   type="url"
                   name="url"
-                  className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="https://youtube.com/watch?v=abc123"
                   required={true}
                   autoComplete="off"
@@ -85,7 +85,7 @@ export default function YoutubeOptions() {
             <button
               type="submit"
               disabled={loading}
-              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-white text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
+              className="mt-2 w-full justify-center border-none px-4 py-2 rounded-sm text-dark-text light:text-foreground text-sm font-bold items-center flex gap-x-2 bg-theme-home-button-primary hover:bg-theme-home-button-primary-hover disabled:bg-theme-home-button-primary-hover disabled:cursor-not-allowed"
             >
               {loading ? "Collecting transcript..." : "Collect transcript"}
             </button>

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/index.jsx
@@ -73,12 +73,12 @@ export default function DataConnectors() {
           <MagnifyingGlass
             size={16}
             weight="bold"
-            className="absolute left-4 z-30 text-white"
+            className="absolute left-4 z-30 text-foreground"
           />
           <input
             type="text"
             placeholder={t("connectors.search-placeholder")}
-            className="border-none z-20 pl-10 h-[38px] rounded-full w-full px-4 py-1 text-sm border-2 border-slate-300/40 outline-none focus:outline-primary-button active:outline-primary-button outline-none placeholder:text-theme-settings-input-placeholder text-white bg-theme-settings-input-bg"
+            className="border-none z-20 pl-10 h-[38px] rounded-full w-full px-4 py-1 text-sm border-2 border-slate-300/40 outline-none focus:outline-primary-button active:outline-primary-button outline-none placeholder:text-theme-settings-input-placeholder text-foreground bg-theme-settings-input-bg"
             autoComplete="off"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
@@ -98,14 +98,14 @@ export default function DataConnectors() {
               />
             ))
           ) : (
-            <div className="text-white text-center mt-4">
+            <div className="text-foreground text-center mt-4">
               {t("connectors.no-connectors")}
             </div>
           )}
         </div>
       </div>
       <div className="xl:block hidden absolute left-1/2 top-0 bottom-0 w-[0.5px] bg-card -translate-x-1/2"></div>
-      <div className="w-full p-4 top-0 text-white min-w-[500px]">
+      <div className="w-full p-4 top-0 text-foreground min-w-[500px]">
         {DATA_CONNECTORS[selectedConnector].options}
       </div>
     </div>

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FileRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FileRow/index.jsx
@@ -12,7 +12,7 @@ export default function FileRow({ item, selected, toggleSelection }) {
     <tr
       onClick={() => toggleSelection(item)}
       className={`text-theme-text-primary text-xs grid grid-cols-12 py-2 pl-3.5 pr-8 hover:bg-theme-file-picker-hover cursor-pointer file-row ${
-        selected ? "selected light:text-white" : ""
+        selected ? "selected light:text-foreground" : ""
       }`}
     >
       <div
@@ -25,8 +25,8 @@ export default function FileRow({ item, selected, toggleSelection }) {
         })}
       >
         <div
-          className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-white ${
-            selected ? "text-white" : "text-theme-text-primary light:invert"
+          className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-border ${
+            selected ? "text-foreground" : "text-theme-text-primary light:invert"
           } flex justify-center items-center cursor-pointer`}
           role="checkbox"
           aria-checked={selected}

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FolderRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FolderRow/index.jsx
@@ -23,17 +23,17 @@ export default function FolderRow({
       <tr
         onClick={onRowClick}
         className={`text-theme-text-primary text-xs grid grid-cols-12 py-2 pl-3.5 pr-8 hover:bg-theme-file-picker-hover cursor-pointer file-row ${
-          selected ? "selected light:text-white !text-white" : ""
+          selected ? "selected light:text-foreground !text-foreground" : ""
         }`}
       >
         <div
           className={`col-span-6 flex gap-x-[4px] items-center ${
-            selected ? "!text-white" : "text-theme-text-primary"
+            selected ? "!text-foreground" : "text-theme-text-primary"
           }`}
         >
           <div
-            className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-white ${
-              selected ? "text-white" : "text-theme-text-primary light:invert"
+            className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-border ${
+              selected ? "text-foreground" : "text-theme-text-primary light:invert"
             } flex justify-center items-center cursor-pointer`}
             role="checkbox"
             aria-checked={selected}

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FolderSelectionPopup/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/FolderSelectionPopup/index.jsx
@@ -13,7 +13,7 @@ export default function FolderSelectionPopup({ folders, onSelect, onClose }) {
           <li
             key={folder.name}
             onClick={() => handleFolderSelect(folder)}
-            className="px-4 py-2 text-xs text-gray-700 hover:bg-gray-200 rounded-lg cursor-pointer whitespace-nowrap"
+            className="px-4 py-2 text-xs text-foreground hover:bg-background rounded-lg cursor-pointer whitespace-nowrap"
           >
             {middleTruncate(folder.name, 25)}
           </li>

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/NewFolderModal/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/NewFolderModal/index.jsx
@@ -33,11 +33,11 @@ export default function NewFolderModal({ closeModal, files, setFiles }) {
     <ModalWrapper isOpen={true} onClose={closeModal} noPortal>
       <div className="onenew-card p-5 shadow-2xl max-w-lg w-[90vw]">
         <div className="flex items-center justify-between mb-5">
-          <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+          <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
             Create New Folder
           </h3>
           <button onClick={closeModal} type="button" className="onenew-btn">
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <form onSubmit={handleCreate}>
@@ -45,7 +45,7 @@ export default function NewFolderModal({ closeModal, files, setFiles }) {
             <div>
               <label
                 htmlFor="folderName"
-                className="block mb-2 text-sm font-medium text-white"
+                className="block mb-2 text-sm font-medium text-foreground"
               >
                 Folder Name
               </label>

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/Directory/index.jsx
@@ -199,7 +199,7 @@ function Directory({
       <div className="px-8 pb-8" onContextMenu={handleContextMenu}>
         <div className="flex flex-col gap-y-6">
           <div className="flex items-center justify-between w-[560px] px-5 relative">
-            <h3 className="text-white text-base font-bold">
+            <h3 className="text-foreground text-base font-bold">
               {t("connectors.directory.my-documents")}
             </h3>
             <div className="relative">
@@ -211,7 +211,7 @@ function Directory({
               />
               <MagnifyingGlass
                 size={14}
-                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-white"
+                className="absolute left-3 top-1/2 transform -translate-y-1/2 text-foreground"
                 weight="bold"
               />
             </div>
@@ -231,7 +231,7 @@ function Directory({
           </div>
 
           <div className="relative w-[560px] h-[310px] bg-theme-settings-input-bg rounded-2xl overflow-hidden border border-theme-modal-border">
-            <div className="absolute top-0 left-0 right-0 z-10 rounded-t-2xl text-theme-text-primary text-xs grid grid-cols-12 py-2 px-8 border-b border-white/20 light:border-theme-modal-border bg-theme-settings-input-bg">
+            <div className="absolute top-0 left-0 right-0 z-10 rounded-t-2xl text-theme-text-primary text-xs grid grid-cols-12 py-2 px-8 border-b border-border/20 light:border-theme-modal-border bg-theme-settings-input-bg">
               <p className="col-span-6">Name</p>
             </div>
 
@@ -239,7 +239,7 @@ function Directory({
               {loading ? (
                 <div className="w-full h-full flex items-center justify-center flex-col gap-y-5">
                   <PreLoader />
-                  <p className="text-white text-sm font-semibold animate-pulse text-center w-1/3">
+                  <p className="text-foreground text-sm font-semibold animate-pulse text-center w-1/3">
                     {loadingMessage}
                   </p>
                 </div>
@@ -263,7 +263,7 @@ function Directory({
                 )
               ) : (
                 <div className="w-full h-full flex items-center justify-center">
-                  <p className="text-white text-opacity-40 text-sm font-medium">
+                  <p className="text-foreground text-opacity-40 text-sm font-medium">
                     {t("connectors.directory.no-documents")}
                   </p>
                 </div>
@@ -288,7 +288,7 @@ function Directory({
                         }
                         className="onenew-btn onenew-btn-secondary h-[32px] w-[32px] flex justify-center items-center group"
                       >
-                        <MoveToFolderIcon className="text-dark-text light:text-[#026AA2] group-hover:text-white" />
+                        <MoveToFolderIcon className="text-dark-text light:text-[#026AA2] group-hover:text-foreground" />
                       </button>
                       {showFolderSelection && (
                         <FolderSelectionPopup
@@ -358,7 +358,7 @@ function DirectoryTooltips() {
         if (!data) return null;
         return (
           <div className="text-xs">
-            <p className="text-white light:invert font-medium break-all">
+            <p className="text-foreground light:invert font-medium break-all">
               {data.title}
             </p>
             <div className="flex mt-1 gap-x-2">

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/FileUploadProgress/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/FileUploadProgress/index.jsx
@@ -96,7 +96,7 @@ function FileUploadProgressComponent({
           />
         </div>
         <div className="flex flex-col">
-          <p className="text-white light:text-red-600 text-xs font-semibold">
+          <p className="text-foreground light:text-red-600 text-xs font-semibold">
             {truncate(pathLabel, 30)}
           </p>
           <p className="text-red-100 light:text-red-600 text-xs font-medium">
@@ -121,7 +121,7 @@ function FileUploadProgressComponent({
           />
         </div>
         <div className="flex flex-col">
-          <p className="text-white light:text-red-600 text-xs font-semibold">
+          <p className="text-foreground light:text-red-600 text-xs font-semibold">
             {truncate(pathLabel, 30)}
           </p>
           <p className="text-red-100 light:text-red-600 text-xs font-medium">
@@ -136,7 +136,7 @@ function FileUploadProgressComponent({
     <div
       className={`${
         isFadingOut ? "file-upload-fadeout" : "file-upload"
-      } h-14 px-2 py-2 flex items-center gap-x-4 rounded-lg bg-zinc-800 light:border-solid light:border-theme-modal-border light:bg-theme-bg-sidebar border border-white/20 shadow-md`}
+      } h-14 px-2 py-2 flex items-center gap-x-4 rounded-lg bg-zinc-800 light:border-solid light:border-theme-modal-border light:bg-theme-bg-sidebar border border-border/20 shadow-md`}
     >
       <div className="w-6 h-6 flex-shrink-0">
         {status !== "complete" ? (
@@ -151,10 +151,10 @@ function FileUploadProgressComponent({
         )}
       </div>
       <div className="flex flex-col">
-        <p className="text-white light:text-theme-text-primary text-xs font-medium">
+        <p className="text-foreground light:text-theme-text-primary text-xs font-medium">
           {truncate(pathLabel, 30)}
         </p>
-        <p className="text-white/80 light:text-theme-text-secondary text-xs font-medium">
+        <p className="text-foreground/80 light:text-theme-text-secondary text-xs font-medium">
           {humanFileSize(file.size)} | {milliToHms(timerMs)}
         </p>
       </div>

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/PreflightModal.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/PreflightModal.jsx
@@ -35,7 +35,7 @@ export default function PreflightModal({
       {Object.entries(node).map(([key, value]) => (
         <li
           key={key}
-          className="text-xs text-white light:text-theme-text-primary"
+          className="text-xs text-foreground light:text-theme-text-primary"
         >
           {key}
           {Object.keys(value || {}).length > 0 && renderTree(value)}
@@ -47,10 +47,10 @@ export default function PreflightModal({
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-40">
       <div className="bg-theme-bg-primary light:bg-card rounded-lg p-6 w-[360px] shadow-xl">
-        <h2 className="text-white light:text-theme-text-primary text-lg font-bold mb-4">
+        <h2 className="text-foreground light:text-theme-text-primary text-lg font-bold mb-4">
           {t("connectors.upload.preflight.title", "Ready to upload?")}
         </h2>
-        <p className="text-white/80 light:text-theme-text-secondary text-sm mb-4">
+        <p className="text-foreground/80 light:text-theme-text-secondary text-sm mb-4">
           {t(
             "connectors.upload.preflight.summary",
             {
@@ -62,10 +62,10 @@ export default function PreflightModal({
         </p>
         <div className="max-h-40 overflow-auto mb-4">{renderTree(tree)}</div>
         <div className="mb-6">
-          <p className="text-white light:text-theme-text-primary text-sm font-semibold mb-2">
+          <p className="text-foreground light:text-theme-text-primary text-sm font-semibold mb-2">
             {t("connectors.upload.preflight.conflict", "If a file exists:")}
           </p>
-          <label className="flex items-center gap-x-2 text-white light:text-theme-text-primary text-sm">
+          <label className="flex items-center gap-x-2 text-foreground light:text-theme-text-primary text-sm">
             <input
               type="radio"
               name="conflictPolicy"
@@ -75,7 +75,7 @@ export default function PreflightModal({
             />
             {t("connectors.upload.preflight.replace", "Replace")}
           </label>
-          <label className="flex items-center gap-x-2 text-white light:text-theme-text-primary text-sm mt-2">
+          <label className="flex items-center gap-x-2 text-foreground light:text-theme-text-primary text-sm mt-2">
             <input
               type="radio"
               name="conflictPolicy"
@@ -85,7 +85,7 @@ export default function PreflightModal({
             />
             {t("connectors.upload.preflight.keep_both", "Keep both")}
           </label>
-          <label className="flex items-center gap-x-2 text-white light:text-theme-text-primary text-sm mt-2">
+          <label className="flex items-center gap-x-2 text-foreground light:text-theme-text-primary text-sm mt-2">
             <input
               type="radio"
               name="conflictPolicy"
@@ -97,7 +97,7 @@ export default function PreflightModal({
           </label>
         </div>
         {libraryEnabled && (
-          <label className="flex items-center gap-x-2 text-white light:text-theme-text-primary text-sm mb-6">
+          <label className="flex items-center gap-x-2 text-foreground light:text-theme-text-primary text-sm mb-6">
             <input
               type="checkbox"
               checked={addToLibrary}
@@ -112,14 +112,14 @@ export default function PreflightModal({
         <div className="flex justify-end gap-x-2">
           <button
             type="button"
-            className="bg-transparent border border-white light:border-theme-modal-border text-white light:text-theme-text-primary rounded-md px-4 py-1 text-sm"
+            className="bg-transparent border border-border light:border-theme-modal-border text-foreground light:text-theme-text-primary rounded-md px-4 py-1 text-sm"
             onClick={onCancel}
           >
             {t("common.cancel", "Cancel")}
           </button>
           <button
             type="button"
-            className="bg-primary-button text-white rounded-md px-4 py-1 text-sm disabled:opacity-50"
+            className="bg-primary-button text-foreground rounded-md px-4 py-1 text-sm disabled:opacity-50"
             onClick={() => onConfirm(policy, addToLibrary)}
           >
             {t("common.confirm", "Upload")}

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/UploadFile/index.jsx
@@ -168,21 +168,21 @@ export default function UploadFile({
         <input {...getInputProps({ webkitdirectory: true })} />
         {ready === false ? (
           <div className="flex flex-col items-center justify-center h-full">
-            <CloudArrowUp className="w-8 h-8 text-white/80 light:invert" />
-            <div className="text-white text-opacity-80 text-sm font-semibold py-1">
+            <CloudArrowUp className="w-8 h-8 text-foreground/80 light:invert" />
+            <div className="text-foreground text-opacity-80 text-sm font-semibold py-1">
               {t("connectors.upload.processor-offline")}
             </div>
-            <div className="text-white text-opacity-60 text-xs font-medium py-1 px-20 text-center">
+            <div className="text-foreground text-opacity-60 text-xs font-medium py-1 px-20 text-center">
               {t("connectors.upload.processor-offline-desc")}
             </div>
           </div>
         ) : files.length === 0 ? (
           <div className="flex flex-col items-center justify-center">
-            <CloudArrowUp className="w-8 h-8 text-white/80 light:invert" />
-            <div className="text-white text-opacity-80 text-sm font-semibold py-1">
+            <CloudArrowUp className="w-8 h-8 text-foreground/80 light:invert" />
+            <div className="text-foreground text-opacity-80 text-sm font-semibold py-1">
               {t("connectors.upload.click-upload")}
             </div>
-            <div className="text-white text-opacity-60 text-xs font-medium py-1">
+            <div className="text-foreground text-opacity-60 text-xs font-medium py-1">
               {t("connectors.upload.file-types")}
             </div>
           </div>
@@ -211,11 +211,11 @@ export default function UploadFile({
         type="button"
         onClick={open}
         disabled={!ready}
-        className="mt-3 w-[560px] bg-primary-button text-white rounded-sm py-2 disabled:opacity-50"
+        className="mt-3 w-[560px] bg-primary-button text-foreground rounded-sm py-2 disabled:opacity-50"
       >
         {t("connectors.upload.upload-button", "Upload")}
       </button>
-      <div className="text-center text-white text-opacity-50 text-xs font-medium w-[560px] py-2">
+      <div className="text-center text-foreground text-opacity-50 text-xs font-medium w-[560px] py-2">
         {t("connectors.upload.or-submit-link")}
       </div>
       <form onSubmit={handleSendLink} className="flex gap-x-2">
@@ -223,21 +223,21 @@ export default function UploadFile({
           disabled={fetchingUrl}
           name="link"
           type="url"
-          className="border-none disabled:bg-theme-settings-input-bg disabled:text-theme-settings-input-placeholder bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-3/4 p-2.5"
+          className="border-none disabled:bg-theme-settings-input-bg disabled:text-theme-settings-input-placeholder bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-3/4 p-2.5"
           placeholder={t("connectors.upload.placeholder-link")}
           autoComplete="off"
         />
         <button
           disabled={fetchingUrl}
           type="submit"
-          className="disabled:bg-card disabled:text-foreground disabled:border-slate-400 disabled:cursor-wait bg bg-transparent hover:bg-card hover:text-foreground w-auto border border-white light:border-theme-modal-border text-sm text-white p-2.5 rounded-sm"
+          className="disabled:bg-card disabled:text-foreground disabled:border-slate-400 disabled:cursor-wait bg bg-transparent hover:bg-card hover:text-foreground w-auto border border-border light:border-theme-modal-border text-sm text-foreground p-2.5 rounded-sm"
         >
           {fetchingUrl
             ? t("connectors.upload.fetching")
             : t("connectors.upload.fetch-website")}
         </button>
       </form>
-      <div className="mt-6 text-center text-white text-opacity-80 text-xs font-medium w-[560px]">
+      <div className="mt-6 text-center text-foreground text-opacity-80 text-xs font-medium w-[560px]">
         {t("connectors.upload.privacy-notice")}
       </div>
       {showPreflight && (

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/WorkspaceFileRow/index.jsx
@@ -61,8 +61,8 @@ export default function WorkspaceFileRow({
         !disableSelection
           ? "hover:bg-theme-file-picker-hover cursor-pointer"
           : ""
-      } ${isMovedItem ? "selected light:text-white" : ""} ${
-        selected ? "selected light:text-white" : ""
+      } ${isMovedItem ? "selected light:text-foreground" : ""} ${
+        selected ? "selected light:text-foreground" : ""
       }`}
       onClick={toggleRowSelection}
     >
@@ -78,8 +78,8 @@ export default function WorkspaceFileRow({
         <div className="shrink-0 w-3 h-3">
           {!disableSelection ? (
             <div
-              className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-white ${
-                selected ? "text-white" : "text-theme-text-primary light:invert"
+              className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-border ${
+                selected ? "text-foreground" : "text-theme-text-primary light:invert"
               } flex justify-center items-center cursor-pointer`}
               role="checkbox"
               aria-checked={selected}

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/WorkspaceDirectory/index.jsx
@@ -91,12 +91,12 @@ function WorkspaceDirectory({
     return (
       <div className="px-8">
         <div className="flex items-center justify-start w-[560px]">
-          <h3 className="text-white text-base font-bold ml-5">
+          <h3 className="text-foreground text-base font-bold ml-5">
             {workspace.name}
           </h3>
         </div>
         <div className="relative w-[560px] h-[445px] bg-theme-settings-input-bg rounded-2xl mt-5 border border-theme-modal-border">
-          <div className="text-white/80 text-xs grid grid-cols-12 py-2 px-3.5 border-b border-white/20 light:border-theme-modal-border bg-theme-settings-input-bg sticky top-0 z-10 rounded-t-2xl">
+          <div className="text-foreground/80 text-xs grid grid-cols-12 py-2 px-3.5 border-b border-border/20 light:border-theme-modal-border bg-theme-settings-input-bg sticky top-0 z-10 rounded-t-2xl">
             <div className="col-span-10 flex items-center gap-x-[4px]">
               <div className="shrink-0 w-3 h-3" />
               <p className="ml-[7px] text-theme-text-primary">Name</p>
@@ -118,7 +118,7 @@ function WorkspaceDirectory({
     <>
       <div className="px-8">
         <div className="flex items-center justify-start w-[560px]">
-          <h3 className="text-white text-base font-bold ml-5">
+          <h3 className="text-foreground text-base font-bold ml-5">
             {workspace.name}
           </h3>
         </div>
@@ -129,12 +129,12 @@ function WorkspaceDirectory({
             }`}
           />
           <div className="relative w-full h-full bg-theme-settings-input-bg rounded-2xl overflow-hidden border border-theme-modal-border">
-            <div className="text-white/80 text-xs grid grid-cols-12 py-2 px-3.5 border-b border-white/20 light:border-theme-modal-border bg-theme-settings-input-bg sticky top-0 z-10">
+            <div className="text-foreground/80 text-xs grid grid-cols-12 py-2 px-3.5 border-b border-border/20 light:border-theme-modal-border bg-theme-settings-input-bg sticky top-0 z-10">
               <div className="col-span-10 flex items-center gap-x-[4px]">
                 {!hasChanges &&
                 files.items.some((folder) => folder.items.length > 0) ? (
                   <div
-                    className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-white text-theme-text-primary light:invert flex justify-center items-center cursor-pointer`}
+                    className={`shrink-0 w-3 h-3 rounded border-[1px] border-solid border-border text-theme-text-primary light:invert flex justify-center items-center cursor-pointer`}
                     role="checkbox"
                     aria-checked={
                       Object.keys(selectedItems).length ===
@@ -187,7 +187,7 @@ function WorkspaceDirectory({
                 </RenderFileRows>
               ) : (
                 <div className="w-full h-full flex items-center justify-center">
-                  <p className="text-white text-opacity-40 text-sm font-medium">
+                  <p className="text-foreground text-opacity-40 text-sm font-medium">
                     {t("connectors.directory.no_docs")}
                   </p>
                 </div>
@@ -200,7 +200,7 @@ function WorkspaceDirectory({
                   <div className="flex flex-row items-center gap-x-2">
                     <button
                       onClick={toggleSelectAll}
-                      className="border-none text-sm font-semibold bg-card light:bg-[#E0F2FE] h-[30px] px-2.5 rounded-sm hover:bg-neutral-800/80 hover:text-white light:text-[#026AA2] light:hover:bg-[#026AA2] light:hover:text-white"
+                      className="border-none text-sm font-semibold bg-card light:bg-[#E0F2FE] h-[30px] px-2.5 rounded-sm hover:bg-neutral-800/80 hover:text-foreground light:text-[#026AA2] light:hover:bg-[#026AA2] light:hover:text-foreground"
                     >
                       {Object.keys(selectedItems).length ===
                       files.items.reduce(
@@ -212,7 +212,7 @@ function WorkspaceDirectory({
                     </button>
                     <button
                       onClick={removeSelectedItems}
-                      className="border-none text-sm font-semibold bg-card light:bg-[#E0F2FE] h-[30px] px-2.5 rounded-sm hover:bg-neutral-800/80 hover:text-white light:text-[#026AA2] light:hover:bg-[#026AA2] light:hover:text-white"
+                      className="border-none text-sm font-semibold bg-card light:bg-[#E0F2FE] h-[30px] px-2.5 rounded-sm hover:bg-neutral-800/80 hover:text-foreground light:text-[#026AA2] light:hover:bg-[#026AA2] light:hover:text-foreground"
                     >
                       {t("connectors.directory.remove_selected")}
                     </button>
@@ -224,7 +224,7 @@ function WorkspaceDirectory({
         </div>
         {hasChanges && (
           <div className="flex items-center justify-between py-6">
-            <div className="text-white/80">
+            <div className="text-foreground/80">
               <p className="text-sm font-semibold">
                 {embeddingCosts === 0
                   ? ""
@@ -241,7 +241,7 @@ function WorkspaceDirectory({
 
             <button
               onClick={(e) => handleSaveChanges(e)}
-              className="border border-slate-200 px-5 py-2.5 rounded-lg text-white text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
+              className="border border-slate-200 px-5 py-2.5 rounded-lg text-foreground text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
             >
               {t("connectors.directory.save_embed")}
             </button>
@@ -283,13 +283,13 @@ const PinAlert = memo(() => {
               className="text-theme-text-primary text-lg w-6 h-6"
               weight="regular"
             />
-            <h3 className="text-xl font-semibold text-white">
+            <h3 className="text-xl font-semibold text-foreground">
               {t("connectors.pinning.what_pinning")}
             </h3>
           </div>
         </div>
         <div className="py-7 px-9 space-y-2 flex-col">
-          <div className="w-full text-white text-md flex flex-col gap-y-2">
+          <div className="w-full text-foreground text-md flex flex-col gap-y-2">
             <p>
               <span
                 dangerouslySetInnerHTML={{
@@ -348,13 +348,13 @@ const DocumentWatchAlert = memo(() => {
               className="text-theme-text-primary text-lg w-6 h-6"
               weight="regular"
             />
-            <h3 className="text-xl font-semibold text-white">
+            <h3 className="text-xl font-semibold text-foreground">
               {t("connectors.watching.what_watching")}
             </h3>
           </div>
         </div>
         <div className="py-7 px-9 space-y-2 flex-col">
-          <div className="w-full text-white text-md flex flex-col gap-y-2">
+          <div className="w-full text-foreground text-md flex flex-col gap-y-2">
             <p>
               <span
                 dangerouslySetInnerHTML={{
@@ -430,7 +430,7 @@ function WorkspaceDocumentTooltips() {
           if (!data) return null;
           return (
             <div className="text-xs">
-              <p className="text-white light:invert font-medium break-all">
+              <p className="text-foreground light:invert font-medium break-all">
                 {data.title}
               </p>
               <div className="flex mt-1 gap-x-2">

--- a/frontend/src/components/Modals/ManageWorkspace/Documents/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/Documents/index.jsx
@@ -215,7 +215,7 @@ export default function DocumentSettings({ workspace, systemSettings }) {
               libraryEnabled={libraryEnabled}
             />
             <div className="upload-modal-arrow">
-              <ArrowsDownUp className="text-white text-base font-bold rotate-90 w-11 h-11" />
+              <ArrowsDownUp className="text-foreground text-base font-bold rotate-90 w-11 h-11" />
             </div>
           </>
         )}

--- a/frontend/src/components/Modals/ManageWorkspace/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/index.jsx
@@ -43,7 +43,7 @@ const ManageWorkspace = ({ hideModal = noop, providedSlug = null }) => {
         <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
           <div className="relative p-6 border-b rounded-t border-theme-modal-border">
             <div className="w-full flex gap-x-2 items-center">
-              <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+              <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
                 {t("connectors.manage.editing")} "{workspace.name}"
               </h3>
             </div>
@@ -52,7 +52,7 @@ const ManageWorkspace = ({ hideModal = noop, providedSlug = null }) => {
               type="button"
               className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
             >
-              <X size={24} weight="bold" className="text-white" />
+              <X size={24} weight="bold" className="text-foreground" />
             </button>
           </div>
           <div
@@ -60,7 +60,7 @@ const ManageWorkspace = ({ hideModal = noop, providedSlug = null }) => {
             style={{ maxHeight: "calc(100vh - 200px)" }}
           >
             <div className="py-7 px-9 space-y-2 flex-col">
-              <p className="text-white">
+              <p className="text-foreground">
                 {t("connectors.manage.desktop-only")}
               </p>
             </div>
@@ -88,9 +88,9 @@ const ManageWorkspace = ({ hideModal = noop, providedSlug = null }) => {
             <button
               onClick={hideModal}
               type="button"
-              className="z-29 text-white bg-transparent rounded-sm text-sm p-1.5 ml-auto inline-flex items-center bg-sidebar-button hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
+              className="z-29 text-foreground bg-transparent rounded-sm text-sm p-1.5 ml-auto inline-flex items-center bg-sidebar-button hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
             >
-              <X size={20} weight="bold" className="text-white" />
+              <X size={20} weight="bold" className="text-foreground" />
             </button>
           </div>
 
@@ -123,8 +123,8 @@ const ModalTabSwitcher = ({ selectedTab, setSelectedTab }) => {
           onClick={() => setSelectedTab("documents")}
           className={`border-none px-4 py-2 rounded-sm font-semibold hover:bg-theme-modal-border hover:bg-opacity-60 ${
             selectedTab === "documents"
-              ? "bg-theme-modal-border font-bold text-white light:bg-[#E0F2FE] light:text-[#026AA2]"
-              : "text-white/20 font-medium hover:text-white light:bg-card light:text-[#535862] light:hover:bg-[#E0F2FE]"
+              ? "bg-theme-modal-border font-bold text-foreground light:bg-[#E0F2FE] light:text-[#026AA2]"
+              : "text-foreground/20 font-medium hover:text-foreground light:bg-card light:text-[#535862] light:hover:bg-[#E0F2FE]"
           }`}
         >
           {t("connectors.manage.documents")}
@@ -133,8 +133,8 @@ const ModalTabSwitcher = ({ selectedTab, setSelectedTab }) => {
           onClick={() => setSelectedTab("dataConnectors")}
           className={`border-none px-4 py-2 rounded-sm font-semibold hover:bg-theme-modal-border hover:bg-opacity-60 ${
             selectedTab === "dataConnectors"
-              ? "bg-theme-modal-border font-bold text-white light:bg-[#E0F2FE] light:text-[#026AA2]"
-              : "text-white/20 font-medium hover:text-white light:bg-card light:text-[#535862] light:hover:bg-[#E0F2FE]"
+              ? "bg-theme-modal-border font-bold text-foreground light:bg-[#E0F2FE] light:text-[#026AA2]"
+              : "text-foreground/20 font-medium hover:text-foreground light:bg-card light:text-[#535862] light:hover:bg-[#E0F2FE]"
           }`}
         >
           {t("connectors.manage.data-connectors")}

--- a/frontend/src/components/Modals/NewWorkspace.jsx
+++ b/frontend/src/components/Modals/NewWorkspace.jsx
@@ -27,11 +27,11 @@ export default function NewWorkspaceModal({ hideModal = noop }) {
     <ModalWrapper isOpen={true} onClose={hideModal}>
       <div className="onenew-card p-5 shadow-2xl max-w-lg w-[90vw]">
         <div className="flex items-center justify-between mb-5">
-          <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+          <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
             {t("new-workspace.title")}
           </h3>
           <button onClick={hideModal} type="button" className="onenew-btn">
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div
@@ -44,7 +44,7 @@ export default function NewWorkspaceModal({ hideModal = noop }) {
                 <div>
                   <label
                     htmlFor="name"
-                    className="block mb-2 text-sm font-medium text-white"
+                    className="block mb-2 text-sm font-medium text-foreground"
                   >
                     {t("common.workspaces-name")}
                   </label>

--- a/frontend/src/components/SettingsSidebar/index.jsx
+++ b/frontend/src/components/SettingsSidebar/index.jsx
@@ -97,7 +97,7 @@ export default function SettingsSidebar() {
                 <div className="flex gap-x-2 items-center text-foreground shrink-0">
                   <a
                     href={paths.home()}
-                    className="transition-all duration-300 p-2 rounded-full text-white bg-theme-action-menu-bg hover:bg-theme-action-menu-item-hover hover:border-slate-100 hover:border-opacity-50 border-transparent border"
+                    className="transition-all duration-300 p-2 rounded-full text-foreground bg-theme-action-menu-bg hover:bg-theme-action-menu-item-hover hover:border-slate-100 hover:border-opacity-50 border-transparent border"
                   >
                     <House className="h-4 w-4" />
                   </a>
@@ -116,7 +116,7 @@ export default function SettingsSidebar() {
                         user?.hasOwnProperty("role") && user.role !== "admin"
                       }
                       to={paths.settings.privacy()}
-                      className="text-theme-text-secondary hover:text-white text-xs leading-[18px] mx-3"
+                      className="text-theme-text-secondary hover:text-foreground text-xs leading-[18px] mx-3"
                     >
                       {t("settings.privacy")}
                     </Link>
@@ -167,7 +167,7 @@ export default function SettingsSidebar() {
                       user?.hasOwnProperty("role") && user.role !== "admin"
                     }
                     to={paths.settings.privacy()}
-                    className="text-theme-text-secondary hover:text-white hover:light:text-theme-text-primary text-xs leading-[18px] mx-3"
+                    className="text-theme-text-secondary hover:text-foreground hover:light:text-theme-text-primary text-xs leading-[18px] mx-3"
                   >
                     {t("settings.privacy")}
                   </Link>
@@ -204,7 +204,7 @@ function SupportEmail() {
   return (
     <Link
       to={supportEmail}
-      className="text-theme-text-secondary hover:text-white hover:light:text-theme-text-primary text-xs leading-[18px] mx-3 mt-1"
+      className="text-theme-text-secondary hover:text-foreground hover:light:text-theme-text-primary text-xs leading-[18px] mx-3 mt-1"
     >
       {t("settings.contact")}
     </Link>

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/ThreadItem/index.jsx
@@ -40,7 +40,7 @@ export default function ThreadItem({
         style={{ width: THREAD_CALLOUT_DETAIL_WIDTH / 2 }}
         className={`${
           isActive
-            ? "border-l-2 border-b-2 border-white light:border-theme-sidebar-border z-[2]"
+            ? "border-l-2 border-b-2 border-border light:border-theme-sidebar-border z-[2]"
             : "border-l border-b border-[#6F6F71] light:border-theme-sidebar-border z-[1]"
         } h-[50%] absolute top-0 left-3 rounded-bl-lg`}
       ></div>
@@ -50,7 +50,7 @@ export default function ThreadItem({
           style={{ width: THREAD_CALLOUT_DETAIL_WIDTH / 2 }}
           className={`${
             idx <= activeIdx && !isActive
-              ? "border-l-2 border-white light:border-theme-sidebar-border z-[2]"
+              ? "border-l-2 border-border light:border-theme-sidebar-border z-[2]"
               : "border-l border-[#6F6F71] light:border-theme-sidebar-border z-[1]"
           } h-[100%] absolute top-0 left-3`}
         ></div>
@@ -80,7 +80,7 @@ export default function ThreadItem({
                 onClick={() => toggleMarkForDeletion(thread.id)}
               >
                 <ArrowCounterClockwise
-                  className="text-zinc-300 hover:text-white light:text-theme-text-secondary hover:light:text-theme-text-primary"
+                  className="text-zinc-300 hover:text-foreground light:text-theme-text-secondary hover:light:text-theme-text-primary"
                   size={18}
                 />
               </button>
@@ -96,7 +96,7 @@ export default function ThreadItem({
           >
             <p
               className={`text-left text-sm truncate max-w-[150px] ${
-                isActive ? "font-medium text-white" : "text-theme-text-primary"
+                isActive ? "font-medium text-foreground" : "text-theme-text-primary"
               }`}
             >
               {thread.name}
@@ -114,7 +114,7 @@ export default function ThreadItem({
                 onClick={() => toggleMarkForDeletion(thread.id)}
               >
                 <X
-                  className="text-zinc-300 light:text-theme-text-secondary hover:text-white hover:light:text-theme-text-primary"
+                  className="text-zinc-300 light:text-theme-text-secondary hover:text-foreground hover:light:text-theme-text-primary"
                   weight="bold"
                   size={18}
                 />
@@ -128,7 +128,7 @@ export default function ThreadItem({
                   aria-label="Thread options"
                 >
                   <DotsThree
-                    className="text-foreground light:text-theme-text-secondary hover:text-white hover:light:text-theme-text-primary"
+                    className="text-foreground light:text-theme-text-secondary hover:text-foreground hover:light:text-theme-text-primary"
                     size={25}
                   />
                 </button>

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/ThreadContainer/index.jsx
@@ -112,7 +112,7 @@ export default function ThreadContainer({ workspace }) {
   if (loading) {
     return (
       <div className="flex flex-col bg-pulse w-full h-10 items-center justify-center">
-        <p className="text-xs text-white animate-pulse">loading threads....</p>
+        <p className="text-xs text-foreground animate-pulse">loading threads....</p>
       </div>
     );
   }
@@ -182,23 +182,23 @@ function NewThreadButton({ workspace }) {
             <CircleNotch
               weight="bold"
               size={14}
-              className="shrink-0 animate-spin text-white light:text-theme-text-primary"
+              className="shrink-0 animate-spin text-foreground light:text-theme-text-primary"
             />
           ) : (
             <Plus
               weight="bold"
               size={14}
-              className="shrink-0 text-white light:text-theme-text-primary"
+              className="shrink-0 text-foreground light:text-theme-text-primary"
             />
           )}
         </div>
 
         {loading ? (
-          <p className="text-left text-white light:text-theme-text-primary text-sm">
+          <p className="text-left text-foreground light:text-theme-text-primary text-sm">
             Starting Thread...
           </p>
         ) : (
-          <p className="text-left text-white light:text-theme-text-primary text-sm">
+          <p className="text-left text-foreground light:text-theme-text-primary text-sm">
             New Thread
           </p>
         )}
@@ -221,10 +221,10 @@ function DeleteAllThreadButton({ ctrlPressed, threads, onDelete }) {
           <Trash
             weight="bold"
             size={14}
-            className="shrink-0 text-white light:text-red-500/50 group-hover:text-red-400"
+            className="shrink-0 text-foreground light:text-red-500/50 group-hover:text-red-400"
           />
         </div>
-        <p className="text-white light:text-theme-text-secondary text-left text-sm group-hover:text-red-400">
+        <p className="text-foreground light:text-theme-text-secondary text-left text-sm group-hover:text-red-400">
           Delete Selected
         </p>
       </div>

--- a/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
+++ b/frontend/src/components/Sidebar/ActiveWorkspaces/index.jsx
@@ -144,7 +144,7 @@ export default function ActiveWorkspaces() {
                                 setSelectedWs(workspace);
                                 showModal();
                               }}
-                              className="border-none rounded-md flex items-center justify-center ml-auto p-[2px] hover:bg-[#646768] text-[#A7A8A9] hover:text-white"
+                              className="border-none rounded-md flex items-center justify-center ml-auto p-[2px] hover:bg-[#646768] text-[#A7A8A9] hover:text-foreground"
                             >
                               <UploadSimple className="h-[20px] w-[20px]" />
                             </button>
@@ -160,7 +160,7 @@ export default function ActiveWorkspaces() {
                                       )
                                 );
                               }}
-                              className="rounded-md flex items-center justify-center text-[#A7A8A9] hover:text-white ml-auto p-[2px] hover:bg-[#646768]"
+                              className="rounded-md flex items-center justify-center text-[#A7A8A9] hover:text-foreground ml-auto p-[2px] hover:bg-[#646768]"
                               aria-label="General appearance settings"
                             >
                               <GearSix

--- a/frontend/src/components/Sidebar/SearchBox/index.jsx
+++ b/frontend/src/components/Sidebar/SearchBox/index.jsx
@@ -61,7 +61,7 @@ export default function SearchBox({ user, showNewWsModal }) {
           onChange={handleSearch}
           onReset={handleReset}
           onFocus={(e) => e.target.select()}
-          className="border-none w-full h-full rounded-lg bg-theme-sidebar-item-default pl-4 pr-1 placeholder:text-theme-settings-input-placeholder placeholder:pl-4 outline-none text-white search-input peer text-sm"
+          className="border-none w-full h-full rounded-lg bg-theme-sidebar-item-default pl-4 pr-1 placeholder:text-theme-settings-input-placeholder placeholder:pl-4 outline-none text-foreground search-input peer text-sm"
         />
         <MagnifyingGlass
           size={14}

--- a/frontend/src/components/SpeechToText/BrowserNative/index.jsx
+++ b/frontend/src/components/SpeechToText/BrowserNative/index.jsx
@@ -1,7 +1,7 @@
 export default function BrowserNative() {
   return (
     <div className="w-full h-10 items-center flex">
-      <p className="text-sm font-base text-white text-opacity-60">
+      <p className="text-sm font-base text-foreground text-opacity-60">
         There is no configuration needed for this provider.
       </p>
     </div>

--- a/frontend/src/components/StatusBadge/index.jsx
+++ b/frontend/src/components/StatusBadge/index.jsx
@@ -11,14 +11,14 @@ export default function StatusBadge({ status }) {
 
   if (upper === "READY") {
     return (
-      <span className="onenew-chip bg-green-600 text-white text-[10px] px-2 py-0.5">
+      <span className="onenew-chip bg-green-600 text-foreground text-[10px] px-2 py-0.5">
         {label}
       </span>
     );
   }
   if (upper === "FAILED") {
     return (
-      <span className="onenew-chip bg-red-600 text-white text-[10px] px-2 py-0.5">
+      <span className="onenew-chip bg-red-600 text-foreground text-[10px] px-2 py-0.5">
         {label}
       </span>
     );
@@ -26,7 +26,7 @@ export default function StatusBadge({ status }) {
 
   if (isProcessingStatus(upper)) {
     return (
-      <span className="onenew-chip flex items-center gap-1 text-[10px] text-white">
+      <span className="onenew-chip flex items-center gap-1 text-[10px] text-foreground">
         <CircleNotch size={10} className="animate-spin" />
         {label}
       </span>

--- a/frontend/src/components/TextToSpeech/BrowserNative/index.jsx
+++ b/frontend/src/components/TextToSpeech/BrowserNative/index.jsx
@@ -1,7 +1,7 @@
 export default function BrowserNative() {
   return (
     <div className="w-full h-10 items-center flex">
-      <p className="text-sm font-base text-white text-opacity-60">
+      <p className="text-sm font-base text-foreground text-opacity-60">
         There is no configuration needed for this provider.
       </p>
     </div>

--- a/frontend/src/components/TextToSpeech/ElevenLabsOptions/index.jsx
+++ b/frontend/src/components/TextToSpeech/ElevenLabsOptions/index.jsx
@@ -10,13 +10,13 @@ export default function ElevenLabsOptions({ settings }) {
   return (
     <div className="flex gap-x-4">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           API Key
         </label>
         <input
           type="password"
           name="TTSElevenLabsKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="ElevenLabs API Key"
           defaultValue={settings?.TTSElevenLabsKey ? "*".repeat(20) : ""}
           required={true}
@@ -62,13 +62,13 @@ function ElevenLabsModelSelection({ apiKey, settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Chat Model Selection
         </label>
         <select
           name="TTSElevenLabsVoiceModel"
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- loading available models --
@@ -80,13 +80,13 @@ function ElevenLabsModelSelection({ apiKey, settings }) {
 
   return (
     <div className="flex flex-col w-60">
-      <label className="text-white text-sm font-semibold block mb-3">
+      <label className="text-foreground text-sm font-semibold block mb-3">
         Chat Model Selection
       </label>
       <select
         name="TTSElevenLabsVoiceModel"
         required={true}
-        className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
       >
         {Object.keys(groupedModels)
           .sort()

--- a/frontend/src/components/TextToSpeech/OpenAiGenericOptions/index.jsx
+++ b/frontend/src/components/TextToSpeech/OpenAiGenericOptions/index.jsx
@@ -6,31 +6,31 @@ export default function OpenAiGenericTextToSpeechOptions({ settings }) {
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
           <div className="flex justify-between items-start mb-2">
-            <label className="text-white text-sm font-semibold">Base URL</label>
+            <label className="text-foreground text-sm font-semibold">Base URL</label>
           </div>
           <input
             type="url"
             name="TTSOpenAICompatibleEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="http://localhost:7851/v1"
             defaultValue={settings?.TTSOpenAICompatibleEndpoint}
             required={false}
             autoComplete="off"
             spellCheck={false}
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             This should be the base URL of the OpenAI compatible TTS service you
             will generate TTS responses from.
           </p>
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-2">
+          <label className="text-foreground text-sm font-semibold block mb-2">
             API Key
           </label>
           <input
             type="password"
             name="TTSOpenAICompatibleKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="API Key"
             defaultValue={
               settings?.TTSOpenAICompatibleKey ? "*".repeat(20) : ""
@@ -38,7 +38,7 @@ export default function OpenAiGenericTextToSpeechOptions({ settings }) {
             autoComplete="off"
             spellCheck={false}
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Some TTS services require an API key to generate TTS responses -
             this is optional if your service does not require one.
           </p>
@@ -46,40 +46,40 @@ export default function OpenAiGenericTextToSpeechOptions({ settings }) {
       </div>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             TTS Model
           </label>
           <input
             type="text"
             name="TTSOpenAICompatibleModel"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Your TTS model identifier"
             defaultValue={settings?.TTSOpenAICompatibleModel}
             required={true}
             autoComplete="off"
             spellCheck={false}
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Most TTS services will have several models available. This is the{" "}
             <code>model</code> parameter you will use to select the model you
             want to use. Note: This is not the same as the voice model.
           </p>
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Voice Model
           </label>
           <input
             type="text"
             name="TTSOpenAICompatibleVoiceModel"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Your voice model identifier"
             defaultValue={settings?.TTSOpenAICompatibleVoiceModel}
             required={true}
             autoComplete="off"
             spellCheck={false}
           />
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60 mt-2">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60 mt-2">
             Most TTS services will have several voice models available, this is
             the identifier for the voice model you want to use.
           </p>

--- a/frontend/src/components/TextToSpeech/OpenAiOptions/index.jsx
+++ b/frontend/src/components/TextToSpeech/OpenAiOptions/index.jsx
@@ -10,13 +10,13 @@ export default function OpenAiTextToSpeechOptions({ settings }) {
   return (
     <div className="flex gap-x-4">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           API Key
         </label>
         <input
           type="password"
           name="TTSOpenAIKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="OpenAI API Key"
           defaultValue={apiKey ? "*".repeat(20) : ""}
           required={true}
@@ -25,13 +25,13 @@ export default function OpenAiTextToSpeechOptions({ settings }) {
         />
       </div>
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Voice Model
         </label>
         <select
           name="TTSOpenAIVoiceModel"
           defaultValue={settings?.TTSOpenAIVoiceModel ?? "alloy"}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           {["alloy", "echo", "fable", "onyx", "nova", "shimmer"].map(
             (voice) => {

--- a/frontend/src/components/TextToSpeech/PiperTTSOptions/index.jsx
+++ b/frontend/src/components/TextToSpeech/PiperTTSOptions/index.jsx
@@ -8,7 +8,7 @@ import { CircleNotch, PauseCircle, PlayCircle } from "@phosphor-icons/react";
 export default function PiperTTSOptions({ settings }) {
   return (
     <>
-      <p className="text-sm font-base text-white text-opacity-60 mb-4">
+      <p className="text-sm font-base text-foreground text-opacity-60 mb-4">
         All PiperTTS models will run in your browser locally. This can be
         resource intensive on lower-end devices.
       </p>
@@ -68,14 +68,14 @@ function PiperTTSModelSelection({ settings }) {
   if (loading) {
     return (
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Voice Model Selection
         </label>
         <select
           name="TTSPiperTTSVoiceModel"
           value=""
           disabled={true}
-          className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option value="" disabled={true}>
             -- loading available models --
@@ -88,7 +88,7 @@ function PiperTTSModelSelection({ settings }) {
   return (
     <div className="flex flex-col w-fit">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Voice Model Selection
         </label>
         <div className="flex items-center w-fit gap-x-4 mb-2">
@@ -97,7 +97,7 @@ function PiperTTSModelSelection({ settings }) {
             required={true}
             onChange={(e) => setSelectedVoice(e.target.value)}
             value={selectedVoice}
-            className="border-none flex-shrink-0 bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+            className="border-none flex-shrink-0 bg-theme-settings-input-bg border-border text-foreground text-sm rounded-lg block w-full p-2.5"
           >
             {voicesByLanguage(voices).map(([lang, voices]) => {
               return (
@@ -113,7 +113,7 @@ function PiperTTSModelSelection({ settings }) {
           </select>
           <DemoVoiceSample voiceId={selectedVoice} />
         </div>
-        <p className="text-xs text-white/40">
+        <p className="text-xs text-foreground/40">
           The "✔" indicates this model is already stored locally and does not
           need to be downloaded when run.
         </p>
@@ -122,7 +122,7 @@ function PiperTTSModelSelection({ settings }) {
         <button
           type="button"
           onClick={flushVoices}
-          className="w-fit border-none hover:text-white hover:underline text-white/40 text-sm my-4"
+          className="w-fit border-none hover:text-foreground hover:underline text-foreground/40 text-sm my-4"
         >
           Flush voice cache
         </button>
@@ -202,8 +202,8 @@ function DemoVoiceSample({ voiceId }) {
             </>
           ) : (
             <>
-              <PlayCircle size={20} className="flex-shrink-0 text-white" />
-              <p className="text-white text-sm flex-shrink-0">Play sample</p>
+              <PlayCircle size={20} className="flex-shrink-0 text-foreground" />
+              <p className="text-foreground text-sm flex-shrink-0">Play sample</p>
             </>
           )}
         </>

--- a/frontend/src/components/TranscriptionSelection/NativeTranscriptionOptions/index.jsx
+++ b/frontend/src/components/TranscriptionSelection/NativeTranscriptionOptions/index.jsx
@@ -11,14 +11,14 @@ export default function NativeTranscriptionOptions({ settings }) {
       <LocalWarning model={model} />
       <div className="w-full flex items-center gap-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             {t("common.selection")}
           </label>
           <select
             name="WhisperModelPref"
             defaultValue={model}
             onChange={(e) => setModel(e.target.value)}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-lg block w-full p-2.5"
           >
             {["Xenova/whisper-small", "Xenova/whisper-large"].map(
               (value, i) => {
@@ -51,7 +51,7 @@ function WhisperSmall() {
   const { t } = useTranslation();
 
   return (
-    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
       <div className="gap-x-2 flex items-center">
         <Gauge size={25} />
         <p className="text-sm">
@@ -71,7 +71,7 @@ function WhisperLarge() {
   const { t } = useTranslation();
 
   return (
-    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+    <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
       <div className="gap-x-2 flex items-center">
         <Gauge size={25} />
         <p className="text-sm">

--- a/frontend/src/components/TranscriptionSelection/OpenAiOptions/index.jsx
+++ b/frontend/src/components/TranscriptionSelection/OpenAiOptions/index.jsx
@@ -7,13 +7,13 @@ export default function OpenAiWhisperOptions({ settings }) {
   return (
     <div className="flex gap-x-7 gap-[36px] mt-1.5">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           API Key
         </label>
         <input
           type="password"
           name="OpenAiKey"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="OpenAI API Key"
           defaultValue={settings?.OpenAiKey ? "*".repeat(20) : ""}
           required={true}
@@ -24,12 +24,12 @@ export default function OpenAiWhisperOptions({ settings }) {
         />
       </div>
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           Whisper Model
         </label>
         <select
           disabled={true}
-          className="border-none flex-shrink-0 bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-sm block w-full p-2.5"
+          className="border-none flex-shrink-0 bg-theme-settings-input-bg border-border text-foreground text-sm rounded-sm block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             Whisper Large

--- a/frontend/src/components/UserMenu/AccountModal/index.jsx
+++ b/frontend/src/components/UserMenu/AccountModal/index.jsx
@@ -73,7 +73,7 @@ export default function AccountModal({ user, hideModal }) {
       <div className="modal__dialog">
         <div className="modal__header relative">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               {t("profile_settings.edit_account")}
             </h3>
           </div>
@@ -82,7 +82,7 @@ export default function AccountModal({ user, hideModal }) {
             type="button"
             className="btn btn--ghost absolute top-4 right-4 p-1"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <form onSubmit={handleUpdate}>
@@ -207,13 +207,13 @@ function LanguagePreference() {
     <div>
       <label
         htmlFor="userLang"
-        className="block mb-2 text-sm font-medium text-white"
+        className="block mb-2 text-sm font-medium text-foreground"
       >
         {t("profile_settings.language")}
       </label>
       <select
         name="userLang"
-        className="border-none bg-theme-settings-input-bg w-fit mt-2 px-4 focus:outline-primary-button active:outline-primary-button outline-none text-white text-sm rounded-sm block py-2"
+        className="border-none bg-theme-settings-input-bg w-fit mt-2 px-4 focus:outline-primary-button active:outline-primary-button outline-none text-foreground text-sm rounded-sm block py-2"
         defaultValue={currentLanguage || "en"}
         onChange={(e) => changeLanguage(e.target.value)}
       >
@@ -236,7 +236,7 @@ function ThemePreference() {
     <div>
       <label
         htmlFor="theme"
-        className="block mb-2 text-sm font-medium text-white"
+        className="block mb-2 text-sm font-medium text-foreground"
       >
         {t("profile_settings.theme")}
       </label>
@@ -244,7 +244,7 @@ function ThemePreference() {
         name="theme"
         value={theme}
         onChange={(e) => setTheme(e.target.value)}
-        className="border-none bg-theme-settings-input-bg w-fit px-4 focus:outline-primary-button active:outline-primary-button outline-none text-white text-sm rounded-lg block py-2"
+        className="border-none bg-theme-settings-input-bg w-fit px-4 focus:outline-primary-button active:outline-primary-button outline-none text-foreground text-sm rounded-lg block py-2"
       >
         {Object.entries(availableThemes).map(([key, value]) => (
           <option key={key} value={key}>
@@ -276,7 +276,7 @@ function AutoSubmitPreference() {
       <div className="flex items-center gap-x-1 mb-2">
         <label
           htmlFor="autoSubmit"
-          className="block text-sm font-medium text-white"
+          className="block text-sm font-medium text-foreground"
         >
           {t("customization.chat.auto_submit.title")}
         </label>
@@ -285,7 +285,7 @@ function AutoSubmitPreference() {
           data-tooltip-content={t("customization.chat.auto_submit.description")}
           className="cursor-pointer h-fit"
         >
-          <Info size={16} weight="bold" className="text-white" />
+          <Info size={16} weight="bold" className="text-foreground" />
         </div>
       </div>
       <div className="flex items-center gap-x-4">
@@ -298,7 +298,7 @@ function AutoSubmitPreference() {
             onChange={handleChange}
             className="peer sr-only"
           />
-          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
         </label>
       </div>
       <Tooltip
@@ -334,7 +334,7 @@ function AutoSpeakPreference() {
       <div className="flex items-center gap-x-1 mb-2">
         <label
           htmlFor="autoSpeak"
-          className="block text-sm font-medium text-white"
+          className="block text-sm font-medium text-foreground"
         >
           {t("customization.chat.auto_speak.title")}
         </label>
@@ -343,7 +343,7 @@ function AutoSpeakPreference() {
           data-tooltip-content={t("customization.chat.auto_speak.description")}
           className="cursor-pointer h-fit"
         >
-          <Info size={16} weight="bold" className="text-white" />
+          <Info size={16} weight="bold" className="text-foreground" />
         </div>
       </div>
       <div className="flex items-center gap-x-4">
@@ -356,7 +356,7 @@ function AutoSpeakPreference() {
             onChange={handleChange}
             className="peer sr-only"
           />
-          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+          <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
         </label>
       </div>
       <Tooltip

--- a/frontend/src/components/VectorDBSelection/AstraDBOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/AstraDBOptions/index.jsx
@@ -3,13 +3,13 @@ export default function AstraDBOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Astra DB Endpoint
           </label>
           <input
             type="url"
             name="AstraDBEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Astra DB API endpoint"
             defaultValue={settings?.AstraDBEndpoint}
             required={true}
@@ -19,13 +19,13 @@ export default function AstraDBOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Astra DB Application Token
           </label>
           <input
             type="password"
             name="AstraDBApplicationToken"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="AstraCS:..."
             defaultValue={
               settings?.AstraDBApplicationToken ? "*".repeat(20) : ""

--- a/frontend/src/components/VectorDBSelection/ChromaDBOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/ChromaDBOptions/index.jsx
@@ -3,13 +3,13 @@ export default function ChromaDBOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Chroma Endpoint
           </label>
           <input
             type="url"
             name="ChromaEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="http://localhost:8000"
             defaultValue={settings?.ChromaEndpoint}
             required={true}
@@ -19,7 +19,7 @@ export default function ChromaDBOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Header
           </label>
           <input
@@ -27,13 +27,13 @@ export default function ChromaDBOptions({ settings }) {
             autoComplete="off"
             type="text"
             defaultValue={settings?.ChromaApiHeader}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="X-Api-Key"
           />
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
@@ -41,7 +41,7 @@ export default function ChromaDBOptions({ settings }) {
             autoComplete="off"
             type="password"
             defaultValue={settings?.ChromaApiKey ? "*".repeat(20) : ""}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="sk-myApiKeyToAccessMyChromaInstance"
           />
         </div>

--- a/frontend/src/components/VectorDBSelection/LanceDBOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/LanceDBOptions/index.jsx
@@ -3,7 +3,7 @@ export default function LanceDBOptions() {
   const { t } = useTranslation();
   return (
     <div className="w-full h-10 items-center flex">
-      <p className="text-sm font-base text-white text-opacity-60">
+      <p className="text-sm font-base text-foreground text-opacity-60">
         {t("vector.provider.description")}
       </p>
     </div>

--- a/frontend/src/components/VectorDBSelection/MilvusDBOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/MilvusDBOptions/index.jsx
@@ -3,13 +3,13 @@ export default function MilvusDBOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Milvus DB Address
           </label>
           <input
             type="text"
             name="MilvusAddress"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="http://localhost:19530"
             defaultValue={settings?.MilvusAddress}
             required={true}
@@ -19,13 +19,13 @@ export default function MilvusDBOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Milvus Username
           </label>
           <input
             type="text"
             name="MilvusUsername"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="username"
             defaultValue={settings?.MilvusUsername}
             autoComplete="off"
@@ -33,13 +33,13 @@ export default function MilvusDBOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Milvus Password
           </label>
           <input
             type="password"
             name="MilvusPassword"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="password"
             defaultValue={settings?.MilvusPassword ? "*".repeat(20) : ""}
             autoComplete="off"

--- a/frontend/src/components/VectorDBSelection/PGVectorOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/PGVectorOptions/index.jsx
@@ -7,7 +7,7 @@ export default function PGVectorOptions({ settings }) {
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-96">
           <div className="flex items-center gap-x-1 mb-3">
-            <label className="text-white text-sm font-semibold block">
+            <label className="text-foreground text-sm font-semibold block">
               Postgres Connection String
             </label>
             <Info
@@ -45,7 +45,7 @@ export default function PGVectorOptions({ settings }) {
           <input
             type="text"
             name="PGVectorConnectionString"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="postgresql://username:password@host:port/database"
             defaultValue={
               settings?.PGVectorConnectionString ? "*".repeat(20) : ""
@@ -58,7 +58,7 @@ export default function PGVectorOptions({ settings }) {
 
         <div className="flex flex-col w-60">
           <div className="flex items-center gap-x-1 mb-3">
-            <label className="text-white text-sm font-semibold block">
+            <label className="text-foreground text-sm font-semibold block">
               Vector Table Name
             </label>
             <Info
@@ -93,7 +93,7 @@ export default function PGVectorOptions({ settings }) {
             name="PGVectorTableName"
             autoComplete="off"
             defaultValue={settings?.PGVectorTableName}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="vector_table"
           />
         </div>

--- a/frontend/src/components/VectorDBSelection/PineconeDBOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/PineconeDBOptions/index.jsx
@@ -3,13 +3,13 @@ export default function PineconeDBOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Pinecone DB API Key
           </label>
           <input
             type="password"
             name="PineConeKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Pinecone API Key"
             defaultValue={settings?.PineConeKey ? "*".repeat(20) : ""}
             required={true}
@@ -18,13 +18,13 @@ export default function PineconeDBOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Pinecone Index Name
           </label>
           <input
             type="text"
             name="PineConeIndex"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="my-index"
             defaultValue={settings?.PineConeIndex}
             required={true}

--- a/frontend/src/components/VectorDBSelection/QDrantDBOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/QDrantDBOptions/index.jsx
@@ -3,13 +3,13 @@ export default function QDrantDBOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             QDrant API Endpoint
           </label>
           <input
             type="url"
             name="QdrantEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="http://localhost:6633"
             defaultValue={settings?.QdrantEndpoint}
             required={true}
@@ -19,13 +19,13 @@ export default function QDrantDBOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="QdrantApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="wOeqxsYP4....1244sba"
             defaultValue={settings?.QdrantApiKey}
             autoComplete="off"

--- a/frontend/src/components/VectorDBSelection/VectorDBItem/index.jsx
+++ b/frontend/src/components/VectorDBSelection/VectorDBItem/index.jsx
@@ -28,7 +28,7 @@ export default function VectorDBItem({
           className="w-10 h-10 rounded-md"
         />
         <div className="flex flex-col">
-          <div className="text-sm font-semibold text-white">{name}</div>
+          <div className="text-sm font-semibold text-foreground">{name}</div>
           <div className="mt-1 text-xs text-description">{description}</div>
         </div>
       </div>

--- a/frontend/src/components/VectorDBSelection/WeaviateDBOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/WeaviateDBOptions/index.jsx
@@ -3,13 +3,13 @@ export default function WeaviateDBOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-7">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Weaviate Endpoint
           </label>
           <input
             type="url"
             name="WeaviateEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="http://localhost:8080"
             defaultValue={settings?.WeaviateEndpoint}
             required={true}
@@ -19,13 +19,13 @@ export default function WeaviateDBOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="WeaviateApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="sk-123Abcweaviate"
             defaultValue={settings?.WeaviateApiKey}
             autoComplete="off"

--- a/frontend/src/components/VectorDBSelection/ZillizCloudOptions/index.jsx
+++ b/frontend/src/components/VectorDBSelection/ZillizCloudOptions/index.jsx
@@ -3,13 +3,13 @@ export default function ZillizCloudOptions({ settings }) {
     <div className="w-full flex flex-col gap-y-4">
       <div className="w-full flex items-center gap-[36px] mt-1.5">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Cluster Endpoint
           </label>
           <input
             type="text"
             name="ZillizEndpoint"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="https://sample.api.gcp-us-west1.zillizcloud.com"
             defaultValue={settings?.ZillizEndpoint}
             required={true}
@@ -19,13 +19,13 @@ export default function ZillizCloudOptions({ settings }) {
         </div>
 
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Token
           </label>
           <input
             type="password"
             name="ZillizApiToken"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Zilliz cluster API Token"
             defaultValue={settings?.ZillizApiToken ? "*".repeat(20) : ""}
             autoComplete="off"

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Chartable/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Chartable/index.jsx
@@ -75,7 +75,7 @@ export function Chartable({ props, workspace }) {
     switch (chartType) {
       case "area":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -92,7 +92,7 @@ export function Chartable({ props, workspace }) {
         );
       case "bar":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -111,7 +111,7 @@ export function Chartable({ props, workspace }) {
         );
       case "line":
         return (
-          <div className="bg-theme-bg-primary p-8 pb-12 rounded-xl text-white h-[500px] w-full light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 pb-12 rounded-xl text-foreground h-[500px] w-full light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -128,7 +128,7 @@ export function Chartable({ props, workspace }) {
         );
       case "composed":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -186,7 +186,7 @@ export function Chartable({ props, workspace }) {
         );
       case "scatter":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -234,7 +234,7 @@ export function Chartable({ props, workspace }) {
         );
       case "pie":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -260,7 +260,7 @@ export function Chartable({ props, workspace }) {
         );
       case "radar":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -296,7 +296,7 @@ export function Chartable({ props, workspace }) {
         );
       case "radialbar":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -333,7 +333,7 @@ export function Chartable({ props, workspace }) {
         );
       case "treemap":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -361,7 +361,7 @@ export function Chartable({ props, workspace }) {
         );
       case "funnel":
         return (
-          <div className="bg-theme-bg-primary p-8 rounded-xl text-white light:border light:border-theme-border-primary">
+          <div className="bg-theme-bg-primary p-8 rounded-xl text-foreground light:border light:border-theme-border-primary">
             <h3 className="text-lg text-theme-text-primary font-medium">
               {title}
             </h3>
@@ -433,7 +433,7 @@ const customTooltip = (props) => {
   const categoryPayload = payload?.[0];
   if (!categoryPayload) return null;
   return (
-    <div className="w-56 bg-theme-bg-primary rounded-lg border p-2 text-white">
+    <div className="w-56 bg-theme-bg-primary rounded-lg border p-2 text-foreground">
       <div className="flex flex-1 space-x-2.5">
         <div
           className={`flex w-1.5 flex-col bg-${categoryPayload?.color}-500 rounded`}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Citation/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/Citation/index.jsx
@@ -52,9 +52,9 @@ export default function Citations({ sources = [] }) {
     <div className="flex flex-col mt-4 justify-left">
       <button
         onClick={() => setOpen(!open)}
-        className={`border-none font-semibold text-white/50 light:text-foreground font-medium italic ${textSizeClass} text-left ml-14 pt-2 ${
+        className={`border-none font-semibold text-foreground/50 light:text-foreground font-medium italic ${textSizeClass} text-left ml-14 pt-2 ${
           open ? "pb-2" : ""
-        } hover:text-white/75 hover:light:text-foreground transition-all duration-300`}
+        } hover:text-foreground/75 hover:light:text-foreground transition-all duration-300`}
       >
         {open
           ? t("chat_window.hide_citations")
@@ -140,7 +140,7 @@ function CitationDetailModal({ source, onClose }) {
                 href={linkTo}
                 target="_blank"
                 rel="noreferrer"
-                className="text-xl w-[90%] font-semibold text-white whitespace-nowrap hover:underline hover:text-blue-300 flex items-center gap-x-1"
+                className="text-xl w-[90%] font-semibold text-foreground whitespace-nowrap hover:underline hover:text-blue-300 flex items-center gap-x-1"
               >
                 <div className="flex items-center gap-x-1 max-w-full overflow-hidden">
                   <h3 className="truncate text-ellipsis whitespace-nowrap overflow-hidden w-full">
@@ -150,13 +150,13 @@ function CitationDetailModal({ source, onClose }) {
                 </div>
               </a>
             ) : (
-              <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+              <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
                 {truncate(title, 45)}
               </h3>
             )}
           </div>
           {references > 1 && (
-            <p className="text-xs text-gray-400 mt-2">
+            <p className="text-xs text-foreground mt-2">
               Referenced {references} times.
             </p>
           )}
@@ -165,7 +165,7 @@ function CitationDetailModal({ source, onClose }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div
@@ -175,14 +175,14 @@ function CitationDetailModal({ source, onClose }) {
           <div className="py-7 px-9 space-y-2 flex-col">
             {chunks.map(({ text, score }, idx) => (
               <>
-                <div key={idx} className="pt-6 text-white">
+                <div key={idx} className="pt-6 text-foreground">
                   <div className="flex flex-col w-full justify-start pb-6 gap-y-1">
-                    <p className="text-white whitespace-pre-line">
+                    <p className="text-foreground whitespace-pre-line">
                       {HTMLDecode(omitChunkHeader(text))}
                     </p>
 
                     {!!score && (
-                      <div className="w-full flex items-center text-xs text-white/60 gap-x-2 cursor-default">
+                      <div className="w-full flex items-center text-xs text-foreground/60 gap-x-2 cursor-default">
                         <div
                           data-tooltip-id="similarity-score"
                           data-tooltip-content={`This is the semantic similarity score of this chunk of text compared to your query calculated by the vector database.`}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/ActionMenu/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/ActionMenu/index.jsx
@@ -48,17 +48,17 @@ function ActionMenu({ chatId, forkThread, isEditing, role }) {
         <DotsThreeVertical size={24} weight="bold" />
       </button>
       {open && (
-        <div className="absolute -top-1 left-7 mt-1 border-[1.5px] border-white/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-white z-99 md:z-10">
+        <div className="absolute -top-1 left-7 mt-1 border-[1.5px] border-border/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-foreground z-99 md:z-10">
           <button
             onClick={handleFork}
-            className="border-none rounded-t-lg flex items-center text-white gap-x-2 hover:bg-theme-action-menu-item-hover py-1.5 px-2 transition-colors duration-200 w-full text-left"
+            className="border-none rounded-t-lg flex items-center text-foreground gap-x-2 hover:bg-theme-action-menu-item-hover py-1.5 px-2 transition-colors duration-200 w-full text-left"
           >
             <TreeView size={18} />
             <span className="text-sm">{t("chat_window.fork")}</span>
           </button>
           <button
             onClick={handleDelete}
-            className="border-none flex rounded-b-lg items-center text-white gap-x-2 hover:bg-theme-action-menu-item-hover py-1.5 px-2 transition-colors duration-200 w-full text-left"
+            className="border-none flex rounded-b-lg items-center text-foreground gap-x-2 hover:bg-theme-action-menu-item-hover py-1.5 px-2 transition-colors duration-200 w-full text-left"
           >
             <Trash size={18} />
             <span className="text-sm">{t("chat_window.delete")}</span>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/EditMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/Actions/EditMessage/index.jsx
@@ -101,20 +101,20 @@ export function EditMessageForm({
         ref={formRef}
         name="editedMessage"
         spellCheck={Appearance.get("enableSpellCheck")}
-        className="text-white w-full rounded bg-theme-bg-secondary border border-white/20 active:outline-none focus:outline-none focus:ring-0 pr-16 pl-1.5 pt-1.5 resize-y"
+        className="text-foreground w-full rounded bg-theme-bg-secondary border border-border/20 active:outline-none focus:outline-none focus:ring-0 pr-16 pl-1.5 pt-1.5 resize-y"
         defaultValue={message}
         onChange={adjustTextArea}
       />
       <div className="mt-3 flex justify-center">
         <button
           type="submit"
-          className="border-none px-2 py-1 bg-gray-200 text-gray-700 font-medium rounded-md mr-2 hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          className="border-none px-2 py-1 bg-background text-foreground font-medium rounded-md mr-2 hover:bg-background focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
         >
           {t("chat_window.save_submit")}
         </button>
         <button
           type="button"
-          className="border-none px-2 py-1 bg-historical-msg-system text-white font-medium rounded-md hover:bg-historical-msg-user/90 light:hover:text-white focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
+          className="border-none px-2 py-1 bg-historical-msg-system text-foreground font-medium rounded-md hover:bg-historical-msg-user/90 light:hover:text-foreground focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
           onClick={cancelEdits}
         >
           {t("chat_window.cancel")}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -183,11 +183,11 @@ export default function ChatHistory({
     return (
       <div className="chat__messages flex flex-col md:mt-0 pb-44 md:pb-40 w-full justify-end items-center">
         <div className="flex flex-col items-center md:items-start md:max-w-[600px] w-full px-4">
-          <p className="text-white/60 text-lg font-base py-4">
+          <p className="text-foreground/60 text-lg font-base py-4">
             {t("chat_window.welcome")}
           </p>
           {!user || user.role !== "default" ? (
-            <p className="w-full items-center text-white/60 text-lg font-base flex flex-col md:flex-row gap-x-1">
+            <p className="w-full items-center text-foreground/60 text-lg font-base flex flex-col md:flex-row gap-x-1">
               {t("chat_window.get_started")}
               <span
                 className="underline font-medium cursor-pointer"
@@ -199,7 +199,7 @@ export default function ChatHistory({
               <b className="font-medium italic">{t("chat_window.send_chat")}</b>
             </p>
           ) : (
-            <p className="w-full items-center text-white/60 text-lg font-base flex flex-col md:flex-row gap-x-1">
+            <p className="w-full items-center text-foreground/60 text-lg font-base flex flex-col md:flex-row gap-x-1">
               {t("chat_window.get_started_default")}{" "}
               <b className="font-medium italic">{t("chat_window.send_chat")}</b>
             </p>
@@ -221,7 +221,7 @@ export default function ChatHistory({
 
   return (
     <div
-      className={`chat__messages chat-messages markdown text-white/80 light:text-theme-text-primary font-light ${textSizeClass} pt-6 md:pt-0 md:mx-0 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
+      className={`chat__messages chat-messages markdown text-foreground/80 light:text-theme-text-primary font-light ${textSizeClass} pt-6 md:pt-0 md:mx-0 flex flex-col justify-start ${showScrollbar ? "show-scrollbar" : "no-scroll"}`}
       id="chat-history"
       ref={chatHistoryRef}
       onScroll={handleScroll}
@@ -236,13 +236,13 @@ export default function ChatHistory({
         <div className="fixed bottom-40 right-10 md:right-20 z-50 cursor-pointer animate-pulse">
           <div className="flex flex-col items-center">
             <div
-              className="p-1 rounded-full border border-white/10 bg-card hover:bg-card hover:text-white"
+              className="p-1 rounded-full border border-border/10 bg-card hover:bg-card hover:text-foreground"
               onClick={() => {
                 scrollToBottom(true);
                 setIsUserScrolling(false);
               }}
             >
-              <ArrowDown weight="bold" className="text-white/60 w-5 h-5" />
+              <ArrowDown weight="bold" className="text-foreground/60 w-5 h-5" />
             </div>
           </div>
         </div>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
@@ -236,15 +236,15 @@ export default function DnDFileUploaderWrapper({ children }) {
     >
       <div
         hidden={!dragging}
-        className="absolute top-0 w-full h-full bg-dark-text/90 light:bg-[#C2E7FE]/90 rounded-2xl border-[4px] border-white z-[9999]"
+        className="absolute top-0 w-full h-full bg-dark-text/90 light:bg-[#C2E7FE]/90 rounded-2xl border-[4px] border-border z-[9999]"
       >
         <div className="w-full h-full flex justify-center items-center rounded-xl">
           <div className="flex flex-col gap-y-[14px] justify-center items-center">
             <img src={DndIcon} width={69} height={69} />
-            <p className="text-white text-[24px] font-semibold">
+            <p className="text-foreground text-[24px] font-semibold">
               Add {canUploadAll ? "anything" : "an image"}
             </p>
-            <p className="text-white text-[16px] text-center">
+            <p className="text-foreground text-[16px] text-center">
               {canUploadAll ? (
                 <>
                   Drop your file here to embed it into your <br />

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
@@ -207,7 +207,7 @@ function AttachmentItem({ attachment }) {
             />
           </div>
           <div className="flex flex-col w-[125px]">
-            <p className="text-white text-xs font-semibold truncate">
+            <p className="text-foreground text-xs font-semibold truncate">
               {file.name}
             </p>
             <p className="text-theme-attachment-text-secondary text-[10px] leading-[14px] font-medium">

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/ChatModelSelection/index.jsx
@@ -23,7 +23,7 @@ export default function ChatModelSelection({
               provider,
             })}
           </label>
-          <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+          <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
             {t(
               "chat_window.workspace_llm_manager.available_models_description"
             )}
@@ -32,7 +32,7 @@ export default function ChatModelSelection({
         <select
           required={true}
           disabled={true}
-          className="border-theme-modal-border border border-solid bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-theme-modal-border border border-solid bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- waiting for models --
@@ -50,7 +50,7 @@ export default function ChatModelSelection({
             provider,
           })}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("chat_window.workspace_llm_manager.available_models_description")}
         </p>
       </div>
@@ -63,7 +63,7 @@ export default function ChatModelSelection({
           setHasChanges(true);
           setSelectedLLMModel(e.target.value);
         }}
-        className="border-theme-modal-border border border-solid bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-theme-modal-border border border-solid bg-theme-settings-input-bg text-foreground text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
       >
         {defaultModels.length > 0 && (
           <optgroup label="General models">

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/LLMSelector/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/LLMSelector/index.jsx
@@ -15,7 +15,7 @@ export default function LLMSelectorSidePanel({
         type="search"
         placeholder={t("chat_window.workspace_llm_manager.search")}
         onChange={onSearchChange}
-        className="search-input bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder outline-none text-sm rounded-sm px-2 py-2 w-full h-[32px] border-theme-modal-border border border-solid"
+        className="search-input bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder outline-none text-sm rounded-sm px-2 py-2 w-full h-[32px] border-theme-modal-border border border-solid"
       />
       <div className="flex flex-col gap-y-2 overflow-y-scroll ">
         {availableProviders.map((llm) => (

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/SetupProvider/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/SetupProvider/index.jsx
@@ -40,7 +40,7 @@ export default function SetupProvider({
         <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
           <div className="relative p-6 border-b rounded-t border-theme-modal-border">
             <div className="w-full flex gap-x-2 items-center">
-              <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+              <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
                 {llmProvider.name} Settings
               </h3>
             </div>
@@ -49,13 +49,13 @@ export default function SetupProvider({
               type="button"
               className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
             >
-              <X size={24} weight="bold" className="text-white" />
+              <X size={24} weight="bold" className="text-foreground" />
             </button>
           </div>
           <form id="provider-form" onSubmit={handleUpdate}>
             <div className="px-7 py-6">
               <div className="space-y-6 max-h-[60vh] overflow-y-auto p-1">
-                <p className="text-sm text-white/60">
+                <p className="text-sm text-foreground/60">
                   To use {llmProvider.name} as this workspace's LLM you need to
                   set it up first.
                 </p>
@@ -68,7 +68,7 @@ export default function SetupProvider({
               <button
                 type="button"
                 onClick={closeModal}
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/LLMSelector/index.jsx
@@ -138,7 +138,7 @@ export default function LLMSelectorModal() {
             type="button"
             disabled={saving}
             onClick={handleSave}
-            className={`border-none text-xs px-4 py-1 font-semibold light:text-[#ffffff] rounded-lg bg-primary-button hover:bg-secondary hover:text-white h-[34px] whitespace-nowrap w-full`}
+            className={`border-none text-xs px-4 py-1 font-semibold light:text-[#ffffff] rounded-lg bg-primary-button hover:bg-secondary hover:text-foreground h-[34px] whitespace-nowrap w-full`}
           >
             {saving
               ? t("chat_window.workspace_llm_manager.saving")

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/SlashPresets/AddPresetModal.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/SlashPresets/AddPresetModal.jsx
@@ -30,7 +30,7 @@ export default function AddPresetModal({ isOpen, onClose, onSave }) {
       <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               {t("chat_window.add_new_preset")}
             </h3>
           </div>
@@ -39,7 +39,7 @@ export default function AddPresetModal({ isOpen, onClose, onSave }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div
@@ -52,12 +52,12 @@ export default function AddPresetModal({ isOpen, onClose, onSave }) {
                 <div>
                   <label
                     htmlFor="command"
-                    className="block mb-2 text-sm font-medium text-white"
+                    className="block mb-2 text-sm font-medium text-foreground"
                   >
                     {t("chat_window.command")}
                   </label>
                   <div className="flex items-center">
-                    <span className="text-white text-sm mr-2 font-bold">/</span>
+                    <span className="text-foreground text-sm mr-2 font-bold">/</span>
                     <input
                       name="command"
                       type="text"
@@ -68,14 +68,14 @@ export default function AddPresetModal({ isOpen, onClose, onSave }) {
                       maxLength={25}
                       autoComplete="off"
                       required={true}
-                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     />
                   </div>
                 </div>
                 <div>
                   <label
                     htmlFor="prompt"
-                    className="block mb-2 text-sm font-medium text-white"
+                    className="block mb-2 text-sm font-medium text-foreground"
                   >
                     Prompt
                   </label>
@@ -85,13 +85,13 @@ export default function AddPresetModal({ isOpen, onClose, onSave }) {
                     autoComplete="off"
                     placeholder={t("chat_window.placeholder_prompt")}
                     required={true}
-                    className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   ></textarea>
                 </div>
                 <div>
                   <label
                     htmlFor="description"
-                    className="block mb-2 text-sm font-medium text-white"
+                    className="block mb-2 text-sm font-medium text-foreground"
                   >
                     {t("chat_window.description")}
                   </label>
@@ -103,7 +103,7 @@ export default function AddPresetModal({ isOpen, onClose, onSave }) {
                     maxLength={80}
                     autoComplete="off"
                     required={true}
-                    className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   />
                 </div>
               </div>
@@ -112,7 +112,7 @@ export default function AddPresetModal({ isOpen, onClose, onSave }) {
               <button
                 onClick={onClose}
                 type="button"
-                className="transition-all duration-300 bg-transparent text-white hover:opacity-60 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 bg-transparent text-foreground hover:opacity-60 px-4 py-2 rounded-sm text-sm"
               >
                 {t("chat_window.cancel")}
               </button>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/SlashPresets/EditPresetModal.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/SlashPresets/EditPresetModal.jsx
@@ -50,7 +50,7 @@ export default function EditPresetModal({
       <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Edit Preset
             </h3>
           </div>
@@ -59,7 +59,7 @@ export default function EditPresetModal({
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div
@@ -72,12 +72,12 @@ export default function EditPresetModal({
                 <div>
                   <label
                     htmlFor="command"
-                    className="block mb-2 text-sm font-medium text-white"
+                    className="block mb-2 text-sm font-medium text-foreground"
                   >
                     Command
                   </label>
                   <div className="flex items-center">
-                    <span className="text-white text-sm mr-2 font-bold">/</span>
+                    <span className="text-foreground text-sm mr-2 font-bold">/</span>
                     <input
                       type="text"
                       name="command"
@@ -85,14 +85,14 @@ export default function EditPresetModal({
                       value={command}
                       onChange={handleCommandChange}
                       required={true}
-                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     />
                   </div>
                 </div>
                 <div>
                   <label
                     htmlFor="prompt"
-                    className="block mb-2 text-sm font-medium text-white"
+                    className="block mb-2 text-sm font-medium text-foreground"
                   >
                     Prompt
                   </label>
@@ -101,13 +101,13 @@ export default function EditPresetModal({
                     placeholder="This is a test prompt. Please respond with a poem about LLMs."
                     defaultValue={preset.prompt}
                     required={true}
-                    className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   ></textarea>
                 </div>
                 <div>
                   <label
                     htmlFor="description"
-                    className="block mb-2 text-sm font-medium text-white"
+                    className="block mb-2 text-sm font-medium text-foreground"
                   >
                     Description
                   </label>
@@ -117,7 +117,7 @@ export default function EditPresetModal({
                     defaultValue={preset.description}
                     placeholder="Responds with a poem about LLMs."
                     required={true}
-                    className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   />
                 </div>
               </div>
@@ -135,7 +135,7 @@ export default function EditPresetModal({
                 <button
                   onClick={onClose}
                   type="button"
-                  className="border-none transition-all duration-300 bg-transparent text-white hover:opacity-60 px-4 py-2 rounded-sm text-sm"
+                  className="border-none transition-all duration-300 bg-transparent text-foreground hover:opacity-60 px-4 py-2 rounded-sm text-sm"
                 >
                   Cancel
                 </button>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/SlashPresets/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/SlashPresets/index.jsx
@@ -217,7 +217,7 @@ function PresetItem({ preset, onUse, onEdit, onPublish }) {
         >
           <button
             type="button"
-            className="px-[10px] py-[6px] text-sm text-white hover:bg-theme-sidebar-item-hover rounded-t-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
+            className="px-[10px] py-[6px] text-sm text-foreground hover:bg-theme-sidebar-item-hover rounded-t-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
             onClick={(e) => {
               e.stopPropagation();
               setShowMenu(false);
@@ -228,7 +228,7 @@ function PresetItem({ preset, onUse, onEdit, onPublish }) {
           </button>
           <button
             type="button"
-            className="px-[10px] py-[6px] text-sm text-white hover:bg-theme-sidebar-item-hover rounded-b-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
+            className="px-[10px] py-[6px] text-sm text-foreground hover:bg-theme-sidebar-item-hover rounded-b-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
             onClick={(e) => {
               e.stopPropagation();
               setShowMenu(false);

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/endAgentSession.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/endAgentSession.jsx
@@ -13,8 +13,8 @@ export default function EndAgentSession({ setShowing, sendCommand }) {
       className="border-none w-full hover:cursor-pointer hover:bg-theme-action-menu-item-hover px-2 py-2 rounded-xl flex flex-col justify-start"
     >
       <div className="w-full flex-col text-left flex pointer-events-none">
-        <div className="text-white text-sm font-bold">/exit</div>
-        <div className="text-white text-opacity-60 text-sm">
+        <div className="text-foreground text-sm font-bold">/exit</div>
+        <div className="text-foreground text-opacity-60 text-sm">
           Halt the current agent session.
         </div>
       </div>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/reset.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/SlashCommands/reset.jsx
@@ -15,10 +15,10 @@ export default function ResetCommand({ setShowing, sendCommand }) {
       className="border-none w-full hover:cursor-pointer hover:bg-theme-action-menu-item-hover px-2 py-2 rounded-xl flex flex-col justify-start"
     >
       <div className="w-full flex-col text-left flex pointer-events-none">
-        <div className="text-white text-sm font-bold">
+        <div className="text-foreground text-sm font-bold">
           {t("chat_window.slash_reset")}
         </div>
-        <div className="text-white text-opacity-60 text-sm">
+        <div className="text-foreground text-opacity-60 text-sm">
           {t("chat_window.preset_reset_description")}
         </div>
       </div>

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/StopGenerationButton/index.jsx
@@ -13,7 +13,7 @@ export default function StopGenerationButton() {
         onClick={emitHaltEvent}
         data-tooltip-id="stop-generation-button"
         data-tooltip-content="Stop generating response"
-        className="border-none cursor-pointer group -mr-1.5 mt-1.5 h-10 w-10 flex items-center justify-center rounded text-white group-hover:text-primary-button light:text-theme-text-secondary light:group-hover:text-primary-button focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-chat"
+        className="border-none cursor-pointer group -mr-1.5 mt-1.5 h-10 w-10 flex items-center justify-center rounded text-foreground group-hover:text-primary-button light:text-theme-text-secondary light:group-hover:text-primary-button focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg-chat"
         aria-label="Stop generating"
       >
         <svg

--- a/frontend/src/components/WorkspaceChat/index.jsx
+++ b/frontend/src/components/WorkspaceChat/index.jsx
@@ -55,7 +55,7 @@ export default function WorkspaceChat({ loading, workspace }) {
                 </div>
               </div>
               <div className="py-7 px-9 space-y-2 flex-col">
-                <p className="text-white text-sm">
+                <p className="text-foreground text-sm">
                   The workspace you're looking for is not available. It may have
                   been deleted or you may not have access to it.
                 </p>

--- a/frontend/src/components/lib/CTAButton/index.jsx
+++ b/frontend/src/components/lib/CTAButton/index.jsx
@@ -8,7 +8,7 @@ export default function CTAButton({
     <button
       disabled={disabled}
       onClick={() => onClick?.()}
-      className={`border-none text-xs px-4 py-1 font-semibold light:text-[#ffffff] rounded-lg bg-primary-button hover:bg-secondary hover:text-white h-[34px] -mr-8 whitespace-nowrap w-fit ${className}`}
+      className={`border-none text-xs px-4 py-1 font-semibold light:text-[#ffffff] rounded-lg bg-primary-button hover:bg-secondary hover:text-foreground h-[34px] -mr-8 whitespace-nowrap w-fit ${className}`}
     >
       <div className="flex items-center justify-center gap-2">{children}</div>
     </button>

--- a/frontend/src/pages/Admin/AgentBuilder/AddBlockMenu/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/AddBlockMenu/index.jsx
@@ -43,7 +43,7 @@ export default function AddBlockMenu({
     <div className="relative mt-4 w-[280px] mx-auto pb-[50%]" ref={menuRef}>
       <button
         onClick={() => setShowBlockMenu(!showBlockMenu)}
-        className="transition-all duration-300 w-full p-2.5 bg-theme-action-menu-bg hover:bg-theme-action-menu-item-hover border border-white/10 rounded-lg text-white flex items-center justify-center gap-2 text-sm font-medium"
+        className="transition-all duration-300 w-full p-2.5 bg-theme-action-menu-bg hover:bg-theme-action-menu-item-hover border border-border/10 rounded-lg text-foreground flex items-center justify-center gap-2 text-sm font-medium"
       >
         <Plus className="w-4 h-4" />
         Add Block
@@ -52,7 +52,7 @@ export default function AddBlockMenu({
         />
       </button>
       {showBlockMenu && (
-        <div className="absolute left-0 right-0 mt-2 bg-theme-action-menu-bg border border-white/10 rounded-lg shadow-lg overflow-hidden z-10 animate-fadeUpIn">
+        <div className="absolute left-0 right-0 mt-2 bg-theme-action-menu-bg border border-border/10 rounded-lg shadow-lg overflow-hidden z-10 animate-fadeUpIn">
           {Object.entries(BLOCK_INFO).map(
             ([type, info]) =>
               type !== BLOCK_TYPES.START &&
@@ -64,14 +64,14 @@ export default function AddBlockMenu({
                     addBlock(type);
                     setShowBlockMenu(false);
                   }}
-                  className="w-full p-2.5 flex items-center gap-3 hover:bg-theme-action-menu-item-hover text-white transition-colors duration-300 group"
+                  className="w-full p-2.5 flex items-center gap-3 hover:bg-theme-action-menu-item-hover text-foreground transition-colors duration-300 group"
                 >
                   <div className="w-7 h-7 rounded-lg bg-card flex items-center justify-center">
-                    <div className="w-fit h-fit text-white">{info.icon}</div>
+                    <div className="w-fit h-fit text-foreground">{info.icon}</div>
                   </div>
                   <div className="text-left flex-1">
                     <div className="text-sm font-medium">{info.label}</div>
-                    <div className="text-xs text-white/60">
+                    <div className="text-xs text-foreground/60">
                       {info.description}
                     </div>
                   </div>

--- a/frontend/src/pages/Admin/AgentBuilder/BlockList/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/BlockList/index.jsx
@@ -172,7 +172,7 @@ export default function BlockList({
       return (
         <div className="space-y-4">
           {renderBlockConfigContent(block, props)}
-          <div className="flex justify-between items-center pt-4 border-t border-white/10">
+          <div className="flex justify-between items-center pt-4 border-t border-border/10">
             <div>
               <label className="block text-sm font-medium text-theme-text-primary">
                 Direct Output
@@ -196,7 +196,7 @@ export default function BlockList({
                 className="peer sr-only"
                 aria-label="Toggle direct output"
               />
-              <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+              <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
             </label>
           </div>
         </div>
@@ -236,7 +236,7 @@ export default function BlockList({
       {blocks.map((block, index) => (
         <div key={block.id} className="flex flex-col">
           <div
-            className={`bg-theme-action-menu-bg border border-white/10 rounded-lg overflow-hidden transition-all duration-300 ${
+            className={`bg-theme-action-menu-bg border border-border/10 rounded-lg overflow-hidden transition-all duration-300 ${
               block.isExpanded ? "w-full" : "w-[280px] mx-auto"
             }`}
           >
@@ -247,15 +247,15 @@ export default function BlockList({
               <div className="flex items-center gap-3">
                 <div className="w-7 h-7 rounded-lg bg-card light:bg-card flex items-center justify-center">
                   {React.cloneElement(BLOCK_INFO[block.type].icon, {
-                    className: "w-4 h-4 text-white",
+                    className: "w-4 h-4 text-foreground",
                   })}
                 </div>
                 <div className="flex-1 text-left min-w-0 max-w-[115px]">
-                  <span className="text-sm font-medium text-white block">
+                  <span className="text-sm font-medium text-foreground block">
                     {BLOCK_INFO[block.type].label}
                   </span>
                   {!block.isExpanded && (
-                    <p className="text-xs text-white/60 truncate">
+                    <p className="text-xs text-foreground/60 truncate">
                       {BLOCK_INFO[block.type].getSummary(block.config)}
                     </p>
                   )}
@@ -272,7 +272,7 @@ export default function BlockList({
                             e.stopPropagation();
                             moveBlock(index, index - 1);
                           }}
-                          className="w-7 h-7 flex items-center justify-center rounded-lg bg-theme-bg-primary border border-white/5 text-white hover:bg-theme-action-menu-item-hover transition-colors duration-300"
+                          className="w-7 h-7 flex items-center justify-center rounded-lg bg-theme-bg-primary border border-border/5 text-foreground hover:bg-theme-action-menu-item-hover transition-colors duration-300"
                           data-tooltip-id="block-action"
                           data-tooltip-content="Move block up"
                         >
@@ -285,7 +285,7 @@ export default function BlockList({
                             e.stopPropagation();
                             moveBlock(index, index + 1);
                           }}
-                          className="w-7 h-7 flex items-center justify-center rounded-lg bg-theme-bg-primary border border-white/5 text-white hover:bg-theme-action-menu-item-hover transition-colors duration-300"
+                          className="w-7 h-7 flex items-center justify-center rounded-lg bg-theme-bg-primary border border-border/5 text-foreground hover:bg-theme-action-menu-item-hover transition-colors duration-300"
                           data-tooltip-id="block-action"
                           data-tooltip-content="Move block down"
                         >
@@ -297,7 +297,7 @@ export default function BlockList({
                           e.stopPropagation();
                           removeBlock(block.id);
                         }}
-                        className="w-7 h-7 flex items-center justify-center rounded-lg bg-theme-bg-primary border border-white/5 text-red-400 hover:bg-red-500/10 hover:border-red-500/20 transition-colors duration-300"
+                        className="w-7 h-7 flex items-center justify-center rounded-lg bg-theme-bg-primary border border-border/5 text-red-400 hover:bg-red-500/10 hover:border-red-500/20 transition-colors duration-300"
                         data-tooltip-id="block-action"
                         data-tooltip-content="Delete block"
                       >
@@ -314,7 +314,7 @@ export default function BlockList({
                   : "max-h-0 opacity-0"
               }`}
             >
-              <div className="border-t border-white/10 p-4 bg-theme-bg-secondary rounded-b-lg">
+              <div className="border-t border-border/10 p-4 bg-theme-bg-secondary rounded-b-lg">
                 {renderBlockConfig(block)}
               </div>
             </div>
@@ -327,7 +327,7 @@ export default function BlockList({
                 viewBox="0 0 24 24"
                 fill="none"
                 xmlns="http://www.w3.org/2000/svg"
-                className="text-white/40 light:invert"
+                className="text-foreground/40 light:invert"
               >
                 <path
                   d="M12 4L12 20M12 20L6 14M12 20L18 14"

--- a/frontend/src/pages/Admin/AgentBuilder/HeaderMenu/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/HeaderMenu/index.jsx
@@ -38,7 +38,7 @@ export default function HeaderMenu({
         <div className="flex items-center gap-x-2">
           <button
             onClick={() => navigate(paths.settings.agentSkills())}
-            className="w-8 h-8 flex items-center justify-center rounded-full bg-theme-settings-input-bg border border-white/10 hover:bg-theme-action-menu-bg transition-colors duration-300"
+            className="w-8 h-8 flex items-center justify-center rounded-full bg-theme-settings-input-bg border border-border/10 hover:bg-theme-action-menu-bg transition-colors duration-300"
           >
             <CaretLeft
               weight="bold"
@@ -46,12 +46,12 @@ export default function HeaderMenu({
             />
           </button>
           <div
-            className="flex items-center bg-theme-settings-input-bg rounded-md border border-white/10 pointer-events-auto"
+            className="flex items-center bg-theme-settings-input-bg rounded-md border border-border/10 pointer-events-auto"
             ref={dropdownRef}
           >
             <button
               onClick={() => navigate(paths.settings.agentSkills())}
-              className="!border-t-transparent !border-l-transparent !border-b-transparent flex items-center gap-x-2 px-4 py-2 border-r border-white/10 hover:bg-theme-action-menu-bg transition-colors duration-300"
+              className="!border-t-transparent !border-l-transparent !border-b-transparent flex items-center gap-x-2 px-4 py-2 border-r border-border/10 hover:bg-theme-action-menu-bg transition-colors duration-300"
             >
               <img
                 src={AnythingInfinityLogo}
@@ -90,7 +90,7 @@ export default function HeaderMenu({
                 )}
               </button>
               {showDropdown && (
-                <div className="absolute top-full left-0 mt-1 w-full min-w-[200px] max-w-[350px] bg-theme-settings-input-bg border border-white/10 rounded-md shadow-lg z-50 animate-fadeUpIn">
+                <div className="absolute top-full left-0 mt-1 w-full min-w-[200px] max-w-[350px] bg-theme-settings-input-bg border border-border/10 rounded-md shadow-lg z-50 animate-fadeUpIn">
                   {availableFlows
                     .filter((flow) => flow.uuid !== flowId)
                     .map((flow) => (
@@ -117,20 +117,20 @@ export default function HeaderMenu({
           <div className="flex items-center gap-x-[15px]">
             <button
               onClick={onNewFlow}
-              className="flex items-center gap-x-2 text-theme-text-primary text-sm font-medium px-3 py-2 rounded-sm border border-white bg-theme-settings-input-bg hover:bg-theme-action-menu-bg transition-colors duration-300"
+              className="flex items-center gap-x-2 text-theme-text-primary text-sm font-medium px-3 py-2 rounded-sm border border-border bg-theme-settings-input-bg hover:bg-theme-action-menu-bg transition-colors duration-300"
             >
               <Plus className="w-4 h-4" />
               New Flow
             </button>
             <button
               onClick={onPublishFlow}
-              className="px-3 py-2 rounded-sm text-sm font-medium flex items-center justify-center gap-2 border border-white/10 bg-theme-bg-primary text-theme-text-primary hover:bg-theme-action-menu-bg transition-all duration-300"
+              className="px-3 py-2 rounded-sm text-sm font-medium flex items-center justify-center gap-2 border border-border/10 bg-theme-bg-primary text-theme-text-primary hover:bg-theme-action-menu-bg transition-all duration-300"
             >
               Publish
             </button>
             <button
               onClick={onSaveFlow}
-              className="border-none bg-primary-button hover:opacity-80 text-foreground light:text-white px-3 py-2 rounded-sm text-sm font-medium transition-all duration-300 flex items-center justify-center gap-2"
+              className="border-none bg-primary-button hover:opacity-80 text-foreground light:text-foreground px-3 py-2 rounded-sm text-sm font-medium transition-all duration-300 flex items-center justify-center gap-2"
             >
               Save
             </button>

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/CodeNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/CodeNode/index.jsx
@@ -8,13 +8,13 @@ export default function CodeNode({
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           Language
         </label>
         <select
           value={config.language}
           onChange={(e) => onConfigChange({ language: e.target.value })}
-          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
+          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
         >
           <option value="javascript" className="bg-theme-bg-primary">
             JavaScript
@@ -28,21 +28,21 @@ export default function CodeNode({
         </select>
       </div>
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           Code
         </label>
         <textarea
           placeholder="Enter code..."
           value={config.code}
           onChange={(e) => onConfigChange({ code: e.target.value })}
-          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white placeholder:text-white/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none font-mono"
+          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground placeholder:text-foreground/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none font-mono"
           rows={5}
           autoComplete="off"
           spellCheck={false}
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           Store Result In
         </label>
         {renderVariableSelect(

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/FileNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/FileNode/index.jsx
@@ -8,13 +8,13 @@ export default function FileNode({
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           Operation
         </label>
         <select
           value={config.operation}
           onChange={(e) => onConfigChange({ operation: e.target.value })}
-          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
+          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
         >
           <option value="read" className="bg-theme-bg-primary">
             Read File
@@ -28,7 +28,7 @@ export default function FileNode({
         </select>
       </div>
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           File Path
         </label>
         <input
@@ -36,21 +36,21 @@ export default function FileNode({
           placeholder="/path/to/file"
           value={config.path}
           onChange={(e) => onConfigChange({ path: e.target.value })}
-          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white placeholder:text-white/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
+          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground placeholder:text-foreground/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
           autoComplete="off"
           spellCheck={false}
         />
       </div>
       {config.operation !== "read" && (
         <div>
-          <label className="block text-sm font-medium text-white mb-2">
+          <label className="block text-sm font-medium text-foreground mb-2">
             Content
           </label>
           <textarea
             placeholder="File content..."
             value={config.content}
             onChange={(e) => onConfigChange({ content: e.target.value })}
-            className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white placeholder:text-white/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
+            className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground placeholder:text-foreground/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
             rows={3}
             autoComplete="off"
             spellCheck={false}
@@ -58,7 +58,7 @@ export default function FileNode({
         </div>
       )}
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           Store Result In
         </label>
         {renderVariableSelect(

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/FinishNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/FinishNode/index.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function FinishNode() {
   return (
-    <div className="text-sm text-white/60">
+    <div className="text-sm text-foreground/60">
       This is the end of your agent flow. All steps above will be executed in
       sequence.
     </div>

--- a/frontend/src/pages/Admin/AgentBuilder/nodes/WebsiteNode/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/nodes/WebsiteNode/index.jsx
@@ -8,25 +8,25 @@ export default function WebsiteNode({
   return (
     <div className="space-y-4">
       <div>
-        <label className="block text-sm font-medium text-white mb-2">URL</label>
+        <label className="block text-sm font-medium text-foreground mb-2">URL</label>
         <input
           type="text"
           placeholder="https://example.com"
           value={config.url}
           onChange={(e) => onConfigChange({ url: e.target.value })}
-          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white placeholder:text-white/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
+          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground placeholder:text-foreground/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
           autoComplete="off"
           spellCheck={false}
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           Action
         </label>
         <select
           value={config.action}
           onChange={(e) => onConfigChange({ action: e.target.value })}
-          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
+          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
         >
           <option value="read" className="bg-theme-bg-primary">
             Read Content
@@ -40,7 +40,7 @@ export default function WebsiteNode({
         </select>
       </div>
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           CSS Selector
         </label>
         <input
@@ -48,13 +48,13 @@ export default function WebsiteNode({
           placeholder="#element-id or .class-name"
           value={config.selector}
           onChange={(e) => onConfigChange({ selector: e.target.value })}
-          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-white/5 text-white placeholder:text-white/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
+          className="w-full p-2.5 text-sm rounded-lg bg-theme-bg-primary border border-border/5 text-foreground placeholder:text-foreground/20 focus:border-primary-button focus:ring-1 focus:ring-primary-button outline-none"
           autoComplete="off"
           spellCheck={false}
         />
       </div>
       <div>
-        <label className="block text-sm font-medium text-white mb-2">
+        <label className="block text-sm font-medium text-foreground mb-2">
           Store Result In
         </label>
         {renderVariableSelect(

--- a/frontend/src/pages/Admin/Agents/AgentFlows/FlowPanel.jsx
+++ b/frontend/src/pages/Admin/Agents/AgentFlows/FlowPanel.jsx
@@ -44,12 +44,12 @@ function ManageFlowMenu({ flow, onDelete }) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="p-1.5 rounded-lg text-white hover:bg-theme-action-menu-item-hover transition-colors duration-300"
+        className="p-1.5 rounded-lg text-foreground hover:bg-theme-action-menu-item-hover transition-colors duration-300"
       >
         <Gear className="h-5 w-5" weight="bold" />
       </button>
       {open && (
-        <div className="absolute w-[100px] -top-1 left-7 mt-1 border-[1.5px] border-white/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-white z-99 md:z-10">
+        <div className="absolute w-[100px] -top-1 left-7 mt-1 border-[1.5px] border-border/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-foreground z-99 md:z-10">
           <button
             type="button"
             onClick={() => navigate(paths.agents.editAgent(flow.uuid))}
@@ -98,8 +98,8 @@ export default function FlowPanel({ flow, toggleFlow, onDelete }) {
       <div className="p-2">
         <div className="flex flex-col gap-y-[18px] max-w-[500px]">
           <div className="flex items-center gap-x-2">
-            <FlowArrow size={24} weight="bold" className="text-white" />
-            <label htmlFor="name" className="text-white text-md font-bold">
+            <FlowArrow size={24} weight="bold" className="text-foreground" />
+            <label htmlFor="name" className="text-foreground text-md font-bold">
               {flow.name}
             </label>
             <label className="border-none relative inline-flex items-center ml-auto cursor-pointer">
@@ -109,12 +109,12 @@ export default function FlowPanel({ flow, toggleFlow, onDelete }) {
                 checked={isActive}
                 onChange={handleToggle}
               />
-              <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+              <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
               <span className="ml-3 text-sm font-medium"></span>
             </label>
             <ManageFlowMenu flow={flow} onDelete={onDelete} />
           </div>
-          <p className="whitespace-pre-wrap text-white text-opacity-60 text-xs font-medium py-1.5">
+          <p className="whitespace-pre-wrap text-foreground text-opacity-60 text-xs font-medium py-1.5">
             {flow.description || "No description provided"}
           </p>
         </div>

--- a/frontend/src/pages/Admin/Agents/AgentFlows/index.jsx
+++ b/frontend/src/pages/Admin/Agents/AgentFlows/index.jsx
@@ -22,7 +22,7 @@ export default function AgentFlowsList({
   }
 
   return (
-    <div className="bg-theme-bg-secondary text-white rounded-xl w-full md:min-w-[360px]">
+    <div className="bg-theme-bg-secondary text-foreground rounded-xl w-full md:min-w-[360px]">
       {flows.map((flow, index) => (
         <div
           key={flow.uuid}
@@ -31,7 +31,7 @@ export default function AgentFlowsList({
           } ${
             index === flows.length - 1
               ? "rounded-b-xl"
-              : "border-b border-white/10"
+              : "border-b border-border/10"
           } cursor-pointer transition-all duration-300 hover:bg-theme-bg-primary ${
             selectedFlow?.uuid === flow.uuid
               ? "bg-card light:bg-theme-bg-sidebar"

--- a/frontend/src/pages/Admin/Agents/Imported/ImportedSkillConfig/index.jsx
+++ b/frontend/src/pages/Admin/Agents/Imported/ImportedSkillConfig/index.jsx
@@ -111,8 +111,8 @@ export default function ImportedSkillConfig({
       <div className="p-2">
         <div className="flex flex-col gap-y-[18px] max-w-[500px]">
           <div className="flex items-center gap-x-2">
-            <Plug size={24} weight="bold" className="text-white" />
-            <label htmlFor="name" className="text-white text-md font-bold">
+            <Plug size={24} weight="bold" className="text-foreground" />
+            <label htmlFor="name" className="text-foreground text-md font-bold">
               {sentenceCase(config.name)}
             </label>
             <label className="border-none relative inline-flex items-center ml-auto cursor-pointer">
@@ -122,7 +122,7 @@ export default function ImportedSkillConfig({
                 checked={config.active}
                 onChange={() => toggleSkill()}
               />
-              <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+              <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
               <span className="ml-3 text-sm font-medium"></span>
             </label>
             <ManageSkillMenu
@@ -130,13 +130,13 @@ export default function ImportedSkillConfig({
               setImportedSkills={setImportedSkills}
             />
           </div>
-          <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+          <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
             {config.description} by{" "}
             <a
               href={config.author_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-white hover:underline"
+              className="text-foreground hover:underline"
             >
               {config.author}
             </a>
@@ -146,7 +146,7 @@ export default function ImportedSkillConfig({
             <div className="flex flex-col gap-y-2">
               {Object.entries(config.setup_args).map(([key, props]) => (
                 <div key={key} className="flex flex-col gap-y-1">
-                  <label htmlFor={key} className="text-white text-sm font-bold">
+                  <label htmlFor={key} className="text-foreground text-sm font-bold">
                     {key}
                   </label>
                   <input
@@ -161,9 +161,9 @@ export default function ImportedSkillConfig({
                       setInputs({ ...inputs, [key]: e.target.value })
                     }
                     placeholder={props?.input?.placeholder || ""}
-                    className="border-solid bg-transparent border border-white light:border-black rounded-md p-2 text-white text-sm"
+                    className="border-solid bg-transparent border border-border light:border-black rounded-md p-2 text-foreground text-sm"
                   />
-                  <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+                  <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
                     {props?.input?.hint}
                   </p>
                 </div>
@@ -172,14 +172,14 @@ export default function ImportedSkillConfig({
                 <button
                   onClick={handleSubmit}
                   type="button"
-                  className="bg-blue-500 text-white light:text-white rounded-md p-2"
+                  className="bg-blue-500 text-foreground light:text-foreground rounded-md p-2"
                 >
                   Save
                 </button>
               )}
             </div>
           ) : (
-            <p className="text-white text-opacity-60 text-sm font-medium py-1.5">
+            <p className="text-foreground text-opacity-60 text-sm font-medium py-1.5">
               There are no options to modify for this skill.
             </p>
           )}
@@ -231,12 +231,12 @@ function ManageSkillMenu({ config, setImportedSkills }) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="p-1.5 rounded-lg text-white hover:bg-theme-action-menu-item-hover transition-colors duration-300"
+        className="p-1.5 rounded-lg text-foreground hover:bg-theme-action-menu-item-hover transition-colors duration-300"
       >
         <Gear className="h-5 w-5" weight="bold" />
       </button>
       {open && (
-        <div className="absolute w-[100px] -top-1 left-7 mt-1 border-[1.5px] border-white/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-white z-99 md:z-10">
+        <div className="absolute w-[100px] -top-1 left-7 mt-1 border-[1.5px] border-border/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-foreground z-99 md:z-10">
           <button
             type="button"
             onClick={deleteSkill}

--- a/frontend/src/pages/Admin/Agents/Imported/SkillList/index.jsx
+++ b/frontend/src/pages/Admin/Agents/Imported/SkillList/index.jsx
@@ -26,7 +26,7 @@ export default function ImportedSkillList({
 
   return (
     <div
-      className={`bg-theme-bg-secondary text-white rounded-xl w-full md:min-w-[360px]`}
+      className={`bg-theme-bg-secondary text-foreground rounded-xl w-full md:min-w-[360px]`}
     >
       {skills.map((config, index) => (
         <div
@@ -36,7 +36,7 @@ export default function ImportedSkillList({
           } ${
             index === Object.keys(skills).length - 1
               ? "rounded-b-xl"
-              : "border-b border-white/10"
+              : "border-b border-border/10"
           } cursor-pointer transition-all duration-300 hover:bg-theme-bg-primary ${
             selectedSkill === config.hubId ? "bg-theme-bg-primary" : ""
           }`}

--- a/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
+++ b/frontend/src/pages/Admin/Agents/MCPServers/ServerPanel.jsx
@@ -73,12 +73,12 @@ function ManageServerMenu({ server, toggleServer, onDelete }) {
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="p-1.5 rounded-lg text-white hover:bg-theme-action-menu-item-hover transition-colors duration-300"
+        className="p-1.5 rounded-lg text-foreground hover:bg-theme-action-menu-item-hover transition-colors duration-300"
       >
         <Gear className="h-5 w-5" weight="bold" />
       </button>
       {open && (
-        <div className="absolute w-[150px] top-1 left-7 mt-1 border-[1.5px] border-white/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-white z-99 md:z-10">
+        <div className="absolute w-[150px] top-1 left-7 mt-1 border-[1.5px] border-border/40 rounded-lg bg-theme-action-menu-bg flex flex-col shadow-[0_4px_14px_rgba(0,0,0,0.25)] text-foreground z-99 md:z-10">
           <button
             type="button"
             onClick={handleToggleServer}
@@ -109,7 +109,7 @@ export default function ServerPanel({ server, toggleServer, onDelete }) {
           <div className="flex w-full justify-between">
             <div className="flex items-center gap-x-2">
               <img src={MCPLogo} className="w-6 h-6 light:invert" />
-              <label htmlFor="name" className="text-white text-md font-bold">
+              <label htmlFor="name" className="text-foreground text-md font-bold">
                 {titleCase(server.name.replace(/[_-]/g, " "))}
               </label>
               {server.tools.length > 0 && (

--- a/frontend/src/pages/Admin/Agents/MCPServers/index.jsx
+++ b/frontend/src/pages/Admin/Agents/MCPServers/index.jsx
@@ -120,7 +120,7 @@ export function MCPServersList({
   }
 
   return (
-    <div className="bg-theme-bg-secondary text-white rounded-xl w-full md:min-w-[360px]">
+    <div className="bg-theme-bg-secondary text-foreground rounded-xl w-full md:min-w-[360px]">
       {servers.map((server, index) => (
         <div
           key={server.name}
@@ -129,7 +129,7 @@ export function MCPServersList({
           } ${
             index === servers.length - 1
               ? "rounded-b-xl"
-              : "border-b border-white/10"
+              : "border-b border-border/10"
           } cursor-pointer transition-all duration-300 hover:bg-theme-bg-primary ${
             selectedServer?.name === server.name
               ? "bg-card light:bg-theme-bg-sidebar"

--- a/frontend/src/pages/Admin/Agents/SQLConnectorSelection/DBConnection.jsx
+++ b/frontend/src/pages/Admin/Agents/SQLConnectorSelection/DBConnection.jsx
@@ -30,13 +30,13 @@ export default function DBConnection({ connection, onRemove }) {
       />
       <div className="flex w-full items-center justify-between">
         <div className="flex flex-col">
-          <div className="text-sm font-semibold text-white">{database_id}</div>
+          <div className="text-sm font-semibold text-foreground">{database_id}</div>
           <div className="mt-1 text-xs text-description">{engine}</div>
         </div>
         <button
           type="button"
           onClick={removeConfirmation}
-          className="border-none text-white hover:text-red-500"
+          className="border-none text-foreground hover:text-red-500"
         >
           <X size={24} />
         </button>

--- a/frontend/src/pages/Admin/Agents/SQLConnectorSelection/NewConnectionModal.jsx
+++ b/frontend/src/pages/Admin/Agents/SQLConnectorSelection/NewConnectionModal.jsx
@@ -121,7 +121,7 @@ export default function NewSQLConnection({
         <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
           <div className="relative p-6 border-b rounded-t border-theme-modal-border">
             <div className="w-full flex gap-x-2 items-center">
-              <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+              <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
                 New SQL Connection
               </h3>
             </div>
@@ -130,7 +130,7 @@ export default function NewSQLConnection({
               type="button"
               className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
             >
-              <X size={24} weight="bold" className="text-white" />
+              <X size={24} weight="bold" className="text-foreground" />
             </button>
           </div>
           <form
@@ -140,7 +140,7 @@ export default function NewSQLConnection({
           >
             <div className="px-7 py-6">
               <div className="space-y-6 max-h-[60vh] overflow-y-auto pr-2">
-                <p className="text-sm text-white/60">
+                <p className="text-sm text-foreground/60">
                   Add the connection information for your database below and it
                   will be available for future SQL agent calls.
                 </p>
@@ -156,7 +156,7 @@ export default function NewSQLConnection({
                     </p>
                   </div>
 
-                  <label className="block mb-2 text-sm font-medium text-white mt-4">
+                  <label className="block mb-2 text-sm font-medium text-foreground mt-4">
                     Select your SQL engine
                   </label>
                   <div className="grid md:grid-cols-4 gap-4 grid-cols-2">
@@ -179,13 +179,13 @@ export default function NewSQLConnection({
                 </div>
 
                 <div className="flex flex-col w-full">
-                  <label className="block mb-2 text-sm font-medium text-white">
+                  <label className="block mb-2 text-sm font-medium text-foreground">
                     Connection name
                   </label>
                   <input
                     type="text"
                     name="name"
-                    className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     placeholder="a unique name to identify this SQL connection"
                     required={true}
                     autoComplete="off"
@@ -195,13 +195,13 @@ export default function NewSQLConnection({
 
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                   <div className="flex flex-col">
-                    <label className="block mb-2 text-sm font-medium text-white">
+                    <label className="block mb-2 text-sm font-medium text-foreground">
                       Database user
                     </label>
                     <input
                       type="text"
                       name="username"
-                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                       placeholder="root"
                       required={true}
                       autoComplete="off"
@@ -209,13 +209,13 @@ export default function NewSQLConnection({
                     />
                   </div>
                   <div className="flex flex-col">
-                    <label className="block mb-2 text-sm font-medium text-white">
+                    <label className="block mb-2 text-sm font-medium text-foreground">
                       Database user password
                     </label>
                     <input
                       type="text"
                       name="password"
-                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                       placeholder="password123"
                       required={true}
                       autoComplete="off"
@@ -226,13 +226,13 @@ export default function NewSQLConnection({
 
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
                   <div className="sm:col-span-2">
-                    <label className="block mb-2 text-sm font-medium text-white">
+                    <label className="block mb-2 text-sm font-medium text-foreground">
                       Server endpoint
                     </label>
                     <input
                       type="text"
                       name="host"
-                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                       placeholder="the hostname or endpoint for your database"
                       required={true}
                       autoComplete="off"
@@ -240,13 +240,13 @@ export default function NewSQLConnection({
                     />
                   </div>
                   <div>
-                    <label className="block mb-2 text-sm font-medium text-white">
+                    <label className="block mb-2 text-sm font-medium text-foreground">
                       Port
                     </label>
                     <input
                       type="text"
                       name="port"
-                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                       placeholder="3306"
                       required={false}
                       autoComplete="off"
@@ -256,13 +256,13 @@ export default function NewSQLConnection({
                 </div>
 
                 <div className="flex flex-col">
-                  <label className="block mb-2 text-sm font-medium text-white">
+                  <label className="block mb-2 text-sm font-medium text-foreground">
                     Database
                   </label>
                   <input
                     type="text"
                     name="database"
-                    className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     placeholder="the database the agent will interact with"
                     required={true}
                     autoComplete="off"
@@ -272,13 +272,13 @@ export default function NewSQLConnection({
 
                 {engine === "postgresql" && (
                   <div className="flex flex-col">
-                    <label className="block mb-2 text-sm font-medium text-white">
+                    <label className="block mb-2 text-sm font-medium text-foreground">
                       Schema (optional)
                     </label>
                     <input
                       type="text"
                       name="schema"
-                      className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                      className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                       placeholder="public (default schema if not specified)"
                       required={false}
                       autoComplete="off"
@@ -297,8 +297,8 @@ export default function NewSQLConnection({
                         className="sr-only peer"
                         checked={config.encrypt}
                       />
-                      <div className="w-11 h-6 bg-theme-settings-input-bg peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-card after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
-                      <span className="ml-3 text-sm font-medium text-white">
+                      <div className="w-11 h-6 bg-theme-settings-input-bg peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-border after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-card after:border-border after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                      <span className="ml-3 text-sm font-medium text-foreground">
                         Enable Encryption
                       </span>
                     </label>
@@ -314,7 +314,7 @@ export default function NewSQLConnection({
               <button
                 type="button"
                 onClick={handleClose}
-                className="transition-all duration-300 text-white hover:bg-zinc-700 light:hover:bg-theme-bg-primary px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 light:hover:bg-theme-bg-primary px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>
@@ -340,7 +340,7 @@ function DBEngine({ provider, active, onClick }) {
     <button
       type="button"
       onClick={onClick}
-      className={`flex flex-col p-4 border border-white/40 bg-zinc-800 light:bg-theme-settings-input-bg rounded-lg w-fit hover:bg-zinc-700 ${
+      className={`flex flex-col p-4 border border-border/40 bg-zinc-800 light:bg-theme-settings-input-bg rounded-lg w-fit hover:bg-zinc-700 ${
         active ? "!bg-blue-500/50" : ""
       }`}
     >

--- a/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderItem/index.jsx
+++ b/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderItem/index.jsx
@@ -18,7 +18,7 @@ export default function SearchProviderItem({ provider, checked, onClick }) {
       <div className="flex gap-x-4 items-center">
         <img src={logo} alt={`${name} logo`} className="w-10 h-10 rounded-md" />
         <div className="flex flex-col">
-          <div className="text-sm font-semibold text-white">{name}</div>
+          <div className="text-sm font-semibold text-foreground">{name}</div>
           <div className="mt-1 text-xs text-description">{description}</div>
         </div>
       </div>

--- a/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderOptions/index.jsx
+++ b/frontend/src/pages/Admin/Agents/WebSearchSelection/SearchProviderOptions/index.jsx
@@ -1,7 +1,7 @@
 export function GoogleSearchOptions({ settings }) {
   return (
     <>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         You can get a free search engine & API key{" "}
         <a
           href="https://programmablesearchengine.google.com/controlpanel/create"
@@ -14,13 +14,13 @@ export function GoogleSearchOptions({ settings }) {
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Search engine ID
           </label>
           <input
             type="text"
             name="env::AgentGoogleSearchEngineId"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Google Search Engine Id"
             defaultValue={settings?.AgentGoogleSearchEngineId}
             required={true}
@@ -29,13 +29,13 @@ export function GoogleSearchOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Programmatic Access API Key
           </label>
           <input
             type="password"
             name="env::AgentGoogleSearchEngineKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Google Search Engine API Key"
             defaultValue={
               settings?.AgentGoogleSearchEngineKey ? "*".repeat(20) : ""
@@ -68,7 +68,7 @@ const SearchApiEngines = [
 export function SearchApiOptions({ settings }) {
   return (
     <>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         You can get a free API key{" "}
         <a
           href="https://www.searchapi.io/"
@@ -81,13 +81,13 @@ export function SearchApiOptions({ settings }) {
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="env::AgentSearchApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="SearchApi API Key"
             defaultValue={settings?.AgentSearchApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -96,13 +96,13 @@ export function SearchApiOptions({ settings }) {
           />
         </div>
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             Engine
           </label>
           <select
             name="env::AgentSearchApiEngine"
             required={true}
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             defaultValue={settings?.AgentSearchApiEngine || "google"}
           >
             {SearchApiEngines.map(({ name, value }) => (
@@ -114,7 +114,7 @@ export function SearchApiOptions({ settings }) {
           {/* <input
             type="text"
             name="env::AgentSearchApiEngine"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="SearchApi engine (Google, Bing...)"
             defaultValue={settings?.AgentSearchApiEngine || "google"}
             required={true}
@@ -130,7 +130,7 @@ export function SearchApiOptions({ settings }) {
 export function SerperDotDevOptions({ settings }) {
   return (
     <>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         You can get a free API key{" "}
         <a
           href="https://serper.dev"
@@ -143,13 +143,13 @@ export function SerperDotDevOptions({ settings }) {
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="env::AgentSerperApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Serper.dev API Key"
             defaultValue={settings?.AgentSerperApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -165,7 +165,7 @@ export function SerperDotDevOptions({ settings }) {
 export function BingSearchOptions({ settings }) {
   return (
     <>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         You can get a Bing Web Search API subscription key{" "}
         <a
           href="https://portal.azure.com/"
@@ -178,13 +178,13 @@ export function BingSearchOptions({ settings }) {
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="env::AgentBingSearchApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Bing Web Search API Key"
             defaultValue={settings?.AgentBingSearchApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -193,10 +193,10 @@ export function BingSearchOptions({ settings }) {
           />
         </div>
       </div>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         To set up a Bing Web Search API subscription:
       </p>
-      <ol className="list-decimal text-sm text-white/60 ml-6">
+      <ol className="list-decimal text-sm text-foreground/60 ml-6">
         <li>
           Go to the Azure portal:{" "}
           <a
@@ -229,7 +229,7 @@ export function BingSearchOptions({ settings }) {
 export function SerplySearchOptions({ settings }) {
   return (
     <>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         You can get a free API key{" "}
         <a
           href="https://serply.io"
@@ -242,13 +242,13 @@ export function SerplySearchOptions({ settings }) {
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="env::AgentSerplyApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Serply API Key"
             defaultValue={settings?.AgentSerplyApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -265,13 +265,13 @@ export function SearXNGOptions({ settings }) {
   return (
     <div className="flex gap-x-4">
       <div className="flex flex-col w-60">
-        <label className="text-white text-sm font-semibold block mb-3">
+        <label className="text-foreground text-sm font-semibold block mb-3">
           SearXNG API Base URL
         </label>
         <input
           type="url"
           name="env::AgentSearXNGApiUrl"
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
           placeholder="SearXNG API Base URL"
           defaultValue={settings?.AgentSearXNGApiUrl}
           required={true}
@@ -286,7 +286,7 @@ export function SearXNGOptions({ settings }) {
 export function TavilySearchOptions({ settings }) {
   return (
     <>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         You can get an API key{" "}
         <a
           href="https://tavily.com/"
@@ -299,13 +299,13 @@ export function TavilySearchOptions({ settings }) {
       </p>
       <div className="flex gap-x-4">
         <div className="flex flex-col w-60">
-          <label className="text-white text-sm font-semibold block mb-3">
+          <label className="text-foreground text-sm font-semibold block mb-3">
             API Key
           </label>
           <input
             type="password"
             name="env::AgentTavilyApiKey"
-            className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             placeholder="Tavily API Key"
             defaultValue={settings?.AgentTavilyApiKey ? "*".repeat(20) : ""}
             required={true}
@@ -321,7 +321,7 @@ export function TavilySearchOptions({ settings }) {
 export function DuckDuckGoOptions() {
   return (
     <>
-      <p className="text-sm text-white/60 my-2">
+      <p className="text-sm text-foreground/60 my-2">
         DuckDuckGo is ready to use without any additional configuration.
       </p>
     </>

--- a/frontend/src/pages/Admin/Agents/WebSearchSelection/index.jsx
+++ b/frontend/src/pages/Admin/Agents/WebSearchSelection/index.jsx
@@ -172,7 +172,7 @@ export default function AgentWebSearchSelection({
               checked={enabled}
               onChange={() => toggleSkill(skill)}
             />
-            <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+            <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
             <span className="ml-3 text-sm font-medium"></span>
           </label>
         </div>
@@ -223,7 +223,7 @@ export default function AgentWebSearchSelection({
                     <X
                       size={20}
                       weight="bold"
-                      className="cursor-pointer text-white hover:text-x-button"
+                      className="cursor-pointer text-foreground hover:text-x-button"
                       onClick={handleXButton}
                     />
                   </div>
@@ -254,7 +254,7 @@ export default function AgentWebSearchSelection({
                     className="w-10 h-10 rounded-md"
                   />
                   <div className="flex flex-col text-left">
-                    <div className="text-sm font-semibold text-white">
+                    <div className="text-sm font-semibold text-foreground">
                       {selectedSearchProviderObject.name}
                     </div>
                     <div className="mt-1 text-xs text-description">
@@ -262,7 +262,7 @@ export default function AgentWebSearchSelection({
                     </div>
                   </div>
                 </div>
-                <CaretUpDown size={24} weight="bold" className="text-white" />
+                <CaretUpDown size={24} weight="bold" className="text-foreground" />
               </button>
             )}
           </div>

--- a/frontend/src/pages/Admin/Agents/index.jsx
+++ b/frontend/src/pages/Admin/Agents/index.jsx
@@ -343,7 +343,7 @@ export default function AdminAgents() {
                       setShowSkillModal(false);
                       setSelectedSkill("");
                     }}
-                    className="text-white/60 hover:text-white transition-colors duration-200"
+                    className="text-foreground/60 hover:text-foreground transition-colors duration-200"
                   >
                     <div className="flex items-center text-sky-400">
                       <CaretLeft size={24} />
@@ -352,7 +352,7 @@ export default function AdminAgents() {
                   </button>
                 </div>
                 <div className="flex-1 overflow-y-auto p-4">
-                  <div className=" bg-theme-bg-secondary text-white rounded-xl p-4 overflow-y-scroll no-scroll">
+                  <div className=" bg-theme-bg-secondary text-foreground rounded-xl p-4 overflow-y-scroll no-scroll">
                     {SelectedSkillComponent ? (
                       <>
                         {selectedMcpServer ? (
@@ -543,7 +543,7 @@ export default function AdminAgents() {
 
         {/* Selected agent skill setting panel */}
         <div className="flex-[2] flex flex-col gap-y-[18px] mt-10">
-          <div className="bg-theme-bg-secondary text-white rounded-xl flex-1 p-4 overflow-y-scroll no-scroll">
+          <div className="bg-theme-bg-secondary text-foreground rounded-xl flex-1 p-4 overflow-y-scroll no-scroll">
             {SelectedSkillComponent ? (
               <>
                 {selectedMcpServer ? (
@@ -646,7 +646,7 @@ function SkillList({
   return (
     <>
       <div
-        className={`bg-theme-bg-secondary text-white rounded-xl ${
+        className={`bg-theme-bg-secondary text-foreground rounded-xl ${
           isMobile ? "w-full" : "min-w-[360px] w-fit"
         }`}
       >
@@ -658,7 +658,7 @@ function SkillList({
             } ${
               index === Object.keys(skills).length - 1
                 ? "rounded-b-xl"
-                : "border-b border-white/10"
+                : "border-b border-border/10"
             } cursor-pointer transition-all duration-300  hover:bg-theme-bg-primary ${
               selectedSkill === skill ? "bg-card light:bg-theme-bg-sidebar" : ""
             }`}

--- a/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/manage/DocumentSyncQueueRow/index.jsx
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/manage/DocumentSyncQueueRow/index.jsx
@@ -19,7 +19,7 @@ export default function DocumentSyncQueueRow({ queue }) {
     <>
       <tr
         ref={rowRef}
-        className="bg-transparent text-white text-opacity-80 text-sm font-medium"
+        className="bg-transparent text-foreground text-opacity-80 text-sm font-medium"
       >
         <td scope="row" className="px-6 py-4 whitespace-nowrap">
           {stripUuidAndJsonFromString(queue.workspaceDoc.filename)}

--- a/frontend/src/pages/Admin/ExperimentalFeatures/index.jsx
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/index.jsx
@@ -47,7 +47,7 @@ export default function ExperimentalFeatures() {
       <div className="flex-1 flex gap-x-6 p-4 mt-10">
         {/* Feature settings nav */}
         <div className="flex flex-col gap-y-[18px]">
-          <div className="text-white flex items-center gap-x-2">
+          <div className="text-foreground flex items-center gap-x-2">
             <Flask size={24} />
             <p className="text-lg font-medium">Experimental Features</p>
           </div>
@@ -65,7 +65,7 @@ export default function ExperimentalFeatures() {
         {/* Selected feature setting panel */}
         <FeatureVerification>
           <div className="flex-[2] flex flex-col gap-y-[18px] mt-10">
-            <div className="bg-theme-bg-secondary text-white rounded-xl flex-1 p-4">
+            <div className="bg-theme-bg-secondary text-foreground rounded-xl flex-1 p-4">
               {selectedFeature ? (
                 <SelectedFeatureComponent
                   feature={configurableFeatures[selectedFeature]}
@@ -73,7 +73,7 @@ export default function ExperimentalFeatures() {
                   refresh={refresh}
                 />
               ) : (
-                <div className="flex flex-col items-center justify-center h-full text-white/60">
+                <div className="flex flex-col items-center justify-center h-full text-foreground/60">
                   <Flask size={40} />
                   <p className="font-medium">Select an experimental feature</p>
                 </div>
@@ -113,7 +113,7 @@ function FeatureList({
 
   return (
     <div
-      className={`bg-theme-bg-secondary text-white rounded-xl ${
+      className={`bg-theme-bg-secondary text-foreground rounded-xl ${
         isMobile ? "w-full" : "min-w-[360px] w-fit"
       }`}
     >
@@ -125,7 +125,7 @@ function FeatureList({
           } ${
             index === Object.keys(features).length - 1
               ? "rounded-b-xl"
-              : "border-b border-white/10"
+              : "border-b border-border/10"
           } cursor-pointer transition-all duration-300 hover:bg-card ${
             selectedFeature === feature
               ? "bg-card light:bg-theme-bg-sidebar  "
@@ -189,14 +189,14 @@ function FeatureVerification({ children }) {
             <div className="relative p-6 border-b rounded-t border-theme-modal-border">
               <div className="flex items-center gap-2">
                 <Flask size={24} className="text-theme-text-primary" />
-                <h3 className="text-xl font-semibold text-white">
+                <h3 className="text-xl font-semibold text-foreground">
                   Terms of use for experimental features
                 </h3>
               </div>
             </div>
             <form onSubmit={acceptTos}>
               <div className="py-7 px-9 space-y-4 flex-col">
-                <div className="w-full text-white text-md flex flex-col gap-y-4">
+                <div className="w-full text-foreground text-md flex flex-col gap-y-4">
                   <p>
                     Experimental features of OneNew are features that we are
                     piloting and are <b>opt-in</b>. We proactively will
@@ -264,7 +264,7 @@ function FeatureVerification({ children }) {
               <div className="flex w-full justify-between items-center p-6 space-x-2 border-t border-theme-modal-border rounded-b">
                 <a
                   href={paths.home()}
-                  className="transition-all duration-300 bg-transparent text-white hover:bg-red-500/50 light:hover:bg-red-300/50 px-4 py-2 rounded-lg text-sm border border-theme-modal-border"
+                  className="transition-all duration-300 bg-transparent text-foreground hover:bg-red-500/50 light:hover:bg-red-300/50 px-4 py-2 rounded-lg text-sm border border-theme-modal-border"
                 >
                   Reject & close
                 </a>

--- a/frontend/src/pages/Admin/Invitations/InviteRow/index.jsx
+++ b/frontend/src/pages/Admin/Invitations/InviteRow/index.jsx
@@ -42,7 +42,7 @@ export default function InviteRow({ invite }) {
     <>
       <tr
         ref={rowRef}
-        className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10"
+        className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10"
       >
         <td scope="row" className="px-6 whitespace-nowrap">
           {titleCase(status)}
@@ -66,7 +66,7 @@ export default function InviteRow({ invite }) {
               </button>
               <button
                 onClick={handleDelete}
-                className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
+                className="text-xs font-medium text-foreground/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
               >
                 <Trash className="h-5 w-5" />
               </button>

--- a/frontend/src/pages/Admin/Invitations/NewInviteModal/index.jsx
+++ b/frontend/src/pages/Admin/Invitations/NewInviteModal/index.jsx
@@ -70,7 +70,7 @@ export default function NewInviteModal({ closeModal, onSuccess }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Create new invite
             </h3>
           </div>
@@ -79,7 +79,7 @@ export default function NewInviteModal({ closeModal, onSuccess }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="p-6">
@@ -92,7 +92,7 @@ export default function NewInviteModal({ closeModal, onSuccess }) {
                     type="url"
                     defaultValue={`${window.location.origin}/accept-invite/${invite.code}`}
                     disabled={true}
-                    className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm outline-none block w-full p-2.5 pr-10"
+                    className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm outline-none block w-full p-2.5 pr-10"
                   />
                   <button
                     type="button"
@@ -107,12 +107,12 @@ export default function NewInviteModal({ closeModal, onSuccess }) {
                         weight="bold"
                       />
                     ) : (
-                      <Copy size={20} className="text-white" weight="bold" />
+                      <Copy size={20} className="text-foreground" weight="bold" />
                     )}
                   </button>
                 </div>
               )}
-              <p className="text-white text-opacity-60 text-xs md:text-sm">
+              <p className="text-foreground text-opacity-60 text-xs md:text-sm">
                 After creation you will be able to copy the invite and send it
                 to a new user where they can create an account as the{" "}
                 <b>default</b> role and automatically be added to workspaces
@@ -126,11 +126,11 @@ export default function NewInviteModal({ closeModal, onSuccess }) {
                   <div className="flex flex-col gap-y-1 mb-2">
                     <label
                       htmlFor="workspaces"
-                      className="block text-sm font-medium text-white"
+                      className="block text-sm font-medium text-foreground"
                     >
                       Auto-add invitee to workspaces
                     </label>
-                    <p className="text-white text-opacity-60 text-xs">
+                    <p className="text-foreground text-opacity-60 text-xs">
                       You can optionally automatically assign the user to the
                       workspaces below by selecting them. By default, the user
                       will not have any workspaces visible. You can assign
@@ -158,7 +158,7 @@ export default function NewInviteModal({ closeModal, onSuccess }) {
                   <button
                     onClick={closeModal}
                     type="button"
-                    className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm mr-2"
+                    className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm mr-2"
                   >
                     Cancel
                   </button>
@@ -173,7 +173,7 @@ export default function NewInviteModal({ closeModal, onSuccess }) {
                 <button
                   onClick={closeModal}
                   type="button"
-                  className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                  className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
                 >
                   Close
                 </button>

--- a/frontend/src/pages/Admin/Logging/LogRow/index.jsx
+++ b/frontend/src/pages/Admin/Logging/LogRow/index.jsx
@@ -27,7 +27,7 @@ export default function LogRow({ log }) {
     <>
       <tr
         onClick={handleRowClick}
-        className={`bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10 ${
+        className={`bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10 ${
           hasMetadata ? "cursor-pointer hover:bg-card" : ""
         }`}
       >
@@ -45,14 +45,14 @@ export default function LogRow({ log }) {
                 className={`px-2 gap-x-1 flex items-center justify-center transform transition-transform duration-200`}
               >
                 <CaretUp weight="bold" size={20} />
-                <p className="text-xs text-white/50 w-[20px]">hide</p>
+                <p className="text-xs text-foreground/50 w-[20px]">hide</p>
               </td>
             ) : (
               <td
                 className={`px-2 gap-x-1 flex items-center justify-center transform transition-transform duration-200`}
               >
                 <CaretDown weight="bold" size={20} />
-                <p className="text-xs text-white/50 w-[20px]">show</p>
+                <p className="text-xs text-foreground/50 w-[20px]">show</p>
               </td>
             )}
           </div>
@@ -74,7 +74,7 @@ const EventMetadata = ({ metadata, expanded = false }) => {
         Event Metadata
       </td>
       <td colSpan="4" className="px-6 py-4 rounded-r-2xl">
-        <div className="w-full rounded-lg bg-theme-bg-secondary p-2 text-white shadow-sm border-white/10 border bg-opacity-10">
+        <div className="w-full rounded-lg bg-theme-bg-secondary p-2 text-foreground shadow-sm border-border/10 border bg-opacity-10">
           <pre className="overflow-scroll">
             {JSON.stringify(metadata, null, 2)}
           </pre>
@@ -106,7 +106,7 @@ const EventBadge = ({ event }) => {
     };
 
   return (
-    <td className="px-6 py-2 font-medium whitespace-nowrap text-white flex items-center">
+    <td className="px-6 py-2 font-medium whitespace-nowrap text-foreground flex items-center">
       <span
         className={`rounded-full ${colorTheme.bg} px-2 py-0.5 text-xs font-medium ${colorTheme.text} shadow-sm`}
       >

--- a/frontend/src/pages/Admin/SystemPromptVariables/AddVariableModal/index.jsx
+++ b/frontend/src/pages/Admin/SystemPromptVariables/AddVariableModal/index.jsx
@@ -35,7 +35,7 @@ export default function AddVariableModal({ closeModal, onRefresh }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Add New Variable
             </h3>
           </div>
@@ -44,7 +44,7 @@ export default function AddVariableModal({ closeModal, onRefresh }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="p-6">
@@ -53,7 +53,7 @@ export default function AddVariableModal({ closeModal, onRefresh }) {
               <div>
                 <label
                   htmlFor="key"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Key
                 </label>
@@ -62,13 +62,13 @@ export default function AddVariableModal({ closeModal, onRefresh }) {
                   type="text"
                   minLength={3}
                   maxLength={255}
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="e.g., company_name"
                   required={true}
                   autoComplete="off"
                   pattern="^[a-zA-Z0-9_]+$"
                 />
-                <p className="mt-2 text-xs text-white/60">
+                <p className="mt-2 text-xs text-foreground/60">
                   Key must be unique and will be used in prompts as {"{key}"}.
                   Only letters, numbers and underscores are allowed.
                 </p>
@@ -76,14 +76,14 @@ export default function AddVariableModal({ closeModal, onRefresh }) {
               <div>
                 <label
                   htmlFor="value"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Value
                 </label>
                 <input
                   name="value"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="e.g., Acme Corp"
                   required={true}
                   autoComplete="off"
@@ -92,14 +92,14 @@ export default function AddVariableModal({ closeModal, onRefresh }) {
               <div>
                 <label
                   htmlFor="description"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Description
                 </label>
                 <input
                   name="description"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="Optional description"
                   autoComplete="off"
                 />
@@ -110,7 +110,7 @@ export default function AddVariableModal({ closeModal, onRefresh }) {
               <button
                 onClick={closeModal}
                 type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/Admin/SystemPromptVariables/VariableRow/EditVariableModal/index.jsx
+++ b/frontend/src/pages/Admin/SystemPromptVariables/VariableRow/EditVariableModal/index.jsx
@@ -36,7 +36,7 @@ export default function EditVariableModal({ variable, closeModal, onRefresh }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Edit {variable.key}
             </h3>
           </div>
@@ -45,7 +45,7 @@ export default function EditVariableModal({ variable, closeModal, onRefresh }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="p-6">
@@ -54,7 +54,7 @@ export default function EditVariableModal({ variable, closeModal, onRefresh }) {
               <div>
                 <label
                   htmlFor="key"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Key
                 </label>
@@ -63,14 +63,14 @@ export default function EditVariableModal({ variable, closeModal, onRefresh }) {
                   minLength={3}
                   maxLength={255}
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="e.g., company_name"
                   defaultValue={variable.key}
                   required={true}
                   autoComplete="off"
                   pattern="^[a-zA-Z0-9_]+$"
                 />
-                <p className="mt-2 text-xs text-white/60">
+                <p className="mt-2 text-xs text-foreground/60">
                   Key must be unique and will be used in prompts as {"{key}"}.
                   Only letters, numbers and underscores are allowed.
                 </p>
@@ -78,14 +78,14 @@ export default function EditVariableModal({ variable, closeModal, onRefresh }) {
               <div>
                 <label
                   htmlFor="value"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Value
                 </label>
                 <input
                   name="value"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="e.g., Acme Corp"
                   defaultValue={variable.value}
                   required={true}
@@ -95,14 +95,14 @@ export default function EditVariableModal({ variable, closeModal, onRefresh }) {
               <div>
                 <label
                   htmlFor="description"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Description
                 </label>
                 <input
                   name="description"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="Optional description"
                   defaultValue={variable.description}
                   autoComplete="off"
@@ -114,7 +114,7 @@ export default function EditVariableModal({ variable, closeModal, onRefresh }) {
               <button
                 onClick={closeModal}
                 type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/Admin/SystemPromptVariables/VariableRow/index.jsx
+++ b/frontend/src/pages/Admin/SystemPromptVariables/VariableRow/index.jsx
@@ -64,7 +64,7 @@ export default function VariableRow({ variable, onRefresh }) {
     <>
       <tr
         ref={rowRef}
-        className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10"
+        className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10"
       >
         <th scope="row" className="px-4 py-2 whitespace-nowrap">
           {variable.key}
@@ -89,13 +89,13 @@ export default function VariableRow({ variable, onRefresh }) {
             <>
               <button
                 onClick={openModal}
-                className="text-xs font-medium text-white/80 light:text-foreground rounded-sm hover:text-white hover:light:text-gray-500 px-2 py-1 hover:bg-card hover:bg-opacity-10"
+                className="text-xs font-medium text-foreground/80 light:text-foreground rounded-sm hover:text-foreground hover:light:text-foreground px-2 py-1 hover:bg-card hover:bg-opacity-10"
               >
                 Edit
               </button>
               <button
                 onClick={handleDelete}
-                className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
+                className="text-xs font-medium text-foreground/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
               >
                 <Trash className="h-4 w-4" />
               </button>

--- a/frontend/src/pages/Admin/Users/NewUserModal/index.jsx
+++ b/frontend/src/pages/Admin/Users/NewUserModal/index.jsx
@@ -32,7 +32,7 @@ export default function NewUserModal({ closeModal }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Add user to instance
             </h3>
           </div>
@@ -41,7 +41,7 @@ export default function NewUserModal({ closeModal }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="p-6">
@@ -50,20 +50,20 @@ export default function NewUserModal({ closeModal }) {
               <div>
                 <label
                   htmlFor="username"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Username
                 </label>
                 <input
                   name="username"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="User's username"
                   minLength={2}
                   required={true}
                   autoComplete="off"
                 />
-                <p className="mt-2 text-xs text-white/60">
+                <p className="mt-2 text-xs text-foreground/60">
                   Username must only contain lowercase letters, periods,
                   numbers, underscores, and hyphens with no spaces
                 </p>
@@ -71,33 +71,33 @@ export default function NewUserModal({ closeModal }) {
               <div>
                 <label
                   htmlFor="password"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Password
                 </label>
                 <input
                   name="password"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="User's initial password"
                   required={true}
                   autoComplete="off"
                   minLength={8}
                 />
-                <p className="mt-2 text-xs text-white/60">
+                <p className="mt-2 text-xs text-foreground/60">
                   Password must be at least 8 characters long
                 </p>
               </div>
               <div>
                 <label
                   htmlFor="bio"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Bio
                 </label>
                 <textarea
                   name="bio"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="User's bio"
                   autoComplete="off"
                   rows={3}
@@ -106,7 +106,7 @@ export default function NewUserModal({ closeModal }) {
               <div>
                 <label
                   htmlFor="role"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Role
                 </label>
@@ -115,7 +115,7 @@ export default function NewUserModal({ closeModal }) {
                   required={true}
                   defaultValue={"default"}
                   onChange={(e) => setRole(e.target.value)}
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 >
                   <option value="default">Default</option>
                   <option value="manager">Manager</option>
@@ -132,7 +132,7 @@ export default function NewUserModal({ closeModal }) {
                 updateState={setMessageLimit}
               />
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
-              <p className="text-white text-xs md:text-sm">
+              <p className="text-foreground text-xs md:text-sm">
                 After creating a user they will need to login with their initial
                 login to get access.
               </p>
@@ -141,7 +141,7 @@ export default function NewUserModal({ closeModal }) {
               <button
                 onClick={closeModal}
                 type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/Admin/Users/UserRow/EditUserModal/index.jsx
+++ b/frontend/src/pages/Admin/Users/UserRow/EditUserModal/index.jsx
@@ -47,7 +47,7 @@ export default function EditUserModal({ currentUser, user, closeModal }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Edit {user.username}
             </h3>
           </div>
@@ -56,7 +56,7 @@ export default function EditUserModal({ currentUser, user, closeModal }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="p-6">
@@ -65,21 +65,21 @@ export default function EditUserModal({ currentUser, user, closeModal }) {
               <div>
                 <label
                   htmlFor="username"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Username
                 </label>
                 <input
                   name="username"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="User's username"
                   defaultValue={user.username}
                   minLength={2}
                   required={true}
                   autoComplete="off"
                 />
-                <p className="mt-2 text-xs text-white/60">
+                <p className="mt-2 text-xs text-foreground/60">
                   Username must only contain lowercase letters, periods,
                   numbers, underscores, and hyphens with no spaces
                 </p>
@@ -87,32 +87,32 @@ export default function EditUserModal({ currentUser, user, closeModal }) {
               <div>
                 <label
                   htmlFor="password"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   New Password
                 </label>
                 <input
                   name="password"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder={`${user.username}'s new password`}
                   autoComplete="off"
                   minLength={8}
                 />
-                <p className="mt-2 text-xs text-white/60">
+                <p className="mt-2 text-xs text-foreground/60">
                   Password must be at least 8 characters long
                 </p>
               </div>
               <div>
                 <label
                   htmlFor="bio"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Bio
                 </label>
                 <textarea
                   name="bio"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="User's bio"
                   defaultValue={user.bio}
                   autoComplete="off"
@@ -122,7 +122,7 @@ export default function EditUserModal({ currentUser, user, closeModal }) {
               <div>
                 <label
                   htmlFor="role"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   Role
                 </label>
@@ -131,7 +131,7 @@ export default function EditUserModal({ currentUser, user, closeModal }) {
                   required={true}
                   defaultValue={user.role}
                   onChange={(e) => setRole(e.target.value)}
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                 >
                   <option value="default">Default</option>
                   <option value="manager">Manager</option>
@@ -153,7 +153,7 @@ export default function EditUserModal({ currentUser, user, closeModal }) {
               <button
                 onClick={closeModal}
                 type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/Admin/Users/UserRow/index.jsx
+++ b/frontend/src/pages/Admin/Users/UserRow/index.jsx
@@ -57,7 +57,7 @@ export default function UserRow({ currUser, user }) {
     <>
       <tr
         ref={rowRef}
-        className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10"
+        className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10"
       >
         <th scope="row" className="px-6 whitespace-nowrap">
           {user.username}
@@ -68,7 +68,7 @@ export default function UserRow({ currUser, user }) {
           {canModify && (
             <button
               onClick={openModal}
-              className="text-xs font-medium text-white/80 light:text-foreground rounded-sm hover:text-white hover:light:text-gray-500 px-2 py-1 hover:bg-card hover:bg-opacity-10"
+              className="text-xs font-medium text-foreground/80 light:text-foreground rounded-sm hover:text-foreground hover:light:text-foreground px-2 py-1 hover:bg-card hover:bg-opacity-10"
             >
               Edit
             </button>
@@ -77,13 +77,13 @@ export default function UserRow({ currUser, user }) {
             <>
               <button
                 onClick={handleSuspend}
-                className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-orange-500 hover:text-orange-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-orange-50 hover:bg-opacity-10"
+                className="text-xs font-medium text-foreground/80 light:text-foreground hover:light:text-orange-500 hover:text-orange-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-orange-50 hover:bg-opacity-10"
               >
                 {suspended ? "Unsuspend" : "Suspend"}
               </button>
               <button
                 onClick={handleDelete}
-                className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
+                className="text-xs font-medium text-foreground/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
               >
                 Delete
               </button>

--- a/frontend/src/pages/Admin/Users/index.jsx
+++ b/frontend/src/pages/Admin/Users/index.jsx
@@ -23,7 +23,7 @@ export default function AdminUsers() {
         className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
       >
         <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16">
-          <div className="w-full flex flex-col gap-y-1 pb-6 border-white/10 border-b-2">
+          <div className="w-full flex flex-col gap-y-1 pb-6 border-border/10 border-b-2">
             <div className="items-center flex gap-x-4">
               <p className="text-lg leading-6 font-bold text-theme-text-primary">
                 Users
@@ -85,7 +85,7 @@ function UsersContainer() {
 
   return (
     <table className="w-full text-xs text-left rounded-lg min-w-[640px] border-spacing-0">
-      <thead className="text-theme-text-secondary text-xs leading-[18px] font-bold uppercase border-white/10 border-b">
+      <thead className="text-theme-text-secondary text-xs leading-[18px] font-bold uppercase border-border/10 border-b">
         <tr>
           <th scope="col" className="px-6 py-3 rounded-tl-lg">
             Username
@@ -149,7 +149,7 @@ export function MessageLimitInput({ enabled, limit, updateState, role }) {
     <div className="mt-4 mb-8">
       <div className="flex flex-col gap-y-1">
         <div className="flex items-center gap-x-2">
-          <h2 className="text-base leading-6 font-bold text-white">
+          <h2 className="text-base leading-6 font-bold text-foreground">
             Limit messages per day
           </h2>
           <label className="relative inline-flex cursor-pointer items-center">
@@ -164,17 +164,17 @@ export function MessageLimitInput({ enabled, limit, updateState, role }) {
               }}
               className="peer sr-only"
             />
-            <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+            <div className="pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
           </label>
         </div>
-        <p className="text-xs leading-[18px] font-base text-white/60">
+        <p className="text-xs leading-[18px] font-base text-foreground/60">
           Restrict this user to a number of successful queries or chats within a
           24 hour window.
         </p>
       </div>
       {enabled && (
         <div className="mt-4">
-          <label className="text-white text-sm font-semibold block mb-4">
+          <label className="text-foreground text-sm font-semibold block mb-4">
             Message limit per day
           </label>
           <div className="relative mt-2">
@@ -189,7 +189,7 @@ export function MessageLimitInput({ enabled, limit, updateState, role }) {
               }}
               value={limit}
               min={1}
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
             />
           </div>
         </div>

--- a/frontend/src/pages/Admin/Workspaces/NewWorkspaceModal/index.jsx
+++ b/frontend/src/pages/Admin/Workspaces/NewWorkspaceModal/index.jsx
@@ -20,7 +20,7 @@ export default function NewWorkspaceModal({ closeModal }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Create new workspace
             </h3>
           </div>
@@ -29,7 +29,7 @@ export default function NewWorkspaceModal({ closeModal }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="p-6">
@@ -38,14 +38,14 @@ export default function NewWorkspaceModal({ closeModal }) {
               <div>
                 <label
                   htmlFor="name"
-                  className="block mb-2 text-sm font-medium text-white"
+                  className="block mb-2 text-sm font-medium text-foreground"
                 >
                   {t("common.workspaces-name")}
                 </label>
                 <input
                   name="name"
                   type="text"
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                   placeholder="My workspace"
                   minLength={4}
                   required={true}
@@ -53,7 +53,7 @@ export default function NewWorkspaceModal({ closeModal }) {
                 />
               </div>
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
-              <p className="text-white text-opacity-60 text-xs md:text-sm">
+              <p className="text-foreground text-opacity-60 text-xs md:text-sm">
                 After creating this workspace only admins will be able to see
                 it. You can add users after it has been created.
               </p>
@@ -62,7 +62,7 @@ export default function NewWorkspaceModal({ closeModal }) {
               <button
                 onClick={closeModal}
                 type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/Admin/Workspaces/WorkspaceRow/index.jsx
+++ b/frontend/src/pages/Admin/Workspaces/WorkspaceRow/index.jsx
@@ -20,7 +20,7 @@ export default function WorkspaceRow({ workspace, users }) {
     <>
       <tr
         ref={rowRef}
-        className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10"
+        className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10"
       >
         <th scope="row" className="px-6 whitespace-nowrap">
           {workspace.name}
@@ -30,7 +30,7 @@ export default function WorkspaceRow({ workspace, users }) {
             href={paths.workspace.chat(workspace.slug)}
             target="_blank"
             rel="noreferrer"
-            className="text-white flex items-center hover:underline"
+            className="text-foreground flex items-center hover:underline"
           >
             <LinkSimple className="mr-2 w-4 h-4" /> {workspace.slug}
           </a>
@@ -38,7 +38,7 @@ export default function WorkspaceRow({ workspace, users }) {
         <td className="px-6">
           <a
             href={paths.workspace.settings.members(workspace.slug)}
-            className="text-white flex items-center underline"
+            className="text-foreground flex items-center underline"
           >
             {workspace.userIds?.length}
           </a>
@@ -47,7 +47,7 @@ export default function WorkspaceRow({ workspace, users }) {
         <td className="px-6 flex items-center gap-x-6 h-full mt-1">
           <button
             onClick={handleDelete}
-            className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
+            className="text-xs font-medium text-foreground/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
           >
             <Trash className="h-5 w-5" />
           </button>

--- a/frontend/src/pages/GeneralSettings/ApiKeys/ApiKeyRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ApiKeys/ApiKeyRow/index.jsx
@@ -41,7 +41,7 @@ export default function ApiKeyRow({ apiKey, removeApiKey }) {
 
   return (
     <>
-      <tr className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10">
+      <tr className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10">
         <td scope="row" className="px-6 whitespace-nowrap">
           {apiKey.secret}
         </td>
@@ -51,13 +51,13 @@ export default function ApiKeyRow({ apiKey, removeApiKey }) {
           <button
             onClick={copyApiKey}
             disabled={copied}
-            className="text-xs font-medium text-blue-300 rounded-sm hover:text-white hover:light:text-blue-500 hover:text-opacity-60 hover:underline"
+            className="text-xs font-medium text-blue-300 rounded-sm hover:text-foreground hover:light:text-blue-500 hover:text-opacity-60 hover:underline"
           >
             {copied ? "Copied" : "Copy API Key"}
           </button>
           <button
             onClick={handleDelete}
-            className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
+            className="text-xs font-medium text-foreground/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
           >
             <Trash className="h-5 w-5" />
           </button>

--- a/frontend/src/pages/GeneralSettings/ApiKeys/NewApiKeyModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ApiKeys/NewApiKeyModal/index.jsx
@@ -49,7 +49,7 @@ export default function NewApiKeyModal({ closeModal, onSuccess }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Create new API key
             </h3>
           </div>
@@ -58,7 +58,7 @@ export default function NewApiKeyModal({ closeModal, onSuccess }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="px-7 py-6">
@@ -71,7 +71,7 @@ export default function NewApiKeyModal({ closeModal, onSuccess }) {
                     type="text"
                     defaultValue={`${apiKey.secret}`}
                     disabled={true}
-                    className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm outline-none block w-full p-2.5 pr-10"
+                    className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm outline-none block w-full p-2.5 pr-10"
                   />
                   <button
                     type="button"
@@ -86,12 +86,12 @@ export default function NewApiKeyModal({ closeModal, onSuccess }) {
                         weight="bold"
                       />
                     ) : (
-                      <Copy size={20} className="text-white" weight="bold" />
+                      <Copy size={20} className="text-foreground" weight="bold" />
                     )}
                   </button>
                 </div>
               )}
-              <p className="text-white text-opacity-60 text-xs md:text-sm">
+              <p className="text-foreground text-opacity-60 text-xs md:text-sm">
                 Once created the API key can be used to programmatically access
                 and configure this OneNew instance.
               </p>
@@ -110,7 +110,7 @@ export default function NewApiKeyModal({ closeModal, onSuccess }) {
                   <button
                     onClick={closeModal}
                     type="button"
-                    className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm mr-2"
+                    className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm mr-2"
                   >
                     Cancel
                   </button>
@@ -125,7 +125,7 @@ export default function NewApiKeyModal({ closeModal, onSuccess }) {
                 <button
                   onClick={closeModal}
                   type="button"
-                  className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                  className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
                 >
                   Close
                 </button>

--- a/frontend/src/pages/GeneralSettings/AudioPreference/stt.jsx
+++ b/frontend/src/pages/GeneralSettings/AudioPreference/stt.jsx
@@ -77,13 +77,13 @@ export default function SpeechToTextProvider({ settings }) {
   return (
     <form onSubmit={handleSubmit} className="flex w-full">
       <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16">
-        <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+        <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
           <div className="flex gap-x-4 items-center">
-            <p className="text-lg leading-6 font-bold text-white">
+            <p className="text-lg leading-6 font-bold text-foreground">
               Speech-to-text Preference
             </p>
           </div>
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
             Here you can specify what kind of text-to-speech and speech-to-text
             providers you would want to use in your OneNew experience. By
             default, we use the browser's built in support for these services,
@@ -100,7 +100,7 @@ export default function SpeechToTextProvider({ settings }) {
             </CTAButton>
           )}
         </div>
-        <div className="text-base font-bold text-white mt-6 mb-4">Provider</div>
+        <div className="text-base font-bold text-foreground mt-6 mb-4">Provider</div>
         <div className="relative">
           {searchMenuOpen && (
             <div
@@ -132,7 +132,7 @@ export default function SpeechToTextProvider({ settings }) {
                   <X
                     size={20}
                     weight="bold"
-                    className="cursor-pointer text-white hover:text-x-button"
+                    className="cursor-pointer text-foreground hover:text-x-button"
                     onClick={handleXButton}
                   />
                 </div>
@@ -164,7 +164,7 @@ export default function SpeechToTextProvider({ settings }) {
                   className="w-10 h-10 rounded-md"
                 />
                 <div className="flex flex-col text-left">
-                  <div className="text-sm font-semibold text-white">
+                  <div className="text-sm font-semibold text-foreground">
                     {selectedProviderObject.name}
                   </div>
                   <div className="mt-1 text-xs text-description">
@@ -172,7 +172,7 @@ export default function SpeechToTextProvider({ settings }) {
                   </div>
                 </div>
               </div>
-              <CaretUpDown size={24} weight="bold" className="text-white" />
+              <CaretUpDown size={24} weight="bold" className="text-foreground" />
             </button>
           )}
         </div>

--- a/frontend/src/pages/GeneralSettings/AudioPreference/tts.jsx
+++ b/frontend/src/pages/GeneralSettings/AudioPreference/tts.jsx
@@ -115,13 +115,13 @@ export default function TextToSpeechProvider({ settings }) {
   return (
     <form onSubmit={handleSubmit} className="flex w-full">
       <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16">
-        <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+        <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
           <div className="flex gap-x-4 items-center">
-            <p className="text-lg leading-6 font-bold text-white">
+            <p className="text-lg leading-6 font-bold text-foreground">
               Text-to-speech Preference
             </p>
           </div>
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
             Here you can specify what kind of text-to-speech providers you would
             want to use in your OneNew experience. By default, we use the
             browser's built in support for these services, but you may want to
@@ -135,7 +135,7 @@ export default function TextToSpeechProvider({ settings }) {
             </CTAButton>
           )}
         </div>
-        <div className="text-base font-bold text-white mt-6 mb-4">Provider</div>
+        <div className="text-base font-bold text-foreground mt-6 mb-4">Provider</div>
         <div className="relative">
           {searchMenuOpen && (
             <div
@@ -167,7 +167,7 @@ export default function TextToSpeechProvider({ settings }) {
                   <X
                     size={20}
                     weight="bold"
-                    className="cursor-pointer text-white hover:text-x-button"
+                    className="cursor-pointer text-foreground hover:text-x-button"
                     onClick={handleXButton}
                   />
                 </div>
@@ -199,7 +199,7 @@ export default function TextToSpeechProvider({ settings }) {
                   className="w-10 h-10 rounded-md"
                 />
                 <div className="flex flex-col text-left">
-                  <div className="text-sm font-semibold text-white">
+                  <div className="text-sm font-semibold text-foreground">
                     {selectedProviderObject.name}
                   </div>
                   <div className="mt-1 text-xs text-description">
@@ -207,7 +207,7 @@ export default function TextToSpeechProvider({ settings }) {
                   </div>
                 </div>
               </div>
-              <CaretUpDown size={24} weight="bold" className="text-white" />
+              <CaretUpDown size={24} weight="bold" className="text-foreground" />
             </button>
           )}
         </div>

--- a/frontend/src/pages/GeneralSettings/BrowserExtensionApiKey/BrowserExtensionApiKeyRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/BrowserExtensionApiKey/BrowserExtensionApiKeyRow/index.jsx
@@ -58,7 +58,7 @@ export default function BrowserExtensionApiKeyRow({
   return (
     <tr
       ref={rowRef}
-      className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10"
+      className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10"
     >
       <td scope="row" className="px-6 py-2 whitespace-nowrap">
         <div className="flex items-center">
@@ -99,7 +99,7 @@ export default function BrowserExtensionApiKeyRow({
       <td className="px-6 py-2">
         <button
           onClick={handleRevoke}
-          className="text-xs font-medium text-white/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
+          className="text-xs font-medium text-foreground/80 light:text-foreground hover:light:text-red-500 hover:text-red-300 rounded-sm px-2 py-1 hover:bg-card hover:light:bg-red-50 hover:bg-opacity-10"
         >
           <Trash className="h-4 w-4" />
         </button>

--- a/frontend/src/pages/GeneralSettings/BrowserExtensionApiKey/NewBrowserExtensionApiKeyModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/BrowserExtensionApiKey/NewBrowserExtensionApiKeyModal/index.jsx
@@ -52,7 +52,7 @@ export default function NewBrowserExtensionApiKeyModal({
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               New Browser Extension API Key
             </h3>
           </div>
@@ -61,7 +61,7 @@ export default function NewBrowserExtensionApiKeyModal({
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="px-7 py-6">
@@ -73,7 +73,7 @@ export default function NewBrowserExtensionApiKeyModal({
                   type="text"
                   defaultValue={apiKey}
                   disabled={true}
-                  className="border-none bg-theme-settings-input-bg w-full text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm block w-full p-2.5"
+                  className="border-none bg-theme-settings-input-bg w-full text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm block w-full p-2.5"
                 />
               )}
               {isMultiUser && (
@@ -83,11 +83,11 @@ export default function NewBrowserExtensionApiKeyModal({
                   share it cautiously.
                 </p>
               )}
-              <p className="text-white text-opacity-60 text-xs md:text-sm">
+              <p className="text-foreground text-opacity-60 text-xs md:text-sm">
                 After clicking "Create API Key", OneNew will attempt to connect
                 to your browser extension automatically.
               </p>
-              <p className="text-white text-opacity-60 text-xs md:text-sm">
+              <p className="text-foreground text-opacity-60 text-xs md:text-sm">
                 If you see "Connected to OneNew" in the extension, the
                 connection was successful. If not, please copy the connection
                 string and paste it into the extension manually.
@@ -99,7 +99,7 @@ export default function NewBrowserExtensionApiKeyModal({
                   <button
                     onClick={closeModal}
                     type="button"
-                    className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                    className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
                   >
                     Cancel
                   </button>

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedChats/ChatRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedChats/ChatRow/index.jsx
@@ -35,13 +35,13 @@ export default function ChatRow({ chat, onDelete }) {
 
   return (
     <>
-      <tr className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10">
-        <td className="px-6 font-medium whitespace-nowrap text-white">
+      <tr className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10">
+        <td className="px-6 font-medium whitespace-nowrap text-foreground">
           <a
             href={paths.settings.embedChatWidgets()}
             target="_blank"
             rel="noreferrer"
-            className="text-white flex items-center hover:underline"
+            className="text-foreground flex items-center hover:underline"
           >
             {chat.embed_config.workspace.name}
           </a>
@@ -108,17 +108,17 @@ const TextPreview = ({ text, closeModal }) => {
     <div className="relative w-full md:max-w-2xl max-h-full">
       <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
         <div className="flex items-center justify-between p-6 border-b rounded-t border-theme-modal-border">
-          <h3 className="text-xl font-semibold text-white">Viewing Text</h3>
+          <h3 className="text-xl font-semibold text-foreground">Viewing Text</h3>
           <button
             onClick={closeModal}
             type="button"
             className="bg-transparent rounded-sm text-sm p-1.5 ml-auto inline-flex items-center bg-sidebar-button hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X className="text-white text-lg" />
+            <X className="text-foreground text-lg" />
           </button>
         </div>
         <div className="w-full p-6">
-          <pre className="w-full h-[200px] py-2 px-4 whitespace-pre-line overflow-auto rounded-lg bg-zinc-900 light:bg-theme-bg-secondary border border-gray-500 text-white text-sm">
+          <pre className="w-full h-[200px] py-2 px-4 whitespace-pre-line overflow-auto rounded-lg bg-zinc-900 light:bg-theme-bg-secondary border border-border text-foreground text-sm">
             {text}
           </pre>
         </div>

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedChats/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedChats/index.jsx
@@ -137,7 +137,7 @@ export default function EmbedChatsView() {
             <button
               ref={openMenuButton}
               onClick={toggleMenu}
-              className="flex items-center gap-x-2 px-4 py-1 rounded-sm text-theme-bg-chat bg-primary-button hover:bg-secondary hover:text-white text-xs font-semibold h-[34px] w-fit"
+              className="flex items-center gap-x-2 px-4 py-1 rounded-sm text-theme-bg-chat bg-primary-button hover:bg-secondary hover:text-foreground text-xs font-semibold h-[34px] w-fit"
             >
               <Download size={18} weight="bold" />
               {t("embed-chats.export")}
@@ -157,7 +157,7 @@ export default function EmbedChatsView() {
                       handleDumpChats(key);
                       setShowMenu(false);
                     }}
-                    className="w-full text-left px-4 py-2 text-white text-sm hover:bg-[#3D4147] light:hover:bg-theme-sidebar-item-hover"
+                    className="w-full text-left px-4 py-2 text-foreground text-sm hover:bg-[#3D4147] light:hover:bg-theme-sidebar-item-hover"
                   >
                     {data.name}
                   </button>
@@ -172,7 +172,7 @@ export default function EmbedChatsView() {
       </div>
       <div className="overflow-x-auto mt-6">
         <table className="w-full text-xs text-left rounded-lg min-w-[640px] border-spacing-0">
-          <thead className="text-theme-text-secondary text-xs leading-[18px] font-bold uppercase border-white/10 border-b">
+          <thead className="text-theme-text-secondary text-xs leading-[18px] font-bold uppercase border-border/10 border-b">
             <tr>
               <th scope="col" className="px-6 py-3 rounded-tl-lg">
                 {t("embed-chats.table.embed")}

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/CodeSnippetModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/CodeSnippetModal/index.jsx
@@ -11,7 +11,7 @@ export default function CodeSnippetModal({ embed, closeModal }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Copy your embed code
             </h3>
           </div>
@@ -20,7 +20,7 @@ export default function CodeSnippetModal({ embed, closeModal }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="px-7 py-6">
@@ -31,7 +31,7 @@ export default function CodeSnippetModal({ embed, closeModal }) {
             <button
               onClick={closeModal}
               type="button"
-              className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+              className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
             >
               Close
             </button>
@@ -82,7 +82,7 @@ const ScriptTag = ({ embed }) => {
   return (
     <div>
       <div className="flex flex-col mb-2">
-        <label className="block text-sm font-medium text-white">
+        <label className="block text-sm font-medium text-foreground">
           HTML Script Tag Embed Code
         </label>
         <p className="text-theme-text-secondary text-xs">
@@ -101,7 +101,7 @@ const ScriptTag = ({ embed }) => {
       <button
         disabled={copied}
         onClick={handleClick}
-        className={`disabled:border disabled:border-green-300 disabled:light:border-green-600 border border-transparent relative w-full font-mono flex hljs ${theme} light:border light:border-gray-700 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5 m-1`}
+        className={`disabled:border disabled:border-green-300 disabled:light:border-green-600 border border-transparent relative w-full font-mono flex hljs ${theme} light:border light:border-border text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none p-2.5 m-1`}
       >
         <div
           className="flex w-full text-left flex-col gap-y-1 pr-6 pl-4 whitespace-pre-line"

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/EditEmbedModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/EditEmbedModal/index.jsx
@@ -34,7 +34,7 @@ export default function EditEmbedModal({ embed, closeModal }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Update embed #{embed.id}
             </h3>
           </div>
@@ -43,7 +43,7 @@ export default function EditEmbedModal({ embed, closeModal }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="px-7 py-6">
@@ -96,10 +96,10 @@ export default function EditEmbedModal({ embed, closeModal }) {
               />
 
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
-              <p className="text-white text-opacity-60 text-xs md:text-sm">
+              <p className="text-foreground text-opacity-60 text-xs md:text-sm">
                 After creating an embed you will be provided a link that you can
                 publish on your website with a simple
-                <code className="border-none bg-theme-settings-input-bg text-white mx-1 px-1 rounded-sm">
+                <code className="border-none bg-theme-settings-input-bg text-foreground mx-1 px-1 rounded-sm">
                   &lt;script&gt;
                 </code>{" "}
                 tag.
@@ -109,7 +109,7 @@ export default function EditEmbedModal({ embed, closeModal }) {
               <button
                 onClick={closeModal}
                 type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/EmbedRow/index.jsx
@@ -64,7 +64,7 @@ export default function EmbedRow({ embed }) {
     <>
       <tr
         ref={rowRef}
-        className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10"
+        className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10"
       >
         <th
           scope="row"
@@ -74,7 +74,7 @@ export default function EmbedRow({ embed }) {
             href={paths.workspace.chat(embed.workspace.slug)}
             target="_blank"
             rel="noreferrer"
-            className="text-white flex items-center hover:underline"
+            className="text-foreground flex items-center hover:underline"
           >
             {embed.workspace.name}
           </a>

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/NewEmbedModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/EmbedConfigs/NewEmbedModal/index.jsx
@@ -42,7 +42,7 @@ export default function NewEmbedModal({ closeModal }) {
       <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
         <div className="relative p-6 border-b rounded-t border-theme-modal-border">
           <div className="w-full flex gap-x-2 items-center">
-            <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+            <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
               Create new embed for workspace
             </h3>
           </div>
@@ -51,7 +51,7 @@ export default function NewEmbedModal({ closeModal }) {
             type="button"
             className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X size={24} weight="bold" className="text-white" />
+            <X size={24} weight="bold" className="text-foreground" />
           </button>
         </div>
         <div className="px-7 py-6">
@@ -93,10 +93,10 @@ export default function NewEmbedModal({ closeModal }) {
               />
 
               {error && <p className="text-red-400 text-sm">Error: {error}</p>}
-              <p className="text-white text-opacity-60 text-xs md:text-sm">
+              <p className="text-foreground text-opacity-60 text-xs md:text-sm">
                 After creating an embed you will be provided a link that you can
                 publish on your website with a simple
-                <code className="light:bg-stone-300 bg-stone-900 text-white mx-1 px-1 rounded-sm">
+                <code className="light:bg-stone-300 bg-stone-900 text-foreground mx-1 px-1 rounded-sm">
                   &lt;script&gt;
                 </code>{" "}
                 tag.
@@ -106,7 +106,7 @@ export default function NewEmbedModal({ closeModal }) {
               <button
                 onClick={closeModal}
                 type="button"
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>
@@ -139,7 +139,7 @@ export const WorkspaceSelection = ({ defaultValue = null }) => {
       <div className="flex flex-col mb-2">
         <label
           htmlFor="workspace_id"
-          className="block  text-sm font-medium text-white"
+          className="block  text-sm font-medium text-foreground"
         >
           Workspace
         </label>
@@ -152,7 +152,7 @@ export const WorkspaceSelection = ({ defaultValue = null }) => {
         name="workspace_id"
         required={true}
         defaultValue={defaultValue}
-        className="min-w-[15rem] rounded-sm bg-theme-settings-input-bg px-4 py-2 text-sm text-white focus:ring-blue-500 focus:border-blue-500"
+        className="min-w-[15rem] rounded-sm bg-theme-settings-input-bg px-4 py-2 text-sm text-foreground focus:ring-blue-500 focus:border-blue-500"
       >
         {workspaces.map((workspace) => {
           return (
@@ -177,7 +177,7 @@ export const ChatModeSelection = ({ defaultValue = null }) => {
     <div>
       <div className="flex flex-col mb-2">
         <label
-          className="block text-sm font-medium text-white"
+          className="block text-sm font-medium text-foreground"
           htmlFor="chat_mode"
         >
           Allowed chat method
@@ -291,7 +291,7 @@ export const PermittedDomains = ({ defaultValue = [] }) => {
       <div className="flex flex-col mb-2">
         <label
           htmlFor="allowlist_domains"
-          className="block text-sm font-medium text-white"
+          className="block text-sm font-medium text-foreground"
         >
           Restrict requests from domains
         </label>
@@ -311,7 +311,7 @@ export const PermittedDomains = ({ defaultValue = [] }) => {
         classNames={{
           tag: "bg-theme-settings-input-bg light:bg-black/10 bg-blue-300/10 text-zinc-800",
           input:
-            "flex p-1 !bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none",
+            "flex p-1 !bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none",
         }}
       />
     </div>
@@ -322,7 +322,7 @@ export const NumberInput = ({ name, title, hint, defaultValue = 0 }) => {
   return (
     <div>
       <div className="flex flex-col mb-2">
-        <label htmlFor={name} className="block text-sm font-medium text-white">
+        <label htmlFor={name} className="block text-sm font-medium text-foreground">
           {title}
         </label>
         <p className="text-theme-text-secondary text-xs">{hint}</p>
@@ -330,7 +330,7 @@ export const NumberInput = ({ name, title, hint, defaultValue = 0 }) => {
       <input
         type="number"
         name={name}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-[15rem] p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-[15rem] p-2.5"
         min={0}
         defaultValue={defaultValue}
         onScroll={(e) => e.target.blur()}
@@ -345,7 +345,7 @@ export const BooleanInput = ({ name, title, hint, defaultValue = null }) => {
   return (
     <div>
       <div className="flex flex-col mb-2">
-        <label htmlFor={name} className="block text-sm font-medium text-white">
+        <label htmlFor={name} className="block text-sm font-medium text-foreground">
           {title}
         </label>
         <p className="text-theme-text-secondary text-xs">{hint}</p>
@@ -358,7 +358,7 @@ export const BooleanInput = ({ name, title, hint, defaultValue = null }) => {
           checked={status}
           className="peer sr-only pointer-events-none"
         />
-        <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
+        <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"></div>
       </label>
     </div>
   );

--- a/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/index.jsx
+++ b/frontend/src/pages/GeneralSettings/ChatEmbedWidgets/index.jsx
@@ -40,7 +40,7 @@ export default function ChatEmbedWidgets() {
                       setShowViewModal(false);
                       setSelectedView("");
                     }}
-                    className="text-white/60 hover:text-white transition-colors duration-200"
+                    className="text-foreground/60 hover:text-foreground transition-colors duration-200"
                   >
                     <div className="flex items-center text-sky-400">
                       <CaretLeft size={24} />
@@ -49,7 +49,7 @@ export default function ChatEmbedWidgets() {
                   </button>
                 </div>
                 <div className="flex-1 overflow-y-auto p-4">
-                  <div className="bg-theme-bg-secondary text-white rounded-xl p-4 overflow-y-scroll no-scroll">
+                  <div className="bg-theme-bg-secondary text-foreground rounded-xl p-4 overflow-y-scroll no-scroll">
                     {selectedView === "configs" ? (
                       <EmbedConfigsView />
                     ) : (
@@ -85,7 +85,7 @@ export default function ChatEmbedWidgets() {
           </div>
         </div>
         <div className="flex-[2] flex flex-col gap-y-[18px] mt-10">
-          <div className="bg-theme-bg-secondary text-white rounded-xl flex-1 p-4 overflow-y-scroll no-scroll">
+          <div className="bg-theme-bg-secondary text-foreground rounded-xl flex-1 p-4 overflow-y-scroll no-scroll">
             {selectedView === "configs" ? (
               <EmbedConfigsView />
             ) : (
@@ -127,7 +127,7 @@ function WidgetList({ selectedView, handleClick }) {
 
   return (
     <div
-      className={`bg-theme-bg-secondary text-white rounded-xl ${isMobile ? "w-full" : "min-w-[360px] w-fit"}`}
+      className={`bg-theme-bg-secondary text-foreground rounded-xl ${isMobile ? "w-full" : "min-w-[360px] w-fit"}`}
     >
       {Object.entries(views).map(([view, settings], index) => (
         <div
@@ -137,7 +137,7 @@ function WidgetList({ selectedView, handleClick }) {
           } ${
             index === Object.keys(views).length - 1
               ? "rounded-b-xl"
-              : "border-b border-white/10"
+              : "border-b border-border/10"
           } cursor-pointer transition-all duration-300 hover:bg-theme-bg-primary ${
             selectedView === view ? "bg-card light:bg-theme-bg-sidebar" : ""
           }`}

--- a/frontend/src/pages/GeneralSettings/Chats/ChatRow/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Chats/ChatRow/index.jsx
@@ -47,11 +47,11 @@ export default function ChatRow({ chat, onDelete }) {
 
   return (
     <>
-      <tr className="bg-transparent text-white text-opacity-80 text-xs font-medium border-b border-white/10 h-10">
-        <td className="px-6 font-medium whitespace-nowrap text-white">
+      <tr className="bg-transparent text-foreground text-opacity-80 text-xs font-medium border-b border-border/10 h-10">
+        <td className="px-6 font-medium whitespace-nowrap text-foreground">
           {chat.id}
         </td>
-        <td className="px-6 font-medium whitespace-nowrap text-white">
+        <td className="px-6 font-medium whitespace-nowrap text-foreground">
           {chat.user?.username}
         </td>
         <td className="px-6">{chat.workspace?.name}</td>
@@ -72,7 +72,7 @@ export default function ChatRow({ chat, onDelete }) {
         <td className="px-6 cell-actions">
           <button
             onClick={handleDelete}
-            className="icon-btn text-white/80 light:text-foreground hover:text-red-300 light:hover:text-red-500"
+            className="icon-btn text-foreground/80 light:text-foreground hover:text-red-300 light:hover:text-red-500"
           >
             <Trash className="h-5 w-5" />
           </button>
@@ -95,17 +95,17 @@ const TextPreview = ({ text, closeModal }) => {
     <div className="relative w-full md:max-w-2xl max-h-full">
       <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
         <div className="flex items-center justify-between p-6 border-b rounded-t border-theme-modal-border">
-          <h3 className="text-xl font-semibold text-white">Viewing Text</h3>
+          <h3 className="text-xl font-semibold text-foreground">Viewing Text</h3>
           <button
             onClick={closeModal}
             type="button"
             className="bg-transparent rounded-sm text-sm p-1.5 ml-auto inline-flex items-center bg-sidebar-button hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X className="text-white text-lg" />
+            <X className="text-foreground text-lg" />
           </button>
         </div>
         <div className="w-full p-6">
-          <pre className="w-full h-[200px] py-2 px-4 whitespace-pre-line overflow-auto rounded-lg bg-zinc-900 light:bg-theme-bg-secondary border border-gray-500 text-white text-sm">
+          <pre className="w-full h-[200px] py-2 px-4 whitespace-pre-line overflow-auto rounded-lg bg-zinc-900 light:bg-theme-bg-secondary border border-border text-foreground text-sm">
             {text}
           </pre>
         </div>

--- a/frontend/src/pages/GeneralSettings/Chats/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Chats/index.jsx
@@ -124,7 +124,7 @@ export default function WorkspaceChats() {
           className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
         >
           <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16">
-            <div className="w-full flex flex-col gap-y-1 pb-6 border-white/10 border-b-2">
+            <div className="w-full flex flex-col gap-y-1 pb-6 border-border/10 border-b-2">
               <div className="flex flex-wrap gap-4 items-center">
                 <p className="text-lg leading-6 font-bold text-theme-text-primary">
                   {t("recorded.title")}
@@ -153,7 +153,7 @@ export default function WorkspaceChats() {
                             handleDumpChats(key);
                             setShowMenu(false);
                           }}
-                          className="w-full text-left px-4 py-2 text-white text-sm hover:bg-[#3D4147] light:hover:bg-theme-sidebar-item-hover"
+                          className="w-full text-left px-4 py-2 text-foreground text-sm hover:bg-[#3D4147] light:hover:bg-theme-sidebar-item-hover"
                         >
                           {data.name}
                         </button>
@@ -164,7 +164,7 @@ export default function WorkspaceChats() {
                 {chats.length > 0 && (
                   <button
                     onClick={handleClearAllChats}
-                    className="flex items-center gap-x-2 px-4 py-1 border hover:border-transparent light:border-theme-sidebar-border border-white/40 text-white/40 light:text-theme-text-secondary rounded-sm bg-transparent hover:light:text-theme-bg-primary hover:text-theme-text-primary text-xs font-semibold hover:bg-red-500 shadow-[0_4px_14px_rgba(0,0,0,0.25)] h-[34px] w-fit"
+                    className="flex items-center gap-x-2 px-4 py-1 border hover:border-transparent light:border-theme-sidebar-border border-border/40 text-foreground/40 light:text-theme-text-secondary rounded-sm bg-transparent hover:light:text-theme-bg-primary hover:text-theme-text-primary text-xs font-semibold hover:bg-red-500 shadow-[0_4px_14px_rgba(0,0,0,0.25)] h-[34px] w-fit"
                   >
                     <Trash size={18} weight="bold" />
                     Clear Chats
@@ -231,7 +231,7 @@ function ChatsContainer({
   return (
     <>
       <table className="w-full text-xs text-left rounded-lg min-w-[640px] border-spacing-0">
-        <thead className="text-theme-text-secondary text-xs leading-[18px] font-bold uppercase border-white/10 border-b">
+        <thead className="text-theme-text-secondary text-xs leading-[18px] font-bold uppercase border-border/10 border-b">
           <tr>
             <th scope="col" className="px-6 py-3 rounded-tl-lg">
               {t("recorded.table.id")}

--- a/frontend/src/pages/GeneralSettings/CommunityHub/Authentication/UserItems/index.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/Authentication/UserItems/index.jsx
@@ -16,9 +16,9 @@ export default function UserItems({ connectionKey }) {
   return (
     <div className="flex flex-col gap-y-8">
       {/* Created By Me Section */}
-      <div className="w-full flex flex-col gap-y-1 pb-6 border-white border-b-2 border-opacity-10">
+      <div className="w-full flex flex-col gap-y-1 pb-6 border-border border-b-2 border-opacity-10">
         <div className="flex items-center justify-between">
-          <p className="text-lg leading-6 font-bold text-white">
+          <p className="text-lg leading-6 font-bold text-foreground">
             Created by me
           </p>
           <a
@@ -30,7 +30,7 @@ export default function UserItems({ connectionKey }) {
             Why can't I see my private items?
           </a>
         </div>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
           Items you have created and shared publicly on the OneNew Community
           Hub.
         </p>
@@ -39,7 +39,7 @@ export default function UserItems({ connectionKey }) {
             if (!createdByMe[type]?.items?.length) return null;
             return (
               <div key={type} className="rounded-lg w-full">
-                <h3 className="text-white capitalize font-medium mb-3">
+                <h3 className="text-foreground capitalize font-medium mb-3">
                   {readableType(type)}
                 </h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
@@ -51,7 +51,7 @@ export default function UserItems({ connectionKey }) {
             );
           })}
           {!hasItems(createdByMe) && (
-            <p className="text-white/60 text-xs text-center mt-4">
+            <p className="text-foreground/60 text-xs text-center mt-4">
               You haven&apos;t created any items yet.
             </p>
           )}
@@ -59,26 +59,26 @@ export default function UserItems({ connectionKey }) {
       </div>
 
       {/* Team Items Section */}
-      <div className="w-full flex flex-col gap-y-1 pb-6 border-white border-b-2 border-opacity-10">
+      <div className="w-full flex flex-col gap-y-1 pb-6 border-border border-b-2 border-opacity-10">
         <div className="items-center">
-          <p className="text-lg leading-6 font-bold text-white">
+          <p className="text-lg leading-6 font-bold text-foreground">
             Items by team
           </p>
         </div>
-        <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+        <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
           Public and private items shared with teams you belong to.
         </p>
         <div className="flex flex-col gap-4 mt-4">
           {teamItems.map((team) => (
             <div key={team.teamId} className="flex flex-col gap-y-4">
-              <h3 className="text-white text-sm font-medium">
+              <h3 className="text-foreground text-sm font-medium">
                 {team.teamName}
               </h3>
               {Object.keys(team.items).map((type) => {
                 if (!team.items[type]?.items?.length) return null;
                 return (
                   <div key={type} className="rounded-lg w-full">
-                    <h3 className="text-white capitalize font-medium mb-3">
+                    <h3 className="text-foreground capitalize font-medium mb-3">
                       {readableType(type)}
                     </h3>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
@@ -90,7 +90,7 @@ export default function UserItems({ connectionKey }) {
                 );
               })}
               {!hasItems(team.items) && (
-                <p className="text-white/60 text-xs text-center mt-4">
+                <p className="text-foreground/60 text-xs text-center mt-4">
                   No items shared with this team yet.
                 </p>
               )}

--- a/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/AgentFlow.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/AgentFlow.jsx
@@ -38,7 +38,7 @@ export default function AgentFlow({ item, setStep }) {
           Import Agent Flow &quot;{item.name}&quot;
         </h2>
         {item.creatorUsername && (
-          <p className="text-white/60 light:text-theme-text-secondary text-xs font-mono">
+          <p className="text-foreground/60 light:text-theme-text-secondary text-xs font-mono">
             Created by{" "}
             <a
               href={paths.communityHub.profile(item.creatorUsername)}
@@ -51,7 +51,7 @@ export default function AgentFlow({ item, setStep }) {
           </p>
         )}
       </div>
-      <div className="flex flex-col gap-y-[25px] text-white/80 light:text-theme-text-secondary text-sm">
+      <div className="flex flex-col gap-y-[25px] text-foreground/80 light:text-theme-text-secondary text-sm">
         <p>
           Agent flows allow you to create reusable sequences of actions that can
           be triggered by your agent.

--- a/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/AgentSkill.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/AgentSkill.jsx
@@ -37,7 +37,7 @@ export default function AgentSkill({ item, settings, setStep }) {
 
   return (
     <div className="flex flex-col mt-4 gap-y-4">
-      <div className="border border-white/10 light:border-orange-500/20 my-2 flex flex-col md:flex-row md:items-center gap-x-2 text-theme-text-primary light:text-orange-600 mb-4 bg-orange-800/30 light:bg-orange-500/10 rounded-lg px-4 py-2">
+      <div className="border border-border/10 light:border-orange-500/20 my-2 flex flex-col md:flex-row md:items-center gap-x-2 text-theme-text-primary light:text-orange-600 mb-4 bg-orange-800/30 light:bg-orange-500/10 rounded-lg px-4 py-2">
         <div className="flex flex-col gap-y-2">
           <div className="gap-x-2 flex items-center">
             <Warning size={25} />
@@ -60,7 +60,7 @@ export default function AgentSkill({ item, settings, setStep }) {
           Review Agent Skill "{item.name}"
         </h2>
         {item.creatorUsername && (
-          <p className="text-white/60 light:text-theme-text-secondary text-xs font-mono">
+          <p className="text-foreground/60 light:text-theme-text-secondary text-xs font-mono">
             Created by{" "}
             <a
               href={paths.communityHub.profile(item.creatorUsername)}
@@ -90,7 +90,7 @@ export default function AgentSkill({ item, settings, setStep }) {
           </a>
         </div>
       </div>
-      <div className="flex flex-col gap-y-[25px] text-white/80 light:text-theme-text-secondary text-sm">
+      <div className="flex flex-col gap-y-[25px] text-foreground/80 light:text-theme-text-secondary text-sm">
         <p>
           Agent skills unlock new capabilities for your OneNew workspace via{" "}
           <code className="font-mono bg-zinc-900 light:bg-card px-1 py-0.5 rounded-md text-sm">
@@ -149,19 +149,19 @@ function FileReview({ item }) {
         <div className="flex justify-between items-center">
           <button
             type="button"
-            className={`border-none bg-black/70 light:bg-card rounded-md p-1 text-white/60 light:text-theme-text-secondary text-xs font-mono ${
+            className={`border-none bg-black/70 light:bg-card rounded-md p-1 text-foreground/60 light:text-theme-text-secondary text-xs font-mono ${
               index === 0 ? "opacity-50 cursor-not-allowed" : ""
             }`}
             onClick={handlePrevious}
           >
             <CaretLeft size={16} />
           </button>
-          <p className="text-white/60 light:text-theme-text-secondary text-xs font-mono">
+          <p className="text-foreground/60 light:text-theme-text-secondary text-xs font-mono">
             {file.name} ({index + 1} of {files.length} files)
           </p>
           <button
             type="button"
-            className={`border-none bg-black/70 light:bg-card rounded-md p-1 text-white/60 light:text-theme-text-secondary text-xs font-mono ${
+            className={`border-none bg-black/70 light:bg-card rounded-md p-1 text-foreground/60 light:text-theme-text-secondary text-xs font-mono ${
               index === files.length - 1 ? "opacity-50 cursor-not-allowed" : ""
             }`}
             onClick={handleNext}

--- a/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/SlashCommand.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/SlashCommand.jsx
@@ -29,7 +29,7 @@ export default function SlashCommand({ item, setStep }) {
           Review Slash Command "{item.name}"
         </h2>
         {item.creatorUsername && (
-          <p className="text-white/60 text-xs font-mono">
+          <p className="text-foreground/60 text-xs font-mono">
             Created by{" "}
             <a
               href={paths.communityHub.profile(item.creatorUsername)}
@@ -42,7 +42,7 @@ export default function SlashCommand({ item, setStep }) {
           </p>
         )}
       </div>
-      <div className="flex flex-col gap-y-[25px] text-white/80 light:text-theme-text-secondary text-sm">
+      <div className="flex flex-col gap-y-[25px] text-foreground/80 light:text-theme-text-secondary text-sm">
         <p>
           Slash commands are used to prefill information into a prompt while
           chatting with a OneNew workspace.
@@ -58,13 +58,13 @@ export default function SlashCommand({ item, setStep }) {
 
         <div className="flex flex-col gap-y-2 mt-2">
           <div className="w-full text-theme-text-primary text-md gap-x-2 flex items-center">
-            <p className="text-white/60 light:text-theme-text-secondary w-fit font-mono bg-zinc-900 light:bg-card px-2 py-1 rounded-md text-sm whitespace-pre-line">
+            <p className="text-foreground/60 light:text-theme-text-secondary w-fit font-mono bg-zinc-900 light:bg-card px-2 py-1 rounded-md text-sm whitespace-pre-line">
               {item.command}
             </p>
           </div>
 
           <div className="w-full text-theme-text-primary text-md flex flex-col gap-y-2">
-            <p className="text-white/60 light:text-theme-text-secondary font-mono bg-zinc-900 light:bg-card p-4 rounded-md text-sm whitespace-pre-line max-h-[calc(200px)] overflow-y-auto">
+            <p className="text-foreground/60 light:text-theme-text-secondary font-mono bg-zinc-900 light:bg-card p-4 rounded-md text-sm whitespace-pre-line max-h-[calc(200px)] overflow-y-auto">
               {item.prompt}
             </p>
           </div>

--- a/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/SystemPrompt.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/SystemPrompt.jsx
@@ -43,7 +43,7 @@ export default function SystemPrompt({ item, setStep }) {
           Review System Prompt "{item.name}"
         </h2>
         {item.creatorUsername && (
-          <p className="text-white/60 light:text-theme-text-secondary text-xs font-mono">
+          <p className="text-foreground/60 light:text-theme-text-secondary text-xs font-mono">
             Created by{" "}
             <a
               href={paths.communityHub.profile(item.creatorUsername)}
@@ -56,18 +56,18 @@ export default function SystemPrompt({ item, setStep }) {
           </p>
         )}
       </div>
-      <div className="flex flex-col gap-y-[25px] text-white/80 light:text-theme-text-secondary text-sm">
+      <div className="flex flex-col gap-y-[25px] text-foreground/80 light:text-theme-text-secondary text-sm">
         <p>
           System prompts are used to guide the behavior of the AI agents and can
           be applied to any existing workspace.
         </p>
 
         <div className="flex flex-col gap-y-2">
-          <p className="text-white/60 light:text-theme-text-secondary font-semibold">
+          <p className="text-foreground/60 light:text-theme-text-secondary font-semibold">
             Provided system prompt:
           </p>
           <div className="w-full text-theme-text-primary text-md flex flex-col max-h-[calc(300px)] overflow-y-auto">
-            <p className="text-white/60 light:text-theme-text-secondary font-mono bg-zinc-900 light:bg-card px-2 py-1 rounded-md text-sm whitespace-pre-line">
+            <p className="text-foreground/60 light:text-theme-text-secondary font-mono bg-zinc-900 light:bg-card px-2 py-1 rounded-md text-sm whitespace-pre-line">
               {item.prompt}
             </p>
           </div>
@@ -81,7 +81,7 @@ export default function SystemPrompt({ item, setStep }) {
             name="destinationWorkspaceSlug"
             required={true}
             onChange={(e) => setDestinationWorkspaceSlug(e.target.value)}
-            className="border-none bg-theme-settings-input-bg border-gray-500 text-white text-sm rounded-lg block w-full p-2.5"
+            className="border-none bg-theme-settings-input-bg border-border text-foreground text-sm rounded-lg block w-full p-2.5"
           >
             <optgroup label="Available workspaces">
               {workspaces.map((workspace) => (

--- a/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/Unknown.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/Unknown.jsx
@@ -11,7 +11,7 @@ export default function UnknownItem({ item, setSettings, setStep }) {
           Unsupported item
         </h2>
       </div>
-      <div className="flex flex-col gap-y-[25px] text-white/80 text-sm">
+      <div className="flex flex-col gap-y-[25px] text-foreground/80 text-sm">
         <p>
           We found an item in the community hub, but we don't know what it is or
           it is not yet supported for import into OneNew.

--- a/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/agentFlow.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/agentFlow.jsx
@@ -10,15 +10,15 @@ export default function AgentFlowHubCard({ item }) {
       className="bg-black/70 light:bg-card rounded-lg p-3 hover:bg-black/60 light:hover:bg-card transition-all duration-200 cursor-pointer group border border-transparent hover:border-slate-400 flex flex-col h-full"
     >
       <div className="flex gap-x-2 items-center">
-        <p className="text-white text-sm font-medium">{item.name}</p>
+        <p className="text-foreground text-sm font-medium">{item.name}</p>
         <VisibilityIcon visibility={item.visibility} />
       </div>
       <div className="flex flex-col gap-2 flex-1">
-        <p className="text-white/60 text-xs mt-1">{item.description}</p>
-        <label className="text-white/60 text-xs font-semibold mt-4">
+        <p className="text-foreground/60 text-xs mt-1">{item.description}</p>
+        <label className="text-foreground/60 text-xs font-semibold mt-4">
           Steps ({flow.steps.length}):
         </label>
-        <p className="text-white/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
+        <p className="text-foreground/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
           <ul className="list-disc pl-4">
             {flow.steps.map((step, index) => (
               <li key={index}>{step.type}</li>

--- a/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/agentSkill.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/agentSkill.jsx
@@ -12,13 +12,13 @@ export default function AgentSkillHubCard({ item }) {
         className="bg-black/70 light:bg-card rounded-lg p-3 hover:bg-black/60 light:hover:bg-card transition-all duration-200 cursor-pointer group border border-transparent hover:border-slate-400"
       >
         <div className="flex gap-x-2 items-center">
-          <p className="text-white text-sm font-medium">{item.name}</p>
+          <p className="text-foreground text-sm font-medium">{item.name}</p>
           <VisibilityIcon visibility={item.visibility} />
         </div>
         <div className="flex flex-col gap-2">
-          <p className="text-white/60 text-xs mt-1">{item.description}</p>
+          <p className="text-foreground/60 text-xs mt-1">{item.description}</p>
 
-          <p className="font-mono text-xs mt-1 text-white/60">
+          <p className="font-mono text-xs mt-1 text-foreground/60">
             {item.verified ? (
               <span className="text-green-500">Verified</span>
             ) : (
@@ -26,7 +26,7 @@ export default function AgentSkillHubCard({ item }) {
             )}{" "}
             Skill
           </p>
-          <p className="font-mono text-xs mt-1 text-white/60">
+          <p className="font-mono text-xs mt-1 text-foreground/60">
             {item.manifest.files?.length || 0}{" "}
             {pluralize("file", item.manifest.files?.length || 0)} found
           </p>

--- a/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/generic.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/generic.jsx
@@ -9,8 +9,8 @@ export default function GenericHubCard({ item }) {
       key={item.id}
       className="bg-zinc-800 light:bg-card rounded-lg p-3 hover:bg-zinc-700 light:hover:bg-card transition-all duration-200"
     >
-      <p className="text-white text-sm font-medium">{item.name}</p>
-      <p className="text-white/60 text-xs mt-1">{item.description}</p>
+      <p className="text-foreground text-sm font-medium">{item.name}</p>
+      <p className="text-foreground/60 text-xs mt-1">{item.description}</p>
       <div className="flex justify-end mt-2">
         <Link
           className="text-primary-button hover:text-primary-button/80 text-xs"
@@ -32,7 +32,7 @@ export function VisibilityIcon({ visibility = "public" }) {
         data-tooltip-id="visibility-icon"
         data-tooltip-content={`This item is ${visibility === "private" ? "private" : "public"}`}
       >
-        <Icon className="w-4 h-4 text-white/60" />
+        <Icon className="w-4 h-4 text-foreground/60" />
       </div>
       <Tooltip
         id="visibility-icon"

--- a/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/slashCommand.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/slashCommand.jsx
@@ -12,22 +12,22 @@ export default function SlashCommandHubCard({ item }) {
         className="bg-black/70 light:bg-card rounded-lg p-3 hover:bg-black/60 light:hover:bg-card transition-all duration-200 cursor-pointer group border border-transparent hover:border-slate-400"
       >
         <div className="flex gap-x-2 items-center">
-          <p className="text-white text-sm font-medium">{item.name}</p>
+          <p className="text-foreground text-sm font-medium">{item.name}</p>
           <VisibilityIcon visibility={item.visibility} />
         </div>
         <div className="flex flex-col gap-2">
-          <p className="text-white/60 text-xs mt-1">{item.description}</p>
-          <label className="text-white/60 text-xs font-semibold mt-4">
+          <p className="text-foreground/60 text-xs mt-1">{item.description}</p>
+          <label className="text-foreground/60 text-xs font-semibold mt-4">
             Command
           </label>
-          <p className="text-white/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
+          <p className="text-foreground/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
             {item.command}
           </p>
 
-          <label className="text-white/60 text-xs font-semibold mt-4">
+          <label className="text-foreground/60 text-xs font-semibold mt-4">
             Prompt
           </label>
-          <p className="text-white/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
+          <p className="text-foreground/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
             {truncate(item.prompt, 90)}
           </p>
         </div>

--- a/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/systemPrompt.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/Trending/HubItems/HubItemCard/systemPrompt.jsx
@@ -12,15 +12,15 @@ export default function SystemPromptHubCard({ item }) {
         className="bg-black/70 light:bg-card rounded-lg p-3 hover:bg-black/60 light:hover:bg-card transition-all duration-200 cursor-pointer group border border-transparent hover:border-slate-400"
       >
         <div className="flex gap-x-2 items-center">
-          <p className="text-white text-sm font-medium">{item.name}</p>
+          <p className="text-foreground text-sm font-medium">{item.name}</p>
           <VisibilityIcon visibility={item.visibility} />
         </div>
         <div className="flex flex-col gap-2">
-          <p className="text-white/60 text-xs mt-1">{item.description}</p>
-          <label className="text-white/60 text-xs font-semibold mt-4">
+          <p className="text-foreground/60 text-xs mt-1">{item.description}</p>
+          <label className="text-foreground/60 text-xs font-semibold mt-4">
             Prompt
           </label>
-          <p className="text-white/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
+          <p className="text-foreground/60 text-xs bg-zinc-900 light:bg-card px-2 py-1 rounded-md font-mono border border-slate-800 light:border-slate-300">
             {truncate(item.prompt, 90)}
           </p>
         </div>

--- a/frontend/src/pages/GeneralSettings/EmbeddingPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbeddingPreference/index.jsx
@@ -250,13 +250,13 @@ export default function GeneralEmbeddingPreference() {
             className="flex w-full"
           >
             <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] py-16 md:py-6">
-              <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+              <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
                 <div className="flex gap-x-4 items-center">
-                  <p className="text-lg leading-6 font-bold text-white">
+                  <p className="text-lg leading-6 font-bold text-foreground">
                     {t("embedding.title")}
                   </p>
                 </div>
-                <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+                <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
                   {t("embedding.desc-start")}
                   <br />
                   {t("embedding.desc-end")}
@@ -272,7 +272,7 @@ export default function GeneralEmbeddingPreference() {
                   </CTAButton>
                 )}
               </div>
-              <div className="text-base font-bold text-white mt-6 mb-4">
+              <div className="text-base font-bold text-foreground mt-6 mb-4">
                 {t("embedding.provider.title")}
               </div>
               <div className="relative">
@@ -306,7 +306,7 @@ export default function GeneralEmbeddingPreference() {
                         <X
                           size={20}
                           weight="bold"
-                          className="cursor-pointer text-white hover:text-x-button"
+                          className="cursor-pointer text-foreground hover:text-x-button"
                           onClick={handleXButton}
                         />
                       </div>
@@ -338,7 +338,7 @@ export default function GeneralEmbeddingPreference() {
                         className="w-10 h-10 rounded-md"
                       />
                       <div className="flex flex-col text-left">
-                        <div className="text-sm font-semibold text-white">
+                        <div className="text-sm font-semibold text-foreground">
                           {selectedEmbedderObject.name}
                         </div>
                         <div className="mt-1 text-xs text-description">
@@ -349,7 +349,7 @@ export default function GeneralEmbeddingPreference() {
                     <CaretUpDown
                       size={24}
                       weight="bold"
-                      className="text-white"
+                      className="text-foreground"
                     />
                   </button>
                 )}

--- a/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbeddingTextSplitterPreference/index.jsx
@@ -103,13 +103,13 @@ export default function EmbeddingTextSplitterPreference() {
             id="text-splitter-chunking-form"
           >
             <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16">
-              <div className="w-full flex flex-col gap-y-1 pb-4 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+              <div className="w-full flex flex-col gap-y-1 pb-4 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
                 <div className="flex gap-x-4 items-center">
-                  <p className="text-lg leading-6 font-bold text-white">
+                  <p className="text-lg leading-6 font-bold text-foreground">
                     {t("text.title")}
                   </p>
                 </div>
-                <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+                <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
                   {t("text.desc-start")} <br />
                   {t("text.desc-end")}
                 </p>
@@ -125,10 +125,10 @@ export default function EmbeddingTextSplitterPreference() {
               <div className="flex flex-col gap-y-4 mt-8">
                 <div className="flex flex-col max-w-[300px]">
                   <div className="flex flex-col gap-y-2 mb-4">
-                    <label className="text-white text-sm font-semibold block">
+                    <label className="text-foreground text-sm font-semibold block">
                       {t("text.size.title")}
                     </label>
-                    <p className="text-xs text-white/60">
+                    <p className="text-xs text-foreground/60">
                       {t("text.size.description")}
                     </p>
                   </div>
@@ -138,7 +138,7 @@ export default function EmbeddingTextSplitterPreference() {
                     min={1}
                     max={settings?.max_embed_chunk_size || 1000}
                     onWheel={(e) => e?.currentTarget?.blur()}
-                    className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     placeholder="maximum length of vectorized text"
                     defaultValue={
                       isNullOrNaN(settings?.text_splitter_chunk_size)
@@ -148,7 +148,7 @@ export default function EmbeddingTextSplitterPreference() {
                     required={true}
                     autoComplete="off"
                   />
-                  <p className="text-xs text-white/40 mt-2">
+                  <p className="text-xs text-foreground/40 mt-2">
                     {t("text.size.recommend")}{" "}
                     {numberWithCommas(settings?.max_embed_chunk_size || 1000)}.
                   </p>
@@ -158,10 +158,10 @@ export default function EmbeddingTextSplitterPreference() {
               <div className="flex flex-col gap-y-4 mt-8">
                 <div className="flex flex-col max-w-[300px]">
                   <div className="flex flex-col gap-y-2 mb-4">
-                    <label className="text-white text-sm font-semibold block">
+                    <label className="text-foreground text-sm font-semibold block">
                       {t("text.overlap.title")}
                     </label>
-                    <p className="text-xs text-white/60">
+                    <p className="text-xs text-foreground/60">
                       {t("text.overlap.description")}
                     </p>
                   </div>
@@ -170,7 +170,7 @@ export default function EmbeddingTextSplitterPreference() {
                     name="text_splitter_chunk_overlap"
                     min={0}
                     onWheel={(e) => e?.currentTarget?.blur()}
-                    className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+                    className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
                     placeholder="maximum length of vectorized text"
                     defaultValue={
                       isNullOrNaN(settings?.text_splitter_chunk_overlap)

--- a/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/LLMPreference/index.jsx
@@ -413,13 +413,13 @@ export default function GeneralLLMPreference() {
         >
           <form onSubmit={handleSubmit} className="flex w-full">
             <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16">
-              <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+              <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
                 <div className="flex gap-x-4 items-center">
-                  <p className="text-lg leading-6 font-bold text-white">
+                  <p className="text-lg leading-6 font-bold text-foreground">
                     {t("llm.title")}
                   </p>
                 </div>
-                <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+                <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
                   {t("llm.description")}
                 </p>
               </div>
@@ -433,7 +433,7 @@ export default function GeneralLLMPreference() {
                   </CTAButton>
                 )}
               </div>
-              <div className="text-base font-bold text-white mt-6 mb-4">
+              <div className="text-base font-bold text-foreground mt-6 mb-4">
                 {t("llm.provider")}
               </div>
               <div className="relative">
@@ -467,7 +467,7 @@ export default function GeneralLLMPreference() {
                         <X
                           size={20}
                           weight="bold"
-                          className="cursor-pointer text-white hover:text-x-button"
+                          className="cursor-pointer text-foreground hover:text-x-button"
                           onClick={handleXButton}
                         />
                       </div>
@@ -501,7 +501,7 @@ export default function GeneralLLMPreference() {
                         className="w-10 h-10 rounded-md"
                       />
                       <div className="flex flex-col text-left">
-                        <div className="text-sm font-semibold text-white">
+                        <div className="text-sm font-semibold text-foreground">
                           {selectedLLMObject?.name || "None selected"}
                         </div>
                         <div className="mt-1 text-xs text-description">
@@ -513,7 +513,7 @@ export default function GeneralLLMPreference() {
                     <CaretUpDown
                       size={24}
                       weight="bold"
-                      className="text-white"
+                      className="text-foreground"
                     />
                   </button>
                 )}

--- a/frontend/src/pages/GeneralSettings/Security/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Security/index.jsx
@@ -88,14 +88,14 @@ function MultiUserMode() {
       onChange={() => setHasChanges(true)}
       className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16"
     >
-      <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
-        <div className="w-full flex flex-col gap-y-1 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10 pb-8">
+      <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
+        <div className="w-full flex flex-col gap-y-1 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10 pb-8">
           <div className="items-center flex gap-x-4">
-            <p className="text-lg leading-6 font-bold text-white">
+            <p className="text-lg leading-6 font-bold text-foreground">
               {t("multi.title")}
             </p>
           </div>
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
             {t("multi.description")}
           </p>
         </div>
@@ -115,7 +115,7 @@ function MultiUserMode() {
             <div className="space-y-6 flex h-full w-full">
               <div className="w-full flex flex-col gap-y-4">
                 <div className="">
-                  <label className="mb-2.5 block font-medium text-white">
+                  <label className="mb-2.5 block font-medium text-foreground">
                     {multiUserModeEnabled
                       ? t("multi.enable.is-enable")
                       : t("multi.enable.enable")}
@@ -130,7 +130,7 @@ function MultiUserMode() {
                     />
                     <div
                       hidden={multiUserModeEnabled}
-                      className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"
+                      className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent"
                     />
                   </label>
                 </div>
@@ -139,14 +139,14 @@ function MultiUserMode() {
                     <div className="w-80">
                       <label
                         htmlFor="username"
-                        className="block mb-3 font-medium text-white"
+                        className="block mb-3 font-medium text-foreground"
                       >
                         {t("multi.enable.username")}
                       </label>
                       <input
                         name="username"
                         type="text"
-                        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 placeholder:text-theme-settings-input-placeholder focus:ring-blue-500"
+                        className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 placeholder:text-theme-settings-input-placeholder focus:ring-blue-500"
                         placeholder="Your admin username"
                         minLength={2}
                         required={true}
@@ -158,14 +158,14 @@ function MultiUserMode() {
                     <div className="mt-4 w-80">
                       <label
                         htmlFor="password"
-                        className="block mb-3 font-medium text-white"
+                        className="block mb-3 font-medium text-foreground"
                       >
                         {t("multi.enable.password")}
                       </label>
                       <input
                         name="password"
                         type="text"
-                        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 placeholder:text-theme-settings-input-placeholder focus:ring-blue-500"
+                        className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 placeholder:text-theme-settings-input-placeholder focus:ring-blue-500"
                         placeholder="Your admin password"
                         minLength={8}
                         required={true}
@@ -178,7 +178,7 @@ function MultiUserMode() {
               </div>
             </div>
             <div className="flex items-center justify-between space-x-14">
-              <p className="text-white text-opacity-80 text-xs rounded-lg w-96">
+              <p className="text-foreground text-opacity-80 text-xs rounded-lg w-96">
                 {t("multi.enable.description")}
               </p>
             </div>
@@ -265,14 +265,14 @@ function PasswordProtection() {
       onChange={() => setHasChanges(true)}
       className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] md:py-6 py-16"
     >
-      <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+      <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
         <div className="w-full flex flex-col gap-y-1">
           <div className="items-center flex gap-x-4">
-            <p className="text-lg leading-6 font-bold text-white">
+            <p className="text-lg leading-6 font-bold text-foreground">
               {t("multi.password.title")}
             </p>
           </div>
-          <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+          <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
             {t("multi.password.description")}
           </p>
         </div>
@@ -292,7 +292,7 @@ function PasswordProtection() {
             <div className="space-y-6 flex h-full w-full">
               <div className="w-full flex flex-col gap-y-4">
                 <div className="">
-                  <label className="mb-2.5 block font-medium text-white">
+                  <label className="mb-2.5 block font-medium text-foreground">
                     {t("multi.instance.title")}
                   </label>
 
@@ -303,7 +303,7 @@ function PasswordProtection() {
                       defaultChecked={usePassword}
                       className="peer sr-only pointer-events-none"
                     />
-                    <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent" />
+                    <div className="peer-disabled:opacity-50 pointer-events-none peer h-6 w-11 rounded-full bg-[#CFCFD0] after:absolute after:left-[2px] after:top-[2px] after:h-5 after:w-5 after:rounded-full after:shadow-xl after:border-none after:bg-card after:box-shadow-md after:transition-all after:content-[''] peer-checked:bg-[#32D583] peer-checked:after:translate-x-full peer-checked:after:border-border peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-transparent" />
                   </label>
                 </div>
                 {usePassword && (
@@ -311,14 +311,14 @@ function PasswordProtection() {
                     <div className="mt-4 w-80">
                       <label
                         htmlFor="password"
-                        className="block mb-3 font-medium text-white"
+                        className="block mb-3 font-medium text-foreground"
                       >
                         {t("multi.instance.password")}
                       </label>
                       <input
                         name="password"
                         type="text"
-                        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 placeholder:text-theme-settings-input-placeholder"
+                        className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 placeholder:text-theme-settings-input-placeholder"
                         placeholder="Your Instance Password"
                         minLength={8}
                         required={true}
@@ -331,7 +331,7 @@ function PasswordProtection() {
               </div>
             </div>
             <div className="flex items-center justify-between space-x-14">
-              <p className="text-white text-opacity-80 light:text-theme-text text-xs rounded-lg w-96">
+              <p className="text-foreground text-opacity-80 light:text-theme-text text-xs rounded-lg w-96">
                 {t("multi.instance.description")}
               </p>
             </div>

--- a/frontend/src/pages/GeneralSettings/Settings/Branding/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/Branding/index.jsx
@@ -19,13 +19,13 @@ export default function BrandingSettings() {
         className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
       >
         <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[86px] md:py-6 py-16">
-          <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+          <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
             <div className="items-center">
-              <p className="text-lg leading-6 font-bold text-white">
+              <p className="text-lg leading-6 font-bold text-foreground">
                 {t("customization.branding.title")}
               </p>
             </div>
-            <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+            <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
               {t("customization.branding.description")}
             </p>
           </div>

--- a/frontend/src/pages/GeneralSettings/Settings/Chat/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/Chat/index.jsx
@@ -17,13 +17,13 @@ export default function ChatSettings() {
         className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
       >
         <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[86px] md:py-6 py-16">
-          <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+          <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
             <div className="items-center">
-              <p className="text-lg leading-6 font-bold text-white">
+              <p className="text-lg leading-6 font-bold text-foreground">
                 {t("customization.chat.title")}
               </p>
             </div>
-            <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+            <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
               {t("customization.chat.description")}
             </p>
           </div>

--- a/frontend/src/pages/GeneralSettings/Settings/Interface/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/Interface/index.jsx
@@ -16,13 +16,13 @@ export default function InterfaceSettings() {
         className="relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg bg-theme-bg-secondary w-full h-full overflow-y-scroll p-4 md:p-0"
       >
         <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[86px] md:py-6 py-16">
-          <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+          <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
             <div className="items-center">
-              <p className="text-lg leading-6 font-bold text-white">
+              <p className="text-lg leading-6 font-bold text-foreground">
                 {t("customization.interface.title")}
               </p>
             </div>
-            <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+            <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
               {t("customization.interface.description")}
             </p>
           </div>

--- a/frontend/src/pages/GeneralSettings/Settings/components/CustomLogo/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/CustomLogo/index.jsx
@@ -70,10 +70,10 @@ export default function CustomLogo() {
 
   return (
     <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.logo.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.logo.description")}
       </p>
       {isDefaultLogo ? (
@@ -118,7 +118,7 @@ export default function CustomLogo() {
               className="w-full h-full object-cover border-2 border-theme-text-secondary border-opacity-60 p-1 rounded-2xl"
             />
 
-            <div className="absolute w-80 top-0 left-0 right-0 bottom-0 flex flex-col gap-y-3 justify-center items-center rounded-2xl mt-3 bg-black bg-opacity-80 opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out border-2 border-transparent hover:border-white">
+            <div className="absolute w-80 top-0 left-0 right-0 bottom-0 flex flex-col gap-y-3 justify-center items-center rounded-2xl mt-3 bg-black bg-opacity-80 opacity-0 group-hover:opacity-100 transition-opacity duration-300 ease-in-out border-2 border-transparent hover:border-border">
               <button
                 onClick={triggerFileInputClick}
                 className="text-foreground text-base font-medium hover:text-opacity-60 mx-2"

--- a/frontend/src/pages/GeneralSettings/Settings/components/CustomMessages/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/CustomMessages/index.jsx
@@ -62,10 +62,10 @@ export default function CustomMessages() {
 
   return (
     <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.welcome-messages.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.welcome-messages.description")}
       </p>
       <div className="mt-2 flex flex-col gap-y-6 bg-theme-settings-input-bg rounded-lg pr-[31px] pl-[12px] pt-4 max-w-[700px]">
@@ -93,7 +93,7 @@ export default function CustomMessages() {
         ))}
         <div className="flex gap-4 mt-12 justify-between pb-[15px]">
           <button
-            className="border-none self-end text-white hover:text-white/60 light:hover:text-foreground transition"
+            className="border-none self-end text-foreground hover:text-foreground/60 light:hover:text-foreground transition"
             onClick={() => addMessage("response")}
           >
             <div className="flex items-center justify-start text-sm font-normal -ml-2">
@@ -108,7 +108,7 @@ export default function CustomMessages() {
             </div>
           </button>
           <button
-            className="border-none self-end text-white hover:text-white/60 light:hover:text-foreground transition"
+            className="border-none self-end text-foreground hover:text-foreground/60 light:hover:text-foreground transition"
             onClick={() => addMessage("user")}
           >
             <div className="flex items-center justify-start text-sm font-normal">
@@ -127,7 +127,7 @@ export default function CustomMessages() {
       {hasChanges && (
         <div className="flex justify-start pt-2">
           <button
-            className="transition-all duration-300 border border-slate-200 px-4 py-2 rounded-sm text-white text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
+            className="transition-all duration-300 border border-slate-200 px-4 py-2 rounded-sm text-foreground text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
             onClick={handleMessageSave}
           >
             {t("customization.items.welcome-messages.save")}

--- a/frontend/src/pages/GeneralSettings/Settings/components/CustomSiteSettings/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/CustomSiteSettings/index.jsx
@@ -37,29 +37,29 @@ export default function CustomSiteSettings() {
 
   return (
     <form
-      className="flex flex-col gap-y-0.5 my-4 border-t border-white border-opacity-20 light:border-black/20 pt-6"
+      className="flex flex-col gap-y-0.5 my-4 border-t border-border border-opacity-20 light:border-black/20 pt-6"
       onChange={() => setHasChanges(true)}
       onSubmit={handleSiteSettingUpdate}
     >
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.browser-appearance.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.browser-appearance.description")}
       </p>
 
       <div className="w-fit">
-        <p className="text-sm leading-6 font-medium text-white mt-2">
+        <p className="text-sm leading-6 font-medium text-foreground mt-2">
           {t("customization.items.browser-appearance.tab.title")}
         </p>
-        <p className="text-xs text-white/60">
+        <p className="text-xs text-foreground/60">
           {t("customization.items.browser-appearance.tab.description")}
         </p>
         <div className="flex items-center gap-x-4">
           <input
             name="meta_page_title"
             type="text"
-            className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
+            className="border-none bg-theme-settings-input-bg mt-2 text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
             placeholder="OneNew | Your personal LLM trained on anything"
             autoComplete="off"
             onChange={(e) => {
@@ -75,10 +75,10 @@ export default function CustomSiteSettings() {
       </div>
 
       <div className="w-fit">
-        <p className="text-sm leading-6 font-medium text-white mt-2">
+        <p className="text-sm leading-6 font-medium text-foreground mt-2">
           {t("customization.items.browser-appearance.favicon.title")}
         </p>
-        <p className="text-xs text-white/60">
+        <p className="text-xs text-foreground/60">
           {t("customization.items.browser-appearance.favicon.description")}
         </p>
         <div className="flex items-center gap-x-2">
@@ -91,7 +91,7 @@ export default function CustomSiteSettings() {
           <input
             name="meta_page_favicon"
             type="url"
-            className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
+            className="border-none bg-theme-settings-input-bg mt-2 text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
             placeholder="url to your image"
             onChange={(e) => {
               setSettings((prev) => {
@@ -107,7 +107,7 @@ export default function CustomSiteSettings() {
       {hasChanges && (
         <button
           type="submit"
-          className="transition-all mt-2 w-fit duration-300 border border-slate-200 px-5 py-2.5 rounded-sm text-white text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
+          className="transition-all mt-2 w-fit duration-300 border border-slate-200 px-5 py-2.5 rounded-sm text-foreground text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
         >
           Save
         </button>

--- a/frontend/src/pages/GeneralSettings/Settings/components/FooterCustomization/NewIconForm/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/FooterCustomization/NewIconForm/index.jsx
@@ -66,7 +66,7 @@ export default function NewIconForm({ icon, url, onSave, onRemove }) {
           })}
         </div>
         {isDropdownOpen && (
-          <div className="absolute z-10 grid grid-cols-4 bg-theme-settings-input-bg mt-2 rounded-md w-[150px] h-[78px] overflow-y-auto border border-white/20 shadow-lg">
+          <div className="absolute z-10 grid grid-cols-4 bg-theme-settings-input-bg mt-2 rounded-md w-[150px] h-[78px] overflow-y-auto border border-border/20 shadow-lg">
             {Object.keys(ICON_COMPONENTS).map((iconName) => (
               <button
                 key={iconName}
@@ -89,7 +89,7 @@ export default function NewIconForm({ icon, url, onSave, onRemove }) {
         value={selectedUrl}
         onChange={handleUrlChange}
         placeholder="https://example.com"
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-md p-2.5 w-[300px] h-[32px] focus:outline-primary-button active:outline-primary-button outline-none"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-md p-2.5 w-[300px] h-[32px] focus:outline-primary-button active:outline-primary-button outline-none"
         required
       />
       {selectedIcon !== "Plus" && (
@@ -105,7 +105,7 @@ export default function NewIconForm({ icon, url, onSave, onRemove }) {
             <button
               type="button"
               onClick={handleRemove}
-              className="hover:text-red-500 text-white/80 px-2 py-2 rounded-md text-sm font-bold"
+              className="hover:text-red-500 text-foreground/80 px-2 py-2 rounded-md text-sm font-bold"
             >
               <X size={20} />
             </button>

--- a/frontend/src/pages/GeneralSettings/Settings/components/FooterCustomization/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/FooterCustomization/index.jsx
@@ -51,13 +51,13 @@ export default function FooterCustomization() {
 
   return (
     <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.sidebar-footer.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.sidebar-footer.description")}
       </p>
-      <div className="mt-2 flex gap-x-3 font-medium text-white text-sm">
+      <div className="mt-2 flex gap-x-3 font-medium text-foreground text-sm">
         <div>{t("customization.items.sidebar-footer.icon")}</div>
         <div>{t("customization.items.sidebar-footer.link")}</div>
       </div>

--- a/frontend/src/pages/GeneralSettings/Settings/components/LanguagePreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/LanguagePreference/index.jsx
@@ -12,16 +12,16 @@ export default function LanguagePreference() {
 
   return (
     <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.display-language.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.display-language.description")}
       </p>
       <div className="flex items-center gap-x-4">
         <select
           name="userLang"
-          className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
+          className="border-none bg-theme-settings-input-bg mt-2 text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
           defaultValue={currentLanguage || "en"}
           onChange={(e) => changeLanguage(e.target.value)}
         >

--- a/frontend/src/pages/GeneralSettings/Settings/components/MessageDirection/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/MessageDirection/index.jsx
@@ -8,10 +8,10 @@ export function MessageDirection() {
 
   return (
     <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.chat-message-alignment.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.chat-message-alignment.description")}
       </p>
       <div className="flex flex-row flex-wrap gap-x-4 pt-1 gap-y-4 md:gap-y-0">
@@ -48,7 +48,7 @@ function ItemDirection({ active, reverse, onSelect, msg }) {
       data-tooltip-id="alignment-choice-item"
       data-tooltip-content={msg}
       type="button"
-      className={`flex:1 p-4 bg-transparent hover:light:bg-gray-100 hover:bg-gray-700/20 rounded-xl border w-[250px] ${active ? "border-primary-button" : " border-theme-sidebar-border"}`}
+      className={`flex:1 p-4 bg-transparent hover:light:bg-background hover:bg-background/20 rounded-xl border w-[250px] ${active ? "border-primary-button" : " border-theme-sidebar-border"}`}
       onClick={onSelect}
     >
       <div className="space-y-4">
@@ -60,7 +60,7 @@ function ItemDirection({ active, reverse, onSelect, msg }) {
             <div
               className={`w-4 h-4 rounded-full ${index % 2 === 0 ? "bg-primary-button" : "bg-card light:bg-black"} flex-shrink-0`}
             />
-            <div className="bg-gray-600 light:bg-gray-200 rounded-2xl px-4 py-2 h-[20px] w-full" />
+            <div className="bg-background light:bg-background rounded-2xl px-4 py-2 h-[20px] w-full" />
           </div>
         ))}
       </div>

--- a/frontend/src/pages/GeneralSettings/Settings/components/SupportEmail/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/SupportEmail/index.jsx
@@ -58,17 +58,17 @@ export default function SupportEmail() {
       className="flex flex-col gap-y-0.5 mt-4"
       onSubmit={updateSupportEmail}
     >
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.support-email.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.support-email.description")}
       </p>
       <div className="flex items-center gap-x-4">
         <input
           name="supportEmail"
           type="email"
-          className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
+          className="border-none bg-theme-settings-input-bg mt-2 text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
           placeholder="support@mycompany.com"
           required={true}
           autoComplete="off"
@@ -79,7 +79,7 @@ export default function SupportEmail() {
           <button
             type="button"
             onClick={(e) => updateSupportEmail(e, "")}
-            className="text-white text-base font-medium hover:text-opacity-60"
+            className="text-foreground text-base font-medium hover:text-opacity-60"
           >
             Clear
           </button>
@@ -88,7 +88,7 @@ export default function SupportEmail() {
       {hasChanges && (
         <button
           type="submit"
-          className="transition-all mt-2 w-fit duration-300 border border-slate-200 px-5 py-2.5 rounded-sm text-white text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
+          className="transition-all mt-2 w-fit duration-300 border border-slate-200 px-5 py-2.5 rounded-sm text-foreground text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
         >
           Save
         </button>

--- a/frontend/src/pages/GeneralSettings/Settings/components/ThemePreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/ThemePreference/index.jsx
@@ -7,17 +7,17 @@ export default function ThemePreference() {
 
   return (
     <div className="flex flex-col gap-y-0.5 my-4">
-      <p className="text-sm leading-6 font-semibold text-white">
+      <p className="text-sm leading-6 font-semibold text-foreground">
         {t("customization.items.theme.title")}
       </p>
-      <p className="text-xs text-white/60">
+      <p className="text-xs text-foreground/60">
         {t("customization.items.theme.description")}
       </p>
       <div className="flex items-center gap-x-4">
         <select
           value={theme}
           onChange={(e) => setTheme(e.target.value)}
-          className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
+          className="border-none bg-theme-settings-input-bg mt-2 text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
         >
           {Object.entries(availableThemes).map(([key, value]) => (
             <option key={key} value={key}>

--- a/frontend/src/pages/GeneralSettings/TranscriptionPreference/index.jsx
+++ b/frontend/src/pages/GeneralSettings/TranscriptionPreference/index.jsx
@@ -117,13 +117,13 @@ export default function TranscriptionModelPreference() {
         >
           <form onSubmit={handleSubmit} className="flex w-full">
             <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] py-16 md:py-6">
-              <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+              <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
                 <div className="flex gap-x-4 items-center">
-                  <p className="text-lg leading-6 font-bold text-white">
+                  <p className="text-lg leading-6 font-bold text-foreground">
                     {t("transcription.title")}
                   </p>
                 </div>
-                <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+                <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
                   {t("transcription.description")}
                 </p>
               </div>
@@ -137,7 +137,7 @@ export default function TranscriptionModelPreference() {
                   </CTAButton>
                 )}
               </div>
-              <div className="text-base font-bold text-white mt-6 mb-4">
+              <div className="text-base font-bold text-foreground mt-6 mb-4">
                 {t("transcription.provider")}
               </div>
               <div className="relative">
@@ -171,7 +171,7 @@ export default function TranscriptionModelPreference() {
                         <X
                           size={20}
                           weight="bold"
-                          className="cursor-pointer text-white hover:text-x-button"
+                          className="cursor-pointer text-foreground hover:text-x-button"
                           onClick={handleXButton}
                         />
                       </div>
@@ -203,7 +203,7 @@ export default function TranscriptionModelPreference() {
                         className="w-10 h-10 rounded-md"
                       />
                       <div className="flex flex-col text-left">
-                        <div className="text-sm font-semibold text-white">
+                        <div className="text-sm font-semibold text-foreground">
                           {selectedProviderObject.name}
                         </div>
                         <div className="mt-1 text-xs text-description">
@@ -214,7 +214,7 @@ export default function TranscriptionModelPreference() {
                     <CaretUpDown
                       size={24}
                       weight="bold"
-                      className="text-white"
+                      className="text-foreground"
                     />
                   </button>
                 )}

--- a/frontend/src/pages/GeneralSettings/VectorDatabase/index.jsx
+++ b/frontend/src/pages/GeneralSettings/VectorDatabase/index.jsx
@@ -204,13 +204,13 @@ export default function GeneralVectorDatabase() {
             className="flex w-full"
           >
             <div className="flex flex-col w-full px-1 md:pl-6 md:pr-[50px] py-16 md:py-6">
-              <div className="w-full flex flex-col gap-y-1 pb-6 border-white light:border-theme-sidebar-border border-b-2 border-opacity-10">
+              <div className="w-full flex flex-col gap-y-1 pb-6 border-border light:border-theme-sidebar-border border-b-2 border-opacity-10">
                 <div className="flex gap-x-4 items-center">
-                  <p className="text-lg leading-6 font-bold text-white">
+                  <p className="text-lg leading-6 font-bold text-foreground">
                     {t("vector.title")}
                   </p>
                 </div>
-                <p className="text-xs leading-[18px] font-base text-white text-opacity-60">
+                <p className="text-xs leading-[18px] font-base text-foreground text-opacity-60">
                   {t("vector.description")}
                 </p>
               </div>
@@ -224,7 +224,7 @@ export default function GeneralVectorDatabase() {
                   </CTAButton>
                 )}
               </div>
-              <div className="text-base font-bold text-white mt-6 mb-4">
+              <div className="text-base font-bold text-foreground mt-6 mb-4">
                 {t("vector.provider.title")}
               </div>
               <div className="relative">
@@ -258,7 +258,7 @@ export default function GeneralVectorDatabase() {
                         <X
                           size={20}
                           weight="bold"
-                          className="cursor-pointer text-white hover:text-x-button"
+                          className="cursor-pointer text-foreground hover:text-x-button"
                           onClick={handleXButton}
                         />
                       </div>
@@ -290,7 +290,7 @@ export default function GeneralVectorDatabase() {
                         className="w-10 h-10 rounded-md"
                       />
                       <div className="flex flex-col text-left">
-                        <div className="text-sm font-semibold text-white">
+                        <div className="text-sm font-semibold text-foreground">
                           {selectedVDBObject.name}
                         </div>
                         <div className="mt-1 text-xs text-description">
@@ -301,7 +301,7 @@ export default function GeneralVectorDatabase() {
                     <CaretUpDown
                       size={24}
                       weight="bold"
-                      className="text-white"
+                      className="text-foreground"
                     />
                   </button>
                 )}

--- a/frontend/src/pages/Main/Home/ExploreFeatures/index.jsx
+++ b/frontend/src/pages/Main/Home/ExploreFeatures/index.jsx
@@ -128,7 +128,7 @@ function FeatureCard({
       <div className="flex flex-col gap-y-[10px]">
         <button
           onClick={onPrimaryAction}
-          className="w-full h-[36px] border border-white/20 light:border-theme-home-button-secondary-border light:hover:border-theme-home-button-secondary-border-hover text-white rounded-sm text-theme-home-button-primary-text text-sm font-medium flex items-center justify-center gap-x-2.5 transition-all duration-200 light:hover:bg-transparent hover:bg-theme-home-button-secondary-hover hover:text-theme-home-button-secondary-hover-text"
+          className="w-full h-[36px] border border-border/20 light:border-theme-home-button-secondary-border light:hover:border-theme-home-button-secondary-border-hover text-foreground rounded-sm text-theme-home-button-primary-text text-sm font-medium flex items-center justify-center gap-x-2.5 transition-all duration-200 light:hover:bg-transparent hover:bg-theme-home-button-secondary-hover hover:text-theme-home-button-secondary-hover-text"
         >
           {primaryAction}
         </button>

--- a/frontend/src/pages/OnboardingFlow/Steps/UserSetup/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/UserSetup/index.jsx
@@ -57,7 +57,7 @@ export default function UserSetup({ setHeader, setForwardBtn, setBackBtn }) {
   return (
     <div className="onenew-page p-6 w-full flex items-center justify-center flex-col gap-y-6">
       <div className="onenew-card flex flex-col p-8 items-center gap-y-4 w-full max-w-[600px]">
-        <div className=" text-white text-sm font-semibold md:-ml-44">
+        <div className=" text-foreground text-sm font-semibold md:-ml-44">
           {t("onboarding.userSetup.howManyUsers")}
         </div>
         <div className="flex flex-col md:flex-row gap-6 w-full justify-center">
@@ -168,7 +168,7 @@ const JustMe = ({
   return (
     <div className="w-full flex items-center justify-center flex-col gap-y-6">
       <div className="onenew-card flex flex-col p-8 items-center gap-y-4 w-full max-w-[600px]">
-        <div className=" text-white text-sm font-semibold md:-ml-56">
+        <div className=" text-foreground text-sm font-semibold md:-ml-56">
           {t("onboarding.userSetup.setPassword")}
         </div>
         <div className="flex flex-col md:flex-row gap-6 w-full justify-center">
@@ -212,7 +212,7 @@ const JustMe = ({
               autoComplete="off"
               onChange={handlePasswordChange}
             />
-            <div className="mt-4 text-white text-opacity-80 text-xs font-base -mb-2">
+            <div className="mt-4 text-foreground text-opacity-80 text-xs font-base -mb-2">
               {t("onboarding.userSetup.passwordReq")}
               <br />
               <i>{t("onboarding.userSetup.passwordWarn")}</i>{" "}
@@ -294,7 +294,7 @@ const MyTeam = ({ setMultiUserLoginValid, myTeamSubmitRef, navigate }) => {
                   onChange={handleUsernameChange}
                 />
               </div>
-              <p className=" text-white text-opacity-80 text-xs font-base">
+              <p className=" text-foreground text-opacity-80 text-xs font-base">
                 {t("onboarding.userSetup.adminUsernameReq")}
               </p>
               <div className="mt-4">
@@ -315,7 +315,7 @@ const MyTeam = ({ setMultiUserLoginValid, myTeamSubmitRef, navigate }) => {
                   onChange={handlePasswordChange}
                 />
               </div>
-              <p className=" text-white text-opacity-80 text-xs font-base">
+              <p className=" text-foreground text-opacity-80 text-xs font-base">
                 {t("onboarding.userSetup.adminPasswordReq")}
               </p>
             </div>

--- a/frontend/src/pages/OnboardingFlow/Steps/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/index.jsx
@@ -62,7 +62,7 @@ export function OnboardingLayout({ children }) {
                   className="group p-2 rounded-sm border-2 border-zinc-300 disabled:border-zinc-600 h-fit w-fit disabled:not-allowed hover:bg-zinc-100 disabled:hover:bg-transparent"
                 >
                   <ArrowLeft
-                    className="text-white group-hover:text-foreground group-disabled:text-gray-500"
+                    className="text-foreground group-hover:text-foreground group-disabled:text-foreground"
                     size={30}
                   />
                 </button>
@@ -77,7 +77,7 @@ export function OnboardingLayout({ children }) {
                   className="group p-2 rounded-sm border-2 border-zinc-300 disabled:border-zinc-600 h-fit w-fit disabled:not-allowed hover:bg-card disabled:hover:bg-transparent"
                 >
                   <ArrowRight
-                    className="text-white group-hover:text-primary group-disabled:text-gray-500"
+                    className="text-foreground group-hover:text-primary group-disabled:text-foreground"
                     size={30}
                   />
                 </button>
@@ -103,7 +103,7 @@ export function OnboardingLayout({ children }) {
             aria-label="Back"
           >
             <ArrowLeft
-              className="text-theme-text-secondary group-hover:text-theme-text-primary group-disabled:text-gray-500"
+              className="text-theme-text-secondary group-hover:text-theme-text-primary group-disabled:text-foreground"
               size={30}
             />
           </button>
@@ -131,7 +131,7 @@ export function OnboardingLayout({ children }) {
             aria-label="Continue"
           >
             <ArrowRight
-              className="text-theme-text-secondary group-hover:text-white group-disabled:text-gray-500"
+              className="text-theme-text-secondary group-hover:text-foreground group-disabled:text-foreground"
               size={30}
             />
           </button>

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentLLMSelection/AgentLLMItem/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentLLMSelection/AgentLLMItem/index.jsx
@@ -70,8 +70,8 @@ export default function AgentLLMItem({
               className="w-10 h-10 rounded-md"
             />
             <div className="flex flex-col">
-              <div className="text-sm font-semibold text-white">{name}</div>
-              <div className="mt-1 text-xs text-white/60">{description}</div>
+              <div className="text-sm font-semibold text-foreground">{name}</div>
+              <div className="mt-1 text-xs text-foreground/60">{description}</div>
             </div>
           </div>
           {checked &&
@@ -82,7 +82,7 @@ export default function AgentLLMItem({
                   e.preventDefault();
                   openModal();
                 }}
-                className="border-none p-2 text-white/60 hover:text-white hover:bg-theme-bg-hover rounded-md transition-all duration-300"
+                className="border-none p-2 text-foreground/60 hover:text-foreground hover:bg-theme-bg-hover rounded-md transition-all duration-300"
                 title="Edit Settings"
               >
                 <Gear size={20} weight="bold" />
@@ -139,7 +139,7 @@ function SetupProvider({
         <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
           <div className="relative p-6 border-b rounded-t border-theme-modal-border">
             <div className="w-full flex gap-x-2 items-center">
-              <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+              <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
                 {LLMOption.name} Settings
               </h3>
             </div>
@@ -148,13 +148,13 @@ function SetupProvider({
               type="button"
               className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
             >
-              <X size={24} weight="bold" className="text-white" />
+              <X size={24} weight="bold" className="text-foreground" />
             </button>
           </div>
           <form id="provider-form" onSubmit={handleUpdate}>
             <div className="px-7 py-6">
               <div className="space-y-6 max-h-[60vh] overflow-y-auto p-1">
-                <p className="text-sm text-white/60">
+                <p className="text-sm text-foreground/60">
                   To use {LLMOption.name} as this workspace's agent LLM you need
                   to set it up first.
                 </p>
@@ -167,7 +167,7 @@ function SetupProvider({
               <button
                 type="button"
                 onClick={closeModal}
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentLLMSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentLLMSelection/index.jsx
@@ -104,9 +104,9 @@ export default function AgentLLMSelection({
 
   const selectedLLMObject = LLMS.find((llm) => llm.value === selectedLLM);
   return (
-    <div className="border-b border-white/40 pb-8">
+    <div className="border-b border-border/40 pb-8">
       {WARN_PERFORMANCE.includes(selectedLLM) && (
-        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-white mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
+        <div className="flex flex-col md:flex-row md:items-center gap-x-2 text-foreground mb-4 bg-blue-800/30 w-fit rounded-lg px-4 py-2">
           <div className="gap-x-2 flex items-center">
             <Gauge className="shrink-0" size={25} />
             <p className="text-sm">{t("agent.performance-warning")}</p>
@@ -118,7 +118,7 @@ export default function AgentLLMSelection({
         <label htmlFor="name" className="block input-label">
           {t("agent.provider.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("agent.provider.description")}
         </p>
       </div>
@@ -188,7 +188,7 @@ export default function AgentLLMSelection({
                 className="w-10 h-10 rounded-md"
               />
               <div className="flex flex-col text-left">
-                <div className="text-sm font-semibold text-white">
+                <div className="text-sm font-semibold text-foreground">
                   {selectedLLMObject.name}
                 </div>
                 <div className="mt-1 text-xs text-description">
@@ -196,7 +196,7 @@ export default function AgentLLMSelection({
                 </div>
               </div>
             </div>
-            <CaretUpDown size={24} weight="bold" className="text-white" />
+            <CaretUpDown size={24} weight="bold" className="text-foreground" />
           </button>
         )}
       </div>

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/AgentModelSelection/index.jsx
@@ -46,7 +46,7 @@ export default function AgentModelSelection({
   if (DISABLED_PROVIDERS.includes(provider)) {
     return (
       <div className="w-full h-10 justify-center items-center flex">
-        <p className="text-sm font-base text-white text-opacity-60 text-center">
+        <p className="text-sm font-base text-foreground text-opacity-60 text-center">
           Multi-model support is not supported for this provider yet.
           <br />
           Agent's will use{" "}
@@ -72,7 +72,7 @@ export default function AgentModelSelection({
           <label htmlFor="name" className="block input-label">
             {t("agent.mode.chat.title")}
           </label>
-          <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+          <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
             {t("agent.mode.chat.description")}
           </p>
         </div>
@@ -80,7 +80,7 @@ export default function AgentModelSelection({
           name="agentModel"
           required={true}
           disabled={true}
-          className="border-none bg-theme-settings-input-bg text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             {t("agent.mode.wait")}
@@ -96,7 +96,7 @@ export default function AgentModelSelection({
         <label htmlFor="name" className="block input-label">
           {t("agent.mode.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("agent.mode.description")}
         </p>
       </div>
@@ -107,7 +107,7 @@ export default function AgentModelSelection({
         onChange={() => {
           setHasChanges(true);
         }}
-        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
       >
         {defaultModels.length > 0 && (
           <optgroup label="General models">

--- a/frontend/src/pages/WorkspaceSettings/AgentConfig/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/AgentConfig/index.jsx
@@ -91,12 +91,12 @@ export default function WorkspaceAgentConfiguration({ workspace }) {
             {!hasChanges && (
               <div className="flex flex-col gap-y-4">
                 <a
-                  className="w-fit transition-all duration-300 border border-slate-200 px-5 py-2.5 rounded-lg text-white text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
+                  className="w-fit transition-all duration-300 border border-slate-200 px-5 py-2.5 rounded-lg text-foreground text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
                   href={paths.settings.agentSkills()}
                 >
                   Configure Agent Skills
                 </a>
-                <p className="text-white text-opacity-60 text-xs font-medium">
+                <p className="text-foreground text-opacity-60 text-xs font-medium">
                   Customize and enhance the default agent's capabilities by
                   enabling or disabling specific skills. These settings will be
                   applied across all workspaces.
@@ -110,7 +110,7 @@ export default function WorkspaceAgentConfiguration({ workspace }) {
           <button
             type="submit"
             form="agent-settings-form"
-            className="w-fit transition-all duration-300 border border-slate-200 px-5 py-2.5 rounded-sm text-white text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
+            className="w-fit transition-all duration-300 border border-slate-200 px-5 py-2.5 rounded-sm text-foreground text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
           >
             {saving ? "Updating agent..." : "Update workspace agent"}
           </button>

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatHistorySettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatHistorySettings/index.jsx
@@ -7,7 +7,7 @@ export default function ChatHistorySettings({ workspace, setHasChanges }) {
         <label htmlFor="name" className="block mb-2 input-label">
           {t("chat.history.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium">
+        <p className="text-foreground text-opacity-60 text-xs font-medium">
           {t("chat.history.desc-start")}
           <i> {t("chat.history.recommend")} </i>
           {t("chat.history.desc-end")}
@@ -21,7 +21,7 @@ export default function ChatHistorySettings({ workspace, setHasChanges }) {
         step={1}
         onWheel={(e) => e.target.blur()}
         defaultValue={workspace?.openAiHistory ?? 20}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         placeholder="20"
         required={true}
         autoComplete="off"

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatModeSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatModeSelection/index.jsx
@@ -21,7 +21,7 @@ export default function ChatModeSelection({ workspace, setHasChanges }) {
               setChatMode("chat");
               setHasChanges(true);
             }}
-            className="transition-bg duration-200 px-6 py-1 text-md text-white/60 disabled:text-white bg-transparent disabled:bg-[#687280] rounded-md"
+            className="transition-bg duration-200 px-6 py-1 text-md text-foreground/60 disabled:text-foreground bg-transparent disabled:bg-[#687280] rounded-md"
           >
             {t("chat.mode.chat.title")}
           </button>
@@ -32,12 +32,12 @@ export default function ChatModeSelection({ workspace, setHasChanges }) {
               setChatMode("query");
               setHasChanges(true);
             }}
-            className="transition-bg duration-200 px-6 py-1 text-md text-white/60 disabled:text-white bg-transparent disabled:bg-[#687280] rounded-md"
+            className="transition-bg duration-200 px-6 py-1 text-md text-foreground/60 disabled:text-foreground bg-transparent disabled:bg-[#687280] rounded-md"
           >
             {t("chat.mode.query.title")}
           </button>
         </div>
-        <p className="text-sm text-white/60">
+        <p className="text-sm text-foreground/60">
           {chatMode === "chat" ? (
             <>
               <b>{t("chat.mode.chat.title")}</b>{" "}

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/ChatPromptHistory/PromptHistoryItem/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/ChatPromptHistory/PromptHistoryItem/index.jsx
@@ -50,16 +50,16 @@ export default function PromptHistoryItem({
   }, [showMenu]);
 
   return (
-    <div className="text-white">
+    <div className="text-foreground">
       <div className="flex items-center justify-between">
         <div className="text-xs">
           {user && (
             <>
               <span className="text-primary-button">{user.username}</span>{" "}
-              <span className="mx-1 text-white">•</span>
+              <span className="mx-1 text-foreground">•</span>
             </>
           )}
-          <span className="text-white opacity-50 light:opacity-100">
+          <span className="text-foreground opacity-50 light:opacity-100">
             {moment(modifiedAt).fromNow()}
           </span>
         </div>
@@ -87,7 +87,7 @@ export default function PromptHistoryItem({
               >
                 <button
                   type="button"
-                  className="px-[10px] py-[6px] text-sm text-white hover:bg-theme-sidebar-item-hover rounded-t-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
+                  className="px-[10px] py-[6px] text-sm text-foreground hover:bg-theme-sidebar-item-hover rounded-t-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
                   onClick={() => {
                     setShowMenu(false);
                     onPublishClick(prompt);
@@ -97,7 +97,7 @@ export default function PromptHistoryItem({
                 </button>
                 <button
                   type="button"
-                  className="px-[10px] py-[6px] text-sm text-white hover:bg-red-500/60 light:hover:bg-red-300/80 rounded-b-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
+                  className="px-[10px] py-[6px] text-sm text-foreground hover:bg-red-500/60 light:hover:bg-red-300/80 rounded-b-lg cursor-pointer border-none w-full text-left whitespace-nowrap"
                   onClick={() => {
                     setShowMenu(false);
                     deleteHistory(id);

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatPromptSettings/index.jsx
@@ -98,10 +98,10 @@ export default function ChatPromptSettings({ workspace, setHasChanges }) {
               {t("chat.prompt.title")}
             </label>
           </div>
-          <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+          <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
             {t("chat.prompt.description")}
           </p>
-          <p className="text-white text-opacity-60 text-xs font-medium mb-2">
+          <p className="text-foreground text-opacity-60 text-xs font-medium mb-2">
             You can insert{" "}
             <Link
               to={paths.settings.systemPromptVariables()}
@@ -134,7 +134,7 @@ export default function ChatPromptSettings({ workspace, setHasChanges }) {
           <button
             ref={historyButtonRef}
             type="button"
-            className="text-theme-text-secondary hover:text-white light:hover:text-foreground text-xs font-medium"
+            className="text-theme-text-secondary hover:text-foreground light:hover:text-foreground text-xs font-medium"
             onClick={(e) => {
               e.preventDefault();
               setShowPromptHistory(!showPromptHistory);
@@ -175,7 +175,7 @@ export default function ChatPromptSettings({ workspace, setHasChanges }) {
                   minHeight: "150px",
                 }}
                 defaultValue={prompt}
-                className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
+                className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
               />
             ) : (
               <div
@@ -185,7 +185,7 @@ export default function ChatPromptSettings({ workspace, setHasChanges }) {
                   overflowY: "scroll",
                   minHeight: "150px",
                 }}
-                className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
+                className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
               >
                 <Highlighter
                   className="whitespace-pre-wrap"
@@ -204,7 +204,7 @@ export default function ChatPromptSettings({ workspace, setHasChanges }) {
                 <button
                   type="button"
                   onClick={() => handleRestore(DEFAULT_PROMPT)}
-                  className="text-theme-text-primary hover:text-white light:hover:text-foreground text-xs font-medium"
+                  className="text-theme-text-primary hover:text-foreground light:hover:text-foreground text-xs font-medium"
                 >
                   Clear
                 </button>
@@ -240,7 +240,7 @@ function PublishPromptCTA({ hidden = false, onClick }) {
     <button
       type="button"
       onClick={onClick}
-      className="border-none text-primary-button hover:text-white light:hover:text-foreground text-xs font-medium"
+      className="border-none text-primary-button hover:text-foreground light:hover:text-foreground text-xs font-medium"
     >
       Publish to Community Hub
     </button>

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatQueryRefusalResponse/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatQueryRefusalResponse/index.jsx
@@ -8,7 +8,7 @@ export default function ChatQueryRefusalResponse({ workspace, setHasChanges }) {
         <label htmlFor="name" className="block input-label">
           {t("chat.refusal.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("chat.refusal.desc-start")}{" "}
           <code className="border-none bg-theme-settings-input-bg p-0.5 rounded-sm">
             {t("chat.refusal.query")}
@@ -20,7 +20,7 @@ export default function ChatQueryRefusalResponse({ workspace, setHasChanges }) {
         name="queryRefusalResponse"
         rows={2}
         defaultValue={chatQueryRefusalResponse(workspace)}
-        className="border-none bg-theme-settings-input-bg placeholder:text-theme-settings-input-placeholder text-white text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
+        className="border-none bg-theme-settings-input-bg placeholder:text-theme-settings-input-placeholder text-foreground text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
         placeholder="The text returned in query mode when there is no relevant context found for a response."
         required={true}
         wrap="soft"

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatTemperatureSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/ChatTemperatureSettings/index.jsx
@@ -21,7 +21,7 @@ export default function ChatTemperatureSettings({
         <label htmlFor="name" className="block input-label">
           {t("chat.temperature.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("chat.temperature.desc-start")}
           <br />
           {t("chat.temperature.desc-end")}
@@ -37,7 +37,7 @@ export default function ChatTemperatureSettings({
         step={0.1}
         onWheel={(e) => e.target.blur()}
         defaultValue={workspace?.openAiTemp ?? defaults.temp}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         placeholder="0.7"
         required={true}
         autoComplete="off"

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/ChatModelSelection/index.jsx
@@ -20,7 +20,7 @@ export default function ChatModelSelection({
           <label htmlFor="name" className="block input-label">
             {t("chat.model.title")}
           </label>
-          <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+          <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
             {t("chat.model.description")}
           </p>
         </div>
@@ -28,7 +28,7 @@ export default function ChatModelSelection({
           name="chatModel"
           required={true}
           disabled={true}
-          className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+          className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         >
           <option disabled={true} selected={true}>
             -- waiting for models --
@@ -44,7 +44,7 @@ export default function ChatModelSelection({
         <label htmlFor="name" className="block input-label">
           {t("chat.model.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("chat.model.description")}
         </p>
       </div>
@@ -55,7 +55,7 @@ export default function ChatModelSelection({
         onChange={() => {
           setHasChanges(true);
         }}
-        className="border-none bg-theme-settings-input-bg text-white text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
       >
         {defaultModels.length > 0 && (
           <optgroup label="General models">

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/WorkspaceLLMItem/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/WorkspaceLLMItem/index.jsx
@@ -70,8 +70,8 @@ export default function WorkspaceLLM({
               className="w-10 h-10 rounded-md"
             />
             <div className="flex flex-col">
-              <div className="text-sm font-semibold text-white">{name}</div>
-              <div className="mt-1 text-xs text-white/60">{description}</div>
+              <div className="text-sm font-semibold text-foreground">{name}</div>
+              <div className="mt-1 text-xs text-foreground/60">{description}</div>
             </div>
           </div>
           {checked && !NO_SETTINGS_NEEDED.includes(value) && (
@@ -80,7 +80,7 @@ export default function WorkspaceLLM({
                 e.preventDefault();
                 openModal();
               }}
-              className="p-2 text-white/60 hover:text-white hover:bg-theme-bg-hover rounded-md transition-all duration-300"
+              className="p-2 text-foreground/60 hover:text-foreground hover:bg-theme-bg-hover rounded-md transition-all duration-300"
               title="Edit Settings"
             >
               <Gear size={20} weight="bold" />
@@ -137,7 +137,7 @@ function SetupProvider({
         <div className="relative w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border">
           <div className="relative p-6 border-b rounded-t border-theme-modal-border">
             <div className="w-full flex gap-x-2 items-center">
-              <h3 className="text-xl font-semibold text-white overflow-hidden overflow-ellipsis whitespace-nowrap">
+              <h3 className="text-xl font-semibold text-foreground overflow-hidden overflow-ellipsis whitespace-nowrap">
                 {LLMOption.name} Settings
               </h3>
             </div>
@@ -146,13 +146,13 @@ function SetupProvider({
               type="button"
               className="absolute top-4 right-4 transition-all duration-300 bg-transparent rounded-sm text-sm p-1 inline-flex items-center hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
             >
-              <X size={24} weight="bold" className="text-white" />
+              <X size={24} weight="bold" className="text-foreground" />
             </button>
           </div>
           <form id="provider-form" onSubmit={handleUpdate}>
             <div className="px-7 py-6">
               <div className="space-y-6 max-h-[60vh] overflow-y-auto p-1">
-                <p className="text-sm text-white/60">
+                <p className="text-sm text-foreground/60">
                   To use {LLMOption.name} as this workspace's LLM you need to
                   set it up first.
                 </p>
@@ -165,7 +165,7 @@ function SetupProvider({
               <button
                 type="button"
                 onClick={closeModal}
-                className="transition-all duration-300 text-white hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
+                className="transition-all duration-300 text-foreground hover:bg-zinc-700 px-4 py-2 rounded-sm text-sm"
               >
                 Cancel
               </button>

--- a/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/ChatSettings/WorkspaceLLMSelection/index.jsx
@@ -71,12 +71,12 @@ export default function WorkspaceLLMSelection({
   const selectedLLMObject = LLMS.find((llm) => llm.value === selectedLLM);
 
   return (
-    <div className="border-b border-white/40 pb-8">
+    <div className="border-b border-border/40 pb-8">
       <div className="flex flex-col">
         <label htmlFor="name" className="block input-label">
           {t("chat.llm.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("chat.llm.description")}
         </p>
       </div>
@@ -146,7 +146,7 @@ export default function WorkspaceLLMSelection({
                 className="w-10 h-10 rounded-md"
               />
               <div className="flex flex-col text-left">
-                <div className="text-sm font-semibold text-white">
+                <div className="text-sm font-semibold text-foreground">
                   {selectedLLMObject.name}
                 </div>
                 <div className="mt-1 text-xs text-description">
@@ -154,7 +154,7 @@ export default function WorkspaceLLMSelection({
                 </div>
               </div>
             </div>
-            <CaretUpDown size={24} weight="bold" className="text-white" />
+            <CaretUpDown size={24} weight="bold" className="text-foreground" />
           </button>
         )}
       </div>
@@ -173,7 +173,7 @@ function ModelSelector({ selectedLLM, workspace, setHasChanges }) {
     if (selectedLLM !== "default") {
       return (
         <div className="w-full h-10 justify-center items-center flex mt-4">
-          <p className="text-sm font-base text-white text-opacity-60 text-center">
+          <p className="text-sm font-base text-foreground text-opacity-60 text-center">
             Multi-model support is not supported for this provider yet.
             <br />
             This workspace will use{" "}
@@ -207,7 +207,7 @@ function FreeFormLLMInput({ workspace, setHasChanges }) {
   return (
     <div className="mt-4 flex flex-col gap-y-1">
       <label className="block input-label">{t("chat.model.title")}</label>
-      <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+      <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
         {t("chat.model.description")}
       </p>
       <input
@@ -215,7 +215,7 @@ function FreeFormLLMInput({ workspace, setHasChanges }) {
         name="chatModel"
         defaultValue={workspace?.chatModel || ""}
         onChange={() => setHasChanges(true)}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         placeholder="Enter model name exactly as referenced in the API (e.g., gpt-3.5-turbo)"
       />
     </div>

--- a/frontend/src/pages/WorkspaceSettings/GeneralAppearance/SuggestedChatMessages/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/GeneralAppearance/SuggestedChatMessages/index.jsx
@@ -95,10 +95,10 @@ export default function SuggestedChatMessages({ slug }) {
         <label className="block input-label">
           {t("general.message.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("general.message.description")}
         </p>
-        <div className="text-white text-opacity-60 text-sm font-medium mt-6">
+        <div className="text-foreground text-opacity-60 text-sm font-medium mt-6">
           <PreLoader size="4" />
         </div>
       </div>
@@ -109,16 +109,16 @@ export default function SuggestedChatMessages({ slug }) {
         <label className="block input-label">
           {t("general.message.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("general.message.description")}
         </p>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-white/60 text-xs mt-2 w-full justify-center max-w-[600px]">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 text-foreground/60 text-xs mt-2 w-full justify-center max-w-[600px]">
         {suggestedMessages.map((suggestion, index) => (
           <div key={index} className="relative w-full">
             <button
-              className="transition-all duration-300 absolute z-10 text-neutral-700 bg-card rounded-full hover:bg-zinc-600 hover:border-zinc-600 hover:text-white border-transparent border shadow-lg ml-2"
+              className="transition-all duration-300 absolute z-10 text-neutral-700 bg-card rounded-full hover:bg-zinc-600 hover:border-zinc-600 hover:text-foreground border-transparent border shadow-lg ml-2"
               style={{
                 top: -8,
                 left: 265,
@@ -130,7 +130,7 @@ export default function SuggestedChatMessages({ slug }) {
             <button
               key={index}
               onClick={(e) => startEditing(e, index)}
-              className={`text-left p-2.5 border rounded-xl w-full border-white/20 bg-theme-settings-input-bg hover:bg-theme-sidebar-item-selected-gradient ${
+              className={`text-left p-2.5 border rounded-xl w-full border-border/20 bg-theme-settings-input-bg hover:bg-theme-sidebar-item-selected-gradient ${
                 editingIndex === index ? "border-sky-400" : ""
               }`}
             >
@@ -143,24 +143,24 @@ export default function SuggestedChatMessages({ slug }) {
       {editingIndex >= 0 && (
         <div className="flex flex-col gap-y-4 mr-2 mt-8">
           <div className="w-1/2">
-            <label className="text-white text-sm font-semibold block mb-2">
+            <label className="text-foreground text-sm font-semibold block mb-2">
               Heading
             </label>
             <input
               placeholder="Message heading"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-white/20 text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block p-2.5 w-full"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-foreground/20 text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block p-2.5 w-full"
               value={newMessage.heading}
               name="heading"
               onChange={onEditChange}
             />
           </div>
           <div className="w-1/2">
-            <label className="text-white text-sm font-semibold block mb-2">
+            <label className="text-foreground text-sm font-semibold block mb-2">
               Message
             </label>
             <input
               placeholder="Message"
-              className="border-none bg-theme-settings-input-bg text-white placeholder:text-white/20 text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block p-2.5 w-full"
+              className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-foreground/20 text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block p-2.5 w-full"
               value={newMessage.message}
               name="message"
               onChange={onEditChange}
@@ -172,7 +172,7 @@ export default function SuggestedChatMessages({ slug }) {
         <button
           type="button"
           onClick={addMessage}
-          className="flex gap-x-2 items-center justify-center mt-6 text-white text-sm hover:text-sky-400 transition-all duration-300"
+          className="flex gap-x-2 items-center justify-center mt-6 text-foreground text-sm hover:text-sky-400 transition-all duration-300"
         >
           {t("general.message.add")}{" "}
           <Plus className="" size={24} weight="fill" />
@@ -183,7 +183,7 @@ export default function SuggestedChatMessages({ slug }) {
         <div className="flex justify-start py-6">
           <button
             type="button"
-            className="transition-all duration-300 border border-slate-200 px-4 py-2 rounded-sm text-white text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
+            className="transition-all duration-300 border border-slate-200 px-4 py-2 rounded-sm text-foreground text-sm items-center flex gap-x-2 hover:bg-card hover:text-foreground focus:ring-gray-800"
             onClick={handleSaveSuggestedMessages}
           >
             {t("general.message.save")}

--- a/frontend/src/pages/WorkspaceSettings/GeneralAppearance/WorkspaceName/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/GeneralAppearance/WorkspaceName/index.jsx
@@ -8,7 +8,7 @@ export default function WorkspaceName({ workspace, setHasChanges }) {
         <label htmlFor="name" className="block input-label">
           {t("common.workspaces-name")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("general.names.description")}
         </p>
       </div>
@@ -18,7 +18,7 @@ export default function WorkspaceName({ workspace, setHasChanges }) {
         minLength={2}
         maxLength={80}
         defaultValue={workspace?.name}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         placeholder="My Workspace"
         required={true}
         autoComplete="off"

--- a/frontend/src/pages/WorkspaceSettings/GeneralAppearance/WorkspacePfp/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/GeneralAppearance/WorkspacePfp/index.jsx
@@ -49,13 +49,13 @@ export default function WorkspacePfp({ workspace, slug }) {
     <div className="mt-6">
       <div className="flex flex-col">
         <label className="block input-label">{t("general.pfp.title")}</label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("general.pfp.description")}
         </p>
       </div>
       <div className="flex flex-col md:flex-row items-center gap-8">
         <div className="flex flex-col items-center">
-          <label className="w-36 h-36 flex flex-col items-center justify-center bg-theme-settings-input-bg transition-all duration-300 rounded-full mt-8 border-2 border-dashed border-white border-opacity-60 cursor-pointer hover:opacity-60">
+          <label className="w-36 h-36 flex flex-col items-center justify-center bg-theme-settings-input-bg transition-all duration-300 rounded-full mt-8 border-2 border-dashed border-border border-opacity-60 cursor-pointer hover:opacity-60">
             <input
               id="workspace-pfp-upload"
               type="file"

--- a/frontend/src/pages/WorkspaceSettings/Members/AddMemberModal/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/Members/AddMemberModal/index.jsx
@@ -66,17 +66,17 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
       <div className="w-full max-w-2xl bg-theme-bg-secondary rounded-lg shadow border-2 border-theme-modal-border overflow-hidden">
         <div className="flex items-center justify-between p-6 border-b rounded-t border-theme-modal-border">
           <div className="flex items-center gap-x-4">
-            <h3 className="text-base font-semibold text-white">Users</h3>
+            <h3 className="text-base font-semibold text-foreground">Users</h3>
             <div className="relative">
               <input
                 onChange={handleSearch}
-                className="w-[400px] h-[34px] bg-theme-bg-primary rounded-sm text-white placeholder:text-theme-text-secondary text-sm px-10 pl-10"
+                className="w-[400px] h-[34px] bg-theme-bg-primary rounded-sm text-foreground placeholder:text-theme-text-secondary text-sm px-10 pl-10"
                 placeholder="Search for a user"
               />
               <MagnifyingGlass
                 size={16}
                 weight="bold"
-                className="text-white text-lg absolute left-3 top-1/2 transform -translate-y-1/2"
+                className="text-foreground text-lg absolute left-3 top-1/2 transform -translate-y-1/2"
               />
             </div>
           </div>
@@ -85,7 +85,7 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
             type="button"
             className="border-none bg-transparent rounded-sm text-sm p-1.5 ml-auto inline-flex items-center bg-sidebar-button hover:bg-theme-modal-border hover:border-theme-modal-border hover:border-opacity-50 border-transparent border"
           >
-            <X className="text-white text-lg" />
+            <X className="text-foreground text-lg" />
           </button>
         </div>
         <form onSubmit={handleUpdate}>
@@ -99,7 +99,7 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
                     onClick={() => handleUserSelect(user.id)}
                   >
                     <div
-                      className="shrink-0 w-3 h-3 rounded border-[1px] border-solid border-white light:border-black flex justify-center items-center"
+                      className="shrink-0 w-3 h-3 rounded border-[1px] border-solid border-border light:border-black flex justify-center items-center"
                       role="checkbox"
                       aria-checked={isUserSelected(user.id)}
                       tabIndex={0}
@@ -123,7 +123,7 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
           <p className="text-theme-text-secondary text-xs px-5 pb-2">
             {t("common.adminRemoveWarning")}
           </p>
-          <div className="flex w-full justify-between items-center p-3 space-x-2 border-t rounded-b border-gray-500/50">
+          <div className="flex w-full justify-between items-center p-3 space-x-2 border-t rounded-b border-border/50">
             <div className="flex items-center gap-x-2">
               <button
                 type="button"
@@ -131,7 +131,7 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
                 className="flex items-center gap-x-2 ml-2"
               >
                 <div
-                  className="shrink-0 w-3 h-3 rounded border-[1px] border-white flex justify-center items-center cursor-pointer"
+                  className="shrink-0 w-3 h-3 rounded border-[1px] border-border flex justify-center items-center cursor-pointer"
                   role="checkbox"
                   aria-checked={selectedUsers.length === filteredUsers.length}
                   tabIndex={0}
@@ -140,7 +140,7 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
                     <div className="w-2 h-2 bg-card rounded-sm" />
                   )}
                 </div>
-                <p className="text-white text-sm font-medium">Select All</p>
+                <p className="text-foreground text-sm font-medium">Select All</p>
               </button>
               {selectedUsers.length > 0 && (
                 <button
@@ -156,7 +156,7 @@ export default function AddMemberModal({ closeModal, workspace, users }) {
             </div>
             <button
               type="submit"
-              className="transition-all duration-300 text-xs px-2 py-1 font-semibold rounded-sm bg-primary-button hover:bg-secondary border-2 border-transparent hover:border-primary-button hover:text-white h-[32px] w-[68px] -mr-8 whitespace-nowrap shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
+              className="transition-all duration-300 text-xs px-2 py-1 font-semibold rounded-sm bg-primary-button hover:bg-secondary border-2 border-transparent hover:border-primary-button hover:text-foreground h-[32px] w-[68px] -mr-8 whitespace-nowrap shadow-[0_4px_14px_rgba(0,0,0,0.25)]"
             >
               Save
             </button>

--- a/frontend/src/pages/WorkspaceSettings/Members/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/Members/index.jsx
@@ -48,7 +48,7 @@ export default function Members({ workspace }) {
   return (
     <div className="flex justify-between -mt-3">
       <table className="w-full max-w-[700px] text-sm text-left rounded-lg">
-        <thead className="text-white text-opacity-80 text-xs leading-[18px] font-bold uppercase border-white/10 border-b border-opacity-60">
+        <thead className="text-foreground text-opacity-80 text-xs leading-[18px] font-bold uppercase border-border/10 border-b border-opacity-60">
           <tr>
             <th scope="col" className="px-6 py-3 rounded-tl-lg">
               Username
@@ -71,7 +71,7 @@ export default function Members({ workspace }) {
             ))
           ) : (
             <tr>
-              <td className="text-center py-4 text-white/80" colSpan="4">
+              <td className="text-center py-4 text-foreground/80" colSpan="4">
                 No workspace members
               </td>
             </tr>

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/DocumentSimilarityThreshold/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/DocumentSimilarityThreshold/index.jsx
@@ -11,14 +11,14 @@ export default function DocumentSimilarityThreshold({
         <label htmlFor="name" className="block input-label">
           {t("vector-workspace.doc.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("vector-workspace.doc.description")}
         </p>
       </div>
       <select
         name="similarityThreshold"
         defaultValue={workspace?.similarityThreshold ?? 0.25}
-        className="border-none bg-theme-settings-input-bg text-white text-sm mt-2 rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground text-sm mt-2 rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         onChange={() => setHasChanges(true)}
         required={true}
       >

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/MaxContextSnippets/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/MaxContextSnippets/index.jsx
@@ -8,7 +8,7 @@ export default function MaxContextSnippets({ workspace, setHasChanges }) {
         <label htmlFor="name" className="block input-label">
           {t("vector-workspace.snippets.title")}
         </label>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
           {t("vector-workspace.snippets.description")}
           <br />
           <i>{t("vector-workspace.snippets.recommend")}</i>
@@ -22,7 +22,7 @@ export default function MaxContextSnippets({ workspace, setHasChanges }) {
         step={1}
         onWheel={(e) => e.target.blur()}
         defaultValue={workspace?.topN ?? 4}
-        className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
+        className="border-none bg-theme-settings-input-bg text-foreground placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5 mt-2"
         placeholder="4"
         required={true}
         autoComplete="off"

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/VectorCount/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/VectorCount/index.jsx
@@ -19,10 +19,10 @@ export default function VectorCount({ reload, workspace }) {
     return (
       <div>
         <h3 className="input-label">{t("general.vector.title")}</h3>
-        <p className="text-white text-opacity-60 text-xs font-medium py-1">
+        <p className="text-foreground text-opacity-60 text-xs font-medium py-1">
           {t("general.vector.description")}
         </p>
-        <div className="text-white text-opacity-60 text-sm font-medium">
+        <div className="text-foreground text-opacity-60 text-sm font-medium">
           <PreLoader size="4" />
         </div>
       </div>
@@ -30,7 +30,7 @@ export default function VectorCount({ reload, workspace }) {
   return (
     <div>
       <h3 className="input-label">{t("general.vector.title")}</h3>
-      <p className="text-white text-opacity-60 text-sm font-medium">
+      <p className="text-foreground text-opacity-60 text-sm font-medium">
         {totalVectors}
       </p>
     </div>

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/VectorDBIdentifier/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/VectorDBIdentifier/index.jsx
@@ -5,8 +5,8 @@ export default function VectorDBIdentifier({ workspace }) {
   return (
     <div>
       <h3 className="input-label">{t("vector-workspace.identifier")}</h3>
-      <p className="text-white/60 text-xs font-medium py-1"> </p>
-      <p className="text-white/60 text-sm">{workspace?.slug}</p>
+      <p className="text-foreground/60 text-xs font-medium py-1"> </p>
+      <p className="text-foreground/60 text-sm">{workspace?.slug}</p>
     </div>
   );
 }

--- a/frontend/src/pages/WorkspaceSettings/VectorDatabase/VectorSearchMode/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/VectorDatabase/VectorSearchMode/index.jsx
@@ -33,7 +33,7 @@ export default function VectorSearchMode({ workspace, setHasChanges }) {
       <select
         name="vectorSearchMode"
         value={selection}
-        className="border-none bg-theme-settings-input-bg text-white text-sm mt-2 rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
+        className="border-none bg-theme-settings-input-bg text-foreground text-sm mt-2 rounded-sm focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
         onChange={(e) => {
           setSelection(e.target.value);
           setHasChanges(true);
@@ -43,7 +43,7 @@ export default function VectorSearchMode({ workspace, setHasChanges }) {
         <option value="default">Default</option>
         <option value="rerank">Accuracy Optimized</option>
       </select>
-      <p className="text-white text-opacity-60 text-xs font-medium py-1.5">
+      <p className="text-foreground text-opacity-60 text-xs font-medium py-1.5">
         {hint[selection]?.description}
       </p>
     </div>

--- a/frontend/src/pages/WorkspaceSettings/index.jsx
+++ b/frontend/src/pages/WorkspaceSettings/index.jsx
@@ -81,10 +81,10 @@ function ShowWorkspaceChat() {
         style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
         className="transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg bg-theme-bg-secondary w-full h-full overflow-y-scroll"
       >
-        <div className="flex gap-x-10 pt-6 pb-4 ml-16 mr-8 border-b-2 border-white light:border-theme-chat-input-border border-opacity-10">
+        <div className="flex gap-x-10 pt-6 pb-4 ml-16 mr-8 border-b-2 border-border light:border-theme-chat-input-border border-opacity-10">
           <Link
             to={paths.workspace.chat(slug)}
-            className="absolute top-2 left-2 md:top-4 md:left-4 transition-all duration-300 p-2 rounded-full text-white bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover z-10"
+            className="absolute top-2 left-2 md:top-4 md:left-4 transition-all duration-300 p-2 rounded-full text-foreground bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover z-10"
           >
             <ArrowUUpLeft className="h-5 w-5" weight="fill" />
           </Link>
@@ -132,7 +132,7 @@ function TabItem({ title, icon, to, visible = true }) {
         `${
           isActive
             ? "text-sky-400 pb-4 border-b-[4px] -mb-[19px] border-sky-400"
-            : "text-white/60 hover:text-sky-400"
+            : "text-foreground/60 hover:text-sky-400"
         } ` + " flex gap-x-2 items-center font-medium"
       }
     >

--- a/frontend/src/utils/chat/markdown.js
+++ b/frontend/src/utils/chat/markdown.js
@@ -19,7 +19,7 @@ const markdown = markdownIt({
     if (lang && hljs.getLanguage(lang)) {
       try {
         return (
-          `<div class="whitespace-pre-line w-full max-w-[65vw] hljs ${theme} light:border-solid light:border light:border-gray-700 rounded-lg relative font-mono font-normal text-sm text-foreground">
+          `<div class="whitespace-pre-line w-full max-w-[65vw] hljs ${theme} light:border-solid light:border light:border-border rounded-lg relative font-mono font-normal text-sm text-foreground">
             <div class="w-full flex items-center sticky top-0 text-foreground light:bg-sky-800 bg-stone-800 px-4 py-2 text-xs font-sans justify-between rounded-t-md -mt-5">
               <div class="flex gap-2">
                 <code class="text-xs">${lang || ""}</code>
@@ -37,7 +37,7 @@ const markdown = markdownIt({
     }
 
     return (
-      `<div class="whitespace-pre-line w-full max-w-[65vw] hljs ${theme} light:border-solid light:border light:border-gray-700 rounded-lg relative font-mono font-normal text-sm text-foreground">
+      `<div class="whitespace-pre-line w-full max-w-[65vw] hljs ${theme} light:border-solid light:border light:border-border rounded-lg relative font-mono font-normal text-sm text-foreground">
         <div class="w-full flex items-center sticky top-0 text-foreground bg-stone-800 px-4 py-2 text-xs font-sans justify-between rounded-t-md -mt-5">
           <div class="flex gap-2"><code class="text-xs"></code></div>
           <button data-code-snippet data-code="code-${uuid}" class="flex items-center gap-x-1">
@@ -53,7 +53,7 @@ const markdown = markdownIt({
 });
 
 // Add custom renderer for strong tags to handle theme colors
-markdown.renderer.rules.strong_open = () => '<strong class="text-white">';
+markdown.renderer.rules.strong_open = () => '<strong class="text-foreground">';
 markdown.renderer.rules.strong_close = () => "</strong>";
 markdown.renderer.rules.link_open = (tokens, idx) => {
   const token = tokens[idx];


### PR DESCRIPTION
## Summary
- replace remaining gray/white utility classes with theme tokens
- ensure SVG icons use `currentColor` so they inherit text color

## Testing
- `git grep -nE 'bg-(gray|slate|white)|text-(white|black)|fill="#fff"|stroke="#fff"' frontend/src`
- `cd frontend && yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e50cf9488328a87f9de6dea7172e