### PR TITLE
docs: document theming tokens and dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ This monorepo consists of six main sections:
 - `embed`: Submodule for generation & creation of the [web embed widget](https://github.com/Mintplex-Labs/anythingllm-embed).
 - `browser-extension`: Submodule for the [chrome browser extension](https://github.com/Mintplex-Labs/anythingllm-extension).
 
+### Theming and styling
+
+The UI uses Tailwind CSS with a custom `onenew` theme. Components should rely on semantic tokens like `bg-bg-0`, `text-text-0`, and spacing values defined in [`frontend/tailwind.config.js`](frontend/tailwind.config.js) rather than hard-coded colors. Dark mode is enabled via the `dark:` class so each component should provide token-based variants for both light and dark themes. See [STYLEGUIDE.md](./STYLEGUIDE.md) for the complete palette and utility classes.
+
 ## 🛳 Self-Hosting
 
 Mintplex Labs & the community maintain a number of deployment methods, scripts, and templates that you can use to run OneNew locally. Refer to the table below to read how to deploy on your preferred environment or to automatically deploy.

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,8 @@
+/**
+ * Tailwind configuration for the custom "onenew" theme.
+ * Components should use these semantic color and spacing tokens instead of hard-coded values.
+ * Dark mode is controlled by the `dark:` class.
+ */
 export default {
   darkMode: ["class"],
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],


### PR DESCRIPTION
## Summary
- describe how to use onenew Tailwind tokens and dark mode in README
- add theme usage comment to Tailwind configuration

## Testing
- `yarn lint` *(fails: Expected modern color-function notation)*
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68a720bf1b2c8328b4ebebc2cd6a8b7c