### PR TITLE
fix: align global styles with theme tokens

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,7 +7,7 @@
 
 body {
   background: var(--bg);
-  color: var(--fg-1);
+  color: var(--text);
 }
 
 @import "./styles/overrides.css";

--- a/frontend/src/styles/onenew-components.css
+++ b/frontend/src/styles/onenew-components.css
@@ -10,7 +10,7 @@
       color-mix(in srgb, var(--brand), transparent 92%),
       transparent 55%
     );
-  color: var(--fg-1);
+  color: var(--text);
 }
 
 /* Ensure SVGs inherit text color */
@@ -21,6 +21,7 @@
 
 /* Strong focus ring everywhere */
 :focus-visible {
+  outline: none;
   box-shadow: 0 0 0 var(--space-1) var(--brand) !important;
 }
 
@@ -118,16 +119,16 @@ textarea.onenew-input {
 
 .bubble-assistant {
   background: color-mix(in srgb, var(--surface), var(--bg) 6%);
-  color: var(--fg-1);
+  color: var(--text);
 }
 
 .bubble-user {
   background: color-mix(in srgb, var(--brand), transparent 92%);
-  color: var(--fg-1);
+  color: var(--text);
 }
 
 .bubble-meta {
-  color: var(--text-2);
+  color: var(--text-subtle);
   margin-top: 8px;
   font-size: 12px;
 }
@@ -138,12 +139,12 @@ textarea.onenew-input {
 }
 
 .nav .item:hover {
-  color: var(--fg-1);
+  color: var(--text);
   background: color-mix(in srgb, var(--surface), var(--bg) 8%);
 }
 
 .nav .item.active {
-  color: var(--fg-1);
+  color: var(--text);
   background: rgba(106, 163, 255, 0.12);
   border-left: 3px solid var(--brand);
 }
@@ -185,12 +186,14 @@ textarea.onenew-input {
   width: 100%;
   border-collapse: collapse;
 }
+
 .onenew-table th {
   text-align: left;
   padding: var(--space-3) var(--space-3);
-  color: var(--fg-2);
+  color: var(--text-subtle);
   border-bottom: 1px solid var(--border);
 }
+
 .onenew-table td {
   padding: var(--space-3) var(--space-3);
   border-bottom: 1px solid var(--border);
@@ -200,7 +203,7 @@ textarea.onenew-input {
 .tooltip,
 .popover {
   background: var(--surface);
-  color: var(--fg-1);
+  color: var(--text);
   border: 1px solid var(--border);
 }
 

--- a/frontend/src/styles/overrides.css
+++ b/frontend/src/styles/overrides.css
@@ -95,7 +95,7 @@ a:hover { text-decoration: underline; }
 .card, .panel { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-1); }
 
 /* Focus visibility */
-:focus-visible { box-shadow: var(--focus); border-radius: .25rem; }
+:focus-visible { outline: none; box-shadow: var(--focus); border-radius: .25rem; }
 
 /* Hide questionable placeholder "AD" badge if it exists */
 .badge--ad, .ad-placeholder { display: none !important; }


### PR DESCRIPTION
## Summary
- unify body color with `--text` token
- replace legacy `--fg-*` references with `--text` tokens and tidy component focus styles
- add `outline: none` to global `:focus-visible` rules for cleaner focus rings

## Testing
- `npx -y yarn@1 lint` *(fails: Expected modern color-function notation and selector patterns)*
- `npx -y yarn@1 test` *(fails: Jest encountered unexpected token and missing initializer errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a72f3a396083288db302a8a41c1bbb