### PR TITLE
refactor: expose design tokens via tailwind

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,7 +1,7 @@
 # Onenew Theme Style Guide
 
 ## Theme usage
-Use `.onenew-*` utilities or CSS variables for app chrome. Avoid Tailwind color utilities except in content (markdown), charts, and third-party widgets.
+Use `.onenew-*` utilities, CSS variables, or the Tailwind token classes for app chrome. Avoid the default Tailwind palette except in content (markdown), charts, and third-party widgets.
 
 ## Palette tokens
 | Token | Purpose |
@@ -16,6 +16,23 @@ Use `.onenew-*` utilities or CSS variables for app chrome. Avoid Tailwind color 
 | `--success` | Positive status color. |
 | `--warning` | Cautionary or pending status color. |
 | `--danger` | Error and destructive status color. |
+
+## Tailwind color utilities
+Tailwind exposes theme tokens as color classes so components can use semantic names instead of raw values.
+
+```jsx
+<div className="bg-bg-0 text-text-0">
+  <button className="bg-onenew text-white">Continue</button>
+  <p className="text-success-600">Saved!</p>
+</div>
+```
+
+Available classes include:
+- `bg-bg-0`, `bg-bg-1`, `bg-bg-2`
+- `text-text-0`, `text-text-1`
+- `border-stroke-0`, `border-stroke-1`
+- `bg-brand-blue-600`, `bg-brand-violet-600`
+- `text-success-600`, `text-danger-600`
 
 ## Adding a new surface or status color
 1. Add the CSS variable to `onenew-theme.css`.

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -12,6 +12,8 @@
   --text-1: #334155;
   --stroke-0: #d1d5db;
   --stroke-1: #94a3b8;
+  --success-600: #16a34a;
+  --danger-600: #dc2626;
 }
 
 [data-theme="dark"] {
@@ -24,6 +26,8 @@
   --text-1: #c9cdd2;
   --stroke-0: #2b333b;
   --stroke-1: #3f4852;
+  --success-600: #16a34a;
+  --danger-600: #dc2626;
 }
 
 /* semantic mappings */

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,12 +4,20 @@ export default {
   theme: {
     extend: {
       colors: {
-        background: "var(--background)",
-        foreground: "var(--foreground)",
-        card: "var(--card)",
-        border: "var(--border)",
-        primary: "var(--primary)",
-        accent: "var(--accent)"
+        "bg-0": "var(--bg-0)",
+        "bg-1": "var(--bg-1)",
+        "bg-2": "var(--bg-2)",
+        "text-0": "var(--text-0)",
+        "text-1": "var(--text-1)",
+        "stroke-0": "var(--stroke-0)",
+        "stroke-1": "var(--stroke-1)",
+        "brand-blue-600": "var(--brand-blue-600)",
+        "brand-violet-600": "var(--brand-violet-600)",
+        "success-600": "var(--success-600)",
+        "danger-600": "var(--danger-600)"
+      },
+      backgroundImage: {
+        onenew: "linear-gradient(135deg, var(--brand-blue-600), var(--brand-violet-600))"
       },
       borderRadius: {
         xl: "var(--radius)",


### PR DESCRIPTION
## Summary
- map Tailwind color tokens to Onenew CSS variables
- add `bg-onenew` gradient utility and semantic success/danger colors
- document using Tailwind token classes instead of hard-coded values

## Testing
- `npx stylelint frontend/src/styles/theme.css` *(fails: Unexpected hex color)*
- `npm test` *(fails: 2 failed test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a631e4e4e883289829f4c82cb31f87