### PR TITLE
feat: refactor chat layout grid and composer behavior

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
@@ -231,7 +231,7 @@ export default function DnDFileUploaderWrapper({ children }) {
 
   return (
     <div
-      className={`relative flex flex-col h-full min-h-0 w-full md:mt-0 mt-[40px] p-[1px]`}
+      className="relative h-full min-h-0 w-full md:mt-0 mt-[40px] p-[1px]"
       {...getRootProps()}
     >
       <div

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -272,33 +272,35 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
   }, [socketId]);
 
   return (
-    <div
-      style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
-      className="chat onenew-page transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg w-full h-full flex flex-col min-h-0 z-[2]"
-    >
-      {isMobile && <SidebarMobileHeader />}
+    <>
       <DnDFileUploaderWrapper>
-        <div className="chat__messages">
-          <MetricsProvider>
-            <ChatHistory
-              history={chatHistory}
-              workspace={workspace}
-              sendCommand={sendCommand}
-              updateHistory={setChatHistory}
-              regenerateAssistantMessage={regenerateAssistantMessage}
-              hasAttachments={files.length > 0}
-            />
-          </MetricsProvider>
+        <div
+          style={{ height: isMobile ? "100%" : "calc(100% - 32px)" }}
+          className="chat onenew-page transition-all duration-500 relative md:ml-[2px] md:mr-[16px] md:my-[16px] md:rounded-lg w-full h-full grid grid-rows-[auto_1fr_auto] min-h-0 z-[2]"
+        >
+          {isMobile && <SidebarMobileHeader />}
+          <div className="chat__messages">
+            <MetricsProvider>
+              <ChatHistory
+                history={chatHistory}
+                workspace={workspace}
+                sendCommand={sendCommand}
+                updateHistory={setChatHistory}
+                regenerateAssistantMessage={regenerateAssistantMessage}
+                hasAttachments={files.length > 0}
+              />
+            </MetricsProvider>
+          </div>
+          <PromptInput
+            submit={handleSubmit}
+            onChange={handleMessageChange}
+            isStreaming={loadingResponse}
+            sendCommand={sendCommand}
+            attachments={files}
+          />
         </div>
-        <PromptInput
-          submit={handleSubmit}
-          onChange={handleMessageChange}
-          isStreaming={loadingResponse}
-          sendCommand={sendCommand}
-          attachments={files}
-        />
       </DnDFileUploaderWrapper>
       <ChatTooltips />
-    </div>
+    </>
   );
 }

--- a/frontend/src/styles/chat.css
+++ b/frontend/src/styles/chat.css
@@ -1,15 +1,15 @@
 .chat{
-  min-height:100dvh; display:flex; flex-direction:column;
+  min-height:100dvh; display:grid; grid-template-rows:auto 1fr auto;
 }
 .chat__messages{
   flex:1 1 auto; min-height:0; overflow:auto; padding:16px;
   scroll-behavior:smooth; /* better feel */
+  padding-bottom:calc(var(--composer-h) + 16px);
 }
 .chat__composer{
-  position:sticky; bottom:0; inset-inline:0;
   background:Canvas; border-top:1px solid color-mix(in hsl, CanvasText 10%, transparent);
   padding:12px clamp(12px, 2vw, 20px) max(12px, env(safe-area-inset-bottom));
 }
 .chat__input{
-  width:100%; min-height:44px; max-height:172px; border-radius:14px; padding:10px 14px; resize:vertical; overflow:auto;
+  width:100%; min-height:44px; max-height:calc(6 * 1lh); border-radius:14px; padding:10px 14px; resize:none; overflow-y:auto;
 }


### PR DESCRIPTION
## Summary
- convert chat container to CSS grid and move composer to footer row
- track composer height to offset message list
- cap composer textarea to six lines with internal scrolling

## Testing
- `yarn lint` *(fails: Expected modern color-function notation)*
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a4f2e148328b99becd291a4772c