### PR TITLE
feat: adopt new theme tokens and helpers

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,7 +13,7 @@ import SimpleSSOPassthrough from "@/pages/Login/SSO/simple";
 import OnboardingFlow from "@/pages/OnboardingFlow";
 import i18n from "./i18n";
 
-import "./styles/onenew-theme-shim.css";
+import "./styles/onenew-theme.css";
 
 import { PfpProvider } from "./PfpContext";
 import { LogoProvider } from "./LogoContext";
@@ -102,7 +102,7 @@ export default function App() {
   }, []);
 
   return (
-    <div className="theme-onenew dark">
+    <div className="theme-onenew">
       <ThemeProvider>
         <Suspense fallback={<FullScreenLoader />}>
           <ContextWrapper>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,7 +7,7 @@ import "./styles/onenew-components.css";
 import "./styles/forms.css";
 import "./styles/a11y.css";
 import "./styles/utilities.css";
-import "./styles/onenew-theme-shim.css";
+import "./styles/onenew-theme.css";
 const isDev = process.env.NODE_ENV !== "production";
 const REACTWRAP = isDev ? React.Fragment : React.StrictMode;
 

--- a/frontend/src/pages/Login/SSO/simple.jsx
+++ b/frontend/src/pages/Login/SSO/simple.jsx
@@ -1,15 +1,18 @@
 import React, { useEffect, useState } from "react";
+import "@/index.css";
 import { FullScreenLoader } from "@/components/Preloader";
 import paths from "@/utils/paths";
 import useQuery from "@/hooks/useQuery";
 import System from "@/models/system";
 import { AUTH_TIMESTAMP, AUTH_TOKEN, AUTH_USER } from "@/utils/constants";
+import { useThemeContext } from "@/ThemeProvider";
 
 export default function SimpleSSOPassthrough() {
   const query = useQuery();
   const redirectPath = query.get("redirectTo") || paths.home();
   const [ready, setReady] = useState(false);
   const [error, setError] = useState(null);
+  const { theme } = useThemeContext();
 
   useEffect(() => {
     try {
@@ -39,7 +42,10 @@ export default function SimpleSSOPassthrough() {
 
   if (error)
     return (
-      <div className="w-screen h-screen overflow-hidden bg-theme-bg-primary flex items-center justify-center flex-col gap-4">
+      <div
+        className="w-screen h-screen overflow-hidden bg-theme-bg-primary flex items-center justify-center flex-col gap-4"
+        data-theme={theme}
+      >
         <p className="text-theme-text-primary font-mono text-lg">{error}</p>
         <p className="text-theme-text-secondary font-mono text-sm">
           Please contact the system administrator about this error.

--- a/frontend/src/pages/Login/index.jsx
+++ b/frontend/src/pages/Login/index.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "@/index.css";
 import { usePasswordModal } from "@/components/Modals/Password";
 import SingleUserAuth from "@/components/Modals/Password/SingleUserAuth";
 import MultiUserAuth from "@/components/Modals/Password/MultiUserAuth";
@@ -8,6 +9,7 @@ import paths from "@/utils/paths";
 import useQuery from "@/hooks/useQuery";
 import useSimpleSSO from "@/hooks/useSimpleSSO";
 import useLogo from "@/hooks/useLogo";
+import { useThemeContext } from "@/ThemeProvider";
 
 /**
  * Login page that handles both single and multi-user login.
@@ -22,6 +24,7 @@ export default function Login() {
   const { loading: ssoLoading, ssoConfig } = useSimpleSSO();
   const { loading, requiresAuth, mode } = usePasswordModal(!!query.get("nt"));
   const { loginLogo } = useLogo();
+  const { theme } = useThemeContext();
 
   if (loading || ssoLoading) return <FullScreenLoader />;
   if (ssoConfig.enabled && ssoConfig.noLogin)
@@ -29,7 +32,10 @@ export default function Login() {
   if (requiresAuth === false) return <Navigate to={paths.home()} />;
 
   return (
-    <div className="onenew-page min-h-screen grid place-items-center p-6">
+    <div
+      className="onenew-page min-h-screen grid place-items-center p-6"
+      data-theme={theme}
+    >
       <div className="onenew-card w-full max-w-md p-6 md:p-8">
         {loginLogo && (
           <img src={loginLogo} alt="Logo" className="mx-auto h-12" />

--- a/frontend/src/pages/OnboardingFlow/Steps/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/Steps/index.jsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, ArrowRight } from "@phosphor-icons/react";
 import { useState } from "react";
 import { isMobile } from "react-device-detect";
+import { useThemeContext } from "@/ThemeProvider";
 import Home from "./Home";
 import LLMPreference from "./LLMPreference";
 import UserSetup from "./UserSetup";
@@ -35,10 +36,13 @@ export function OnboardingLayout({ children }) {
     onClick: () => null,
   });
 
+  const { theme } = useThemeContext();
+
   if (isMobile) {
     return (
       <div
         data-layout="onboarding"
+        data-theme={theme}
         className="w-screen h-screen overflow-y-auto bg-theme-bg-primary overflow-hidden"
       >
         <div className="flex flex-col">
@@ -92,6 +96,7 @@ export function OnboardingLayout({ children }) {
   return (
     <div
       data-layout="onboarding"
+      data-theme={theme}
       className="w-screen overflow-y-auto bg-theme-bg-primary flex justify-center overflow-hidden"
     >
       <div className="flex w-1/5 h-screen justify-center items-center">

--- a/frontend/src/pages/OnboardingFlow/index.jsx
+++ b/frontend/src/pages/OnboardingFlow/index.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "@/index.css";
 import OnboardingSteps, { OnboardingLayout } from "./Steps";
 import { useParams } from "react-router-dom";
 

--- a/frontend/src/styles/onenew-theme.css
+++ b/frontend/src/styles/onenew-theme.css
@@ -1,0 +1,29 @@
+.onenew-gradient {
+  background-image: linear-gradient(135deg, var(--brand-blue-600), var(--brand-violet-600));
+}
+
+.glass {
+  background: color-mix(in srgb, var(--theme-bg-primary), transparent 30%);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--theme-modal-border);
+}
+
+/* semantic helpers */
+.bg-theme-bg-primary { background-color: var(--theme-bg-primary); }
+.bg-theme-bg-secondary { background-color: var(--theme-bg-secondary); }
+.bg-theme-bg-hover { background-color: var(--theme-bg-hover); }
+.bg-theme-bg-container { background-color: var(--theme-bg-container); }
+.bg-theme-bg-sidebar { background-color: var(--theme-bg-sidebar); }
+.bg-theme-bg-sidebar-hover { background-color: var(--theme-bg-sidebar-hover); }
+.bg-theme-bg-popup-menu { background-color: var(--theme-bg-popup-menu); }
+.bg-theme-bg-chat { background-color: var(--theme-bg-chat); }
+
+.text-theme-text-primary { color: var(--theme-text-primary); }
+.text-theme-text-secondary { color: var(--theme-text-secondary); }
+.text-theme-text-placeholder { color: var(--theme-text-placeholder); }
+
+.border-theme-modal-border { border-color: var(--theme-modal-border); }
+.border-theme-sidebar-border { border-color: var(--theme-sidebar-border); }
+.border-theme-sidebar-item-hover { border-color: var(--theme-sidebar-item-hover); }
+.border-theme-sidebar-item-workspace-active { border-color: var(--theme-sidebar-item-workspace-active); }

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,23 +1,55 @@
-/* Theme-specific color tokens */
-
-[data-theme="dark"] {
-  --bg: #0f1216;
-  --surface: #151a1f;
-  --elev: #1b2229;
-  --border: #2b333b;
-  --fg-1: #edeef0;
-  --fg-2: #c9cdd2;
-  --muted: #9aa3ac;
-  --brand: #6aa3ff;
+:root {
+  color-scheme: light dark;
 }
 
 [data-theme="light"] {
-  --bg: #ffffff;
-  --surface: #f1f5f9;
-  --elev: #e2e8f0;
-  --border: #d1d5db;
-  --fg-1: #0f172a;
-  --fg-2: #334155;
-  --muted: #64748b;
-  --brand: #3b82f6;
+  --brand-blue-600: #2563eb;
+  --brand-violet-600: #7c3aed;
+  --bg-0: #ffffff;
+  --bg-1: #f1f5f9;
+  --bg-2: #e2e8f0;
+  --text-0: #0f172a;
+  --text-1: #334155;
+  --stroke-0: #d1d5db;
+  --stroke-1: #94a3b8;
+}
+
+[data-theme="dark"] {
+  --brand-blue-600: #3b82f6;
+  --brand-violet-600: #8b5cf6;
+  --bg-0: #0f1216;
+  --bg-1: #151a1f;
+  --bg-2: #1b2229;
+  --text-0: #edeef0;
+  --text-1: #c9cdd2;
+  --stroke-0: #2b333b;
+  --stroke-1: #3f4852;
+}
+
+/* semantic mappings */
+[data-theme] {
+  --theme-bg-primary: var(--bg-0);
+  --theme-bg-secondary: var(--bg-1);
+  --theme-bg-hover: var(--bg-2);
+  --theme-bg-container: var(--bg-1);
+  --theme-bg-sidebar: var(--bg-1);
+  --theme-bg-sidebar-hover: var(--bg-2);
+  --theme-bg-popup-menu: var(--bg-1);
+  --theme-bg-chat: var(--bg-0);
+
+  --theme-text-primary: var(--text-0);
+  --theme-text-secondary: var(--text-1);
+  --theme-text-placeholder: var(--text-1);
+
+  --theme-modal-border: var(--stroke-0);
+  --theme-sidebar-border: var(--stroke-0);
+  --theme-sidebar-item-hover: var(--bg-2);
+  --theme-sidebar-item-workspace-active: var(--brand-blue-600);
+  --theme-primary-button: var(--brand-blue-600);
+  --theme-home-button-primary: var(--brand-blue-600);
+  --theme-home-button-primary-hover: var(--brand-violet-600);
+  --theme-file-picker-hover: var(--bg-2);
+  --theme-settings-input-bg: var(--bg-1);
+  --theme-settings-input-placeholder: var(--text-1);
+  --theme-settings-input-active: var(--brand-blue-600);
 }


### PR DESCRIPTION
## Summary
- replace theme variables with brand and semantic tokens for light and dark modes
- add gradient, glass, and theme color helper classes
- ensure login and onboarding flows import theme and set data-theme attribute

## Testing
- `yarn lint:css` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68a61c093e688328b1f4627881bd7986