### PR TITLE
feat: replace outline focus rings with box shadows

### DIFF
--- a/frontend/src/styles/a11y.css
+++ b/frontend/src/styles/a11y.css
@@ -1,4 +1,9 @@
 :focus-visible {
-  outline: 2px solid var(--brand);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(124,58,237,0.28);
+}
+
+[data-theme="dark"] :focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(139,92,246,0.45);
 }

--- a/frontend/src/styles/buttons.css
+++ b/frontend/src/styles/buttons.css
@@ -1,3 +1,2 @@
 .icon-btn{ display:inline-grid; place-items:center; width:32px; height:32px; border-radius:10px; }
 .icon-btn:hover{ background: color-mix(in hsl, CanvasText 8%, transparent); }
-.icon-btn:focus-visible{ outline:2px solid AccentColor; outline-offset:2px; }

--- a/frontend/src/styles/forms.css
+++ b/frontend/src/styles/forms.css
@@ -2,6 +2,5 @@
   height:40px; border-radius:12px; padding:0 12px; border:1px solid color-mix(in hsl, currentColor 12%, transparent);
   background:Canvas; color:CanvasText;
 }
-.input:focus, .select:focus{ outline:2px solid color-mix(in hsl, AccentColor 60%, transparent); outline-offset:2px; }
 .dropdown{ position:relative; }
 .dropdown-menu{ position:absolute; inset-inline-start:0; top:calc(100% + 6px); z-index: 60; min-width: 220px; }

--- a/frontend/src/styles/onenew-components.css
+++ b/frontend/src/styles/onenew-components.css
@@ -21,7 +21,6 @@
 
 /* Strong focus ring everywhere */
 :focus-visible {
-  outline: none !important;
   box-shadow: 0 0 0 var(--space-1) var(--brand) !important;
 }
 
@@ -73,7 +72,6 @@
   color: color-mix(in srgb, var(--text), transparent 55%);
 }
 .onenew-input:focus {
-  outline: none;
   box-shadow: 0 0 0 4px var(--ring);
 }
 select.onenew-input,

--- a/frontend/src/styles/overrides.css
+++ b/frontend/src/styles/overrides.css
@@ -37,7 +37,7 @@
   --primary-600: #3f8ff0;
   --danger: #ff6b6b;
   --accent: #7ee787;
-  --focus: 0 0 0 2px rgba(90,167,255,.35);
+  --focus: 0 0 0 3px rgba(139,92,246,0.45);
 }
 
 @media (prefers-color-scheme: light) {
@@ -54,6 +54,7 @@
     --primary-600: #1d4ed8;
     --danger: #dc2626;
     --accent: #16a34a;
+    --focus: 0 0 0 3px rgba(124,58,237,0.28);
   }
 }
 
@@ -94,7 +95,7 @@ a:hover { text-decoration: underline; }
 .card, .panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-1); }
 
 /* Focus visibility */
-:focus-visible { outline: none; box-shadow: var(--focus); border-radius: .25rem; }
+:focus-visible { box-shadow: var(--focus); border-radius: .25rem; }
 
 /* Hide questionable placeholder "AD" badge if it exists */
 .badge--ad, .ad-placeholder { display: none !important; }

--- a/server/swagger/dark-swagger.css
+++ b/server/swagger/dark-swagger.css
@@ -65,15 +65,15 @@
   }
 
   .swagger-ui .debug * {
-    outline: #e6da99 solid 1px;
+    box-shadow: 0 0 0 1px #e6da99;
   }
 
   .swagger-ui .debug-white * {
-    outline: #fff solid 1px;
+    box-shadow: 0 0 0 1px #fff;
   }
 
   .swagger-ui .debug-black * {
-    outline: #bfbfbf solid 1px;
+    box-shadow: 0 0 0 1px #bfbfbf;
   }
 
   .swagger-ui .debug-grid {


### PR DESCRIPTION
## Summary
- add shared `:focus-visible` rule with themed box-shadow
- remove outline usage from button, form, component, and override styles
- swap swagger debug outlines with box-shadow

## Testing
- `npx stylelint "frontend/src/**/*.css"` *(fails: Expected ""./styles/tokens.css"" to be "url("./styles/tokens.css")" and 280 other errors)*
- `npx jest` *(fails: frontend/__tests__/jobStream.test.js, tests/theme.smoke.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a63a4c5c288328ae695279ee55e3db