### PR TITLE
feat(chat): add bubble meta row and style refinements

### DIFF
--- a/frontend/src/components/ChatBubble/index.jsx
+++ b/frontend/src/components/ChatBubble/index.jsx
@@ -5,8 +5,9 @@ import renderMarkdown from "@/utils/chat/markdown";
 import DOMPurify from "@/utils/chat/purify";
 import { cn } from "@/lib/utils";
 
-export default function ChatBubble({ message, type, popMsg }) {
+export default function ChatBubble({ message, type, popMsg, timestamp, status }) {
   const isUser = type === "user";
+  const meta = [timestamp, status].filter(Boolean).join(" • ");
 
   return (
     <div className="flex justify-center items-end w-full">
@@ -17,15 +18,18 @@ export default function ChatBubble({ message, type, popMsg }) {
             role={type}
           />
 
-          <div
-            className={cn(
-              "markdown whitespace-pre-line font-normal text-sm md:text-sm flex flex-col gap-y-1 mt-2 bubble",
-              isUser ? "bubble-user" : "bubble-assistant"
-            )}
-            dangerouslySetInnerHTML={{
-              __html: DOMPurify.sanitize(renderMarkdown(message)),
-            }}
-          />
+          <div className="flex flex-col">
+            <div
+              className={cn(
+                "markdown whitespace-pre-line font-normal text-sm md:text-sm flex flex-col gap-y-1 mt-2 bubble",
+                isUser ? "bubble-user" : "bubble-assistant"
+              )}
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(renderMarkdown(message)),
+              }}
+            />
+            {meta && <div className="bubble-meta">{meta}</div>}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/components/DefaultChat/index.jsx
+++ b/frontend/src/components/DefaultChat/index.jsx
@@ -230,6 +230,8 @@ export default function DefaultChatContainer() {
                   }
                   type={fetchedMessage.user === "" ? "response" : "user"}
                   popMsg={popMsg}
+                  timestamp={fetchedMessage.timestamp}
+                  status={fetchedMessage.status}
                 />
               </React.Fragment>
             );

--- a/frontend/src/styles/onenew-components.css
+++ b/frontend/src/styles/onenew-components.css
@@ -114,8 +114,8 @@ textarea.onenew-input {
 /* Chat bubbles */
 .bubble {
   border: 1px solid var(--border);
-  border-radius: calc(var(--radius-lg) - var(--space-1) / 2);
-  padding: var(--space-3) var(--space-4);
+  border-radius: 16px;
+  padding: 12px 16px;
 }
 
 .bubble-assistant {
@@ -124,8 +124,14 @@ textarea.onenew-input {
 }
 
 .bubble-user {
-  background: color-mix(in srgb, var(--brand), transparent 80%);
+  background: color-mix(in srgb, var(--brand), transparent 92%);
   color: var(--fg-1);
+}
+
+.bubble-meta {
+  color: var(--text-2);
+  margin-top: 8px;
+  font-size: 12px;
 }
 
 /* Sidebar navigation */


### PR DESCRIPTION
## Summary
- adjust chat bubble geometry and user tint
- render meta row for timestamps and statuses

## Testing
- `yarn lint` *(fails: stylelint errors across CSS files)*
- `yarn test` *(fails: Jest failed to parse some frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_68a636aec7148328bbb67bdc8a0dc65c