### PR TITLE
docs(frontend): add component documentation comments

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -92,6 +92,12 @@ const SystemPromptVariables = lazy(
   () => import("@/pages/Admin/SystemPromptVariables")
 );
 
+/**
+ * App component: entry point for the dashboard with routing and global providers.
+ *
+ * Sets up contexts, theming, and lazy-loaded routes. This component does not
+ * accept any props and is mounted by `main.jsx`.
+ */
 export default function App() {
   useEffect(() => {
     document.title = "OneNew — Dashboard";

--- a/frontend/src/ThemeProvider.tsx
+++ b/frontend/src/ThemeProvider.tsx
@@ -1,3 +1,11 @@
+/**
+ * ThemeProvider component: supplies the current theme and utilities to child components.
+ *
+ * Props:
+ *  - children: ReactNode - elements that should have access to theme context.
+ *
+ * Use at the root of the app to allow components to read and update the selected theme.
+ */
 import React, { createContext, useContext, type ReactNode } from "react";
 import { useTheme } from "./hooks/useTheme";
 

--- a/frontend/src/components/Card.tsx
+++ b/frontend/src/components/Card.tsx
@@ -1,3 +1,13 @@
+/**
+ * Card component: lightweight container with optional click handling and custom classes.
+ *
+ * Props:
+ *  - className?: string - additional CSS classes.
+ *  - onClick?: (event) => void - click handler enabling interactive styling.
+ *  - children: ReactNode - content displayed inside the card.
+ *
+ * Use to group related content in a bordered box; becomes clickable when onClick is provided.
+ */
 import React, { type HTMLAttributes } from "react";
 
 export default function Card({

--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -1,3 +1,12 @@
+/**
+ * Select component: styled wrapper around the native `<select>` element.
+ *
+ * Props:
+ *  - className?: string - additional classes to apply.
+ *  - ...SelectHTMLAttributes - standard select element attributes and event handlers.
+ *
+ * Use in forms to maintain consistent appearance across the application.
+ */
 import React, { type SelectHTMLAttributes } from "react";
 
 export default function Select({

--- a/frontend/src/components/chat/Composer.tsx
+++ b/frontend/src/components/chat/Composer.tsx
@@ -1,3 +1,11 @@
+/**
+ * Composer component: text entry field for chat messages with send, attach, and voice options.
+ *
+ * Props:
+ *  - onSend?: (message: string) => void - callback invoked with the message when submitted.
+ *
+ * Renders at the bottom of the chat interface, providing controls for composing and sending messages.
+ */
 import React, { useState, FormEvent } from "react";
 import { PaperPlaneRight, PaperclipHorizontal, Microphone } from "@phosphor-icons/react";
 import "@/styles/chat.css";

--- a/frontend/src/components/chat/Message.tsx
+++ b/frontend/src/components/chat/Message.tsx
@@ -1,3 +1,12 @@
+/**
+ * Message component: renders a single chat message with styling based on the sender.
+ *
+ * Props:
+ *  - sender: "user" | "bot" - determines alignment and appearance.
+ *  - children: ReactNode - message content to display.
+ *
+ * Used within chat transcripts to display messages from either the user or the assistant.
+ */
 import React, { ReactNode } from "react";
 import "@/styles/chat.css";
 

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,3 +1,11 @@
+/**
+ * AppLayout component: renders the primary layout with sidebar navigation and main content area.
+ *
+ * Props:
+ *  - children: ReactNode - page content to display inside the layout.
+ *
+ * Used to wrap top-level pages, handling responsive sidebar behavior for mobile and desktop.
+ */
 import React, { type ReactNode } from "react";
 import Sidebar, { SidebarMobileHeader } from "@/components/Sidebar";
 import { isMobile } from "react-device-detect";


### PR DESCRIPTION
## Summary
- document ThemeProvider usage and props
- add purpose and prop docs for layout and UI components
- clarify chat components and root App

## Testing
- `yarn lint` *(fails: import-notation, at-rule, color-function-notation, etc.)*
- `yarn test` *(fails: Jest encountered an unexpected token in frontend/__tests__/jobStream.test.js and tests/theme.smoke.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a720a6e2a0832896cc02f395631fd3