### PR TITLE
feat: add chat message timestamps

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/HistoricalMessage/index.jsx
@@ -10,8 +10,9 @@ import DOMPurify from "@/utils/chat/purify";
 import { EditMessageForm, useEditMessage } from "./Actions/EditMessage";
 import { useWatchDeleteMessage } from "./Actions/DeleteMessage";
 import TTSMessage from "./Actions/TTSButton";
+import moment from "moment";
 import {
-  THOUGHT_REGEX_CLOSE,
+    THOUGHT_REGEX_CLOSE,
   THOUGHT_REGEX_COMPLETE,
   THOUGHT_REGEX_OPEN,
   ThoughtChainComponent,
@@ -37,21 +38,25 @@ const HistoricalMessage = ({
   forkThread,
   metrics = {},
   alignmentCls = "",
-}) => {
-  const { t } = useTranslation();
-  const { isEditing } = useEditMessage({ chatId, role });
-  const { isDeleted, completeDelete, onEndAnimation } = useWatchDeleteMessage({
-    chatId,
-    role,
-  });
+    sentAt,
+  }) => {
+    const { t } = useTranslation();
+    const { isEditing } = useEditMessage({ chatId, role });
+    const { isDeleted, completeDelete, onEndAnimation } = useWatchDeleteMessage({
+      chatId,
+      role,
+    });
   const adjustTextArea = (event) => {
     const element = event.target;
     element.style.height = "auto";
     element.style.height = element.scrollHeight + "px";
   };
 
-  const isRefusalMessage =
-    role === "assistant" && message === chatQueryRefusalResponse(workspace);
+    const isRefusalMessage =
+      role === "assistant" && message === chatQueryRefusalResponse(workspace);
+    const timestamp = sentAt
+      ? moment.unix(sentAt).format("h:mm A")
+      : null;
 
   if (!!error) {
     return (
@@ -147,6 +152,15 @@ const HistoricalMessage = ({
             </div>
           )}
         </div>
+        {timestamp && (
+          <div
+            className={`bubble-meta ml-14 ${
+              alignmentCls.includes("flex-row-reverse") ? "text-right" : ""
+            }`}
+          >
+            {timestamp}
+          </div>
+        )}
         <div className="flex gap-x-5 ml-14">
           <Actions
             message={message}

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/PromptReply/index.jsx
@@ -3,6 +3,7 @@ import { Warning } from "@phosphor-icons/react";
 import UserIcon from "../../../../UserIcon";
 import renderMarkdown from "@/utils/chat/markdown";
 import Citations from "../Citation";
+import moment from "moment";
 import {
   THOUGHT_REGEX_CLOSE,
   THOUGHT_REGEX_COMPLETE,
@@ -18,6 +19,7 @@ const PromptReply = ({
   workspace,
   sources = [],
   closed = true,
+  sentAt,
 }) => {
   const assistantBackgroundColor = "bg-theme-bg-chat";
 
@@ -67,11 +69,18 @@ const PromptReply = ({
       <div className="py-8 px-4 w-full flex gap-x-5 md:max-w-[80%] flex-col">
         <div className="flex gap-x-5">
           <WorkspaceProfileImage workspace={workspace} />
-          <div className="onenew-card p-3 md:p-4">
-            <RenderAssistantChatContent
-              key={`${uuid}-prompt-reply-content`}
-              message={reply}
-            />
+          <div className="flex flex-col">
+            <div className="onenew-card p-3 md:p-4">
+              <RenderAssistantChatContent
+                key={`${uuid}-prompt-reply-content`}
+                message={reply}
+              />
+            </div>
+            {sentAt && (
+              <div className="bubble-meta">
+                {moment.unix(sentAt).format("h:mm A")}
+              </div>
+            )}
           </div>
         </div>
         <Citations sources={sources} />

--- a/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/ChatHistory/index.jsx
@@ -334,6 +334,7 @@ function buildMessages({
           error={props.error}
           workspace={workspace}
           closed={props.closed}
+          sentAt={props.sentAt}
         />
       );
     } else {
@@ -354,6 +355,7 @@ function buildMessages({
           forkThread={forkThread}
           metrics={props.metrics}
           alignmentCls={getMessageAlignment?.(props.role)}
+          sentAt={props.sentAt}
         />
       );
     }

--- a/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/index.jsx
@@ -56,6 +56,7 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
         content: message,
         role: "user",
         attachments: parseAttachments(),
+        sentAt: Math.floor(Date.now() / 1000),
       },
       {
         content: "",
@@ -63,6 +64,7 @@ export default function ChatContainer({ workspace, knownHistory = [] }) {
         pending: true,
         userMessage: message,
         animate: true,
+        sentAt: Math.floor(Date.now() / 1000),
       },
     ];
 

--- a/frontend/src/utils/chat/index.js
+++ b/frontend/src/utils/chat/index.js
@@ -22,10 +22,12 @@ export default function handleChat(
     chatId = null,
     action = null,
     metrics = {},
+    sentAt,
   } = chatResult;
 
   if (type === "abort" || type === "statusResponse") {
     setLoadingResponse(false);
+    const timestamp = sentAt ?? Math.floor(Date.now() / 1000);
     setChatHistory([
       ...remHistory,
       {
@@ -39,6 +41,7 @@ export default function handleChat(
         animate,
         pending: false,
         metrics,
+        sentAt: timestamp,
       },
     ]);
     _chatHistory.push({
@@ -52,9 +55,11 @@ export default function handleChat(
       animate,
       pending: false,
       metrics,
+      sentAt: timestamp,
     });
   } else if (type === "textResponse") {
     setLoadingResponse(false);
+    const timestamp = sentAt ?? Math.floor(Date.now() / 1000);
     setChatHistory([
       ...remHistory,
       {
@@ -68,6 +73,7 @@ export default function handleChat(
         pending: false,
         chatId,
         metrics,
+        sentAt: timestamp,
       },
     ]);
     _chatHistory.push({
@@ -81,6 +87,7 @@ export default function handleChat(
       pending: false,
       chatId,
       metrics,
+      sentAt: timestamp,
     });
     emitAssistantMessageCompleteEvent(chatId);
   } else if (
@@ -91,6 +98,7 @@ export default function handleChat(
     if (chatIdx !== -1) {
       const existingHistory = { ..._chatHistory[chatIdx] };
       let updatedHistory;
+      const timestamp = existingHistory.sentAt ?? sentAt ?? Math.floor(Date.now() / 1000);
 
       // If the response is finalized, we can set the loading state to false.
       // and append the metrics to the history.
@@ -102,6 +110,7 @@ export default function handleChat(
           pending: false,
           chatId,
           metrics,
+          sentAt: timestamp,
         };
         setLoadingResponse(false);
         emitAssistantMessageCompleteEvent(chatId);
@@ -116,6 +125,7 @@ export default function handleChat(
           pending: false,
           chatId,
           metrics,
+          sentAt: timestamp,
         };
       }
       _chatHistory[chatIdx] = updatedHistory;
@@ -131,6 +141,7 @@ export default function handleChat(
         pending: false,
         chatId,
         metrics,
+        sentAt: sentAt ?? Math.floor(Date.now() / 1000),
       });
     }
     setChatHistory([..._chatHistory]);
@@ -156,6 +167,7 @@ export default function handleChat(
       animate: false,
       pending: false,
       metrics,
+      sentAt: existingHistory.sentAt ?? Math.floor(Date.now() / 1000),
     };
     _chatHistory[chatIdx] = updatedHistory;
 


### PR DESCRIPTION
## Summary
- show timestamp meta row beneath each chat message
- propagate and store sentAt timestamps for chat history items

## Testing
- `yarn lint` *(fails: Expected modern color-function notation and unknown at-rules in CSS)*
- `yarn test` *(fails: Jest encountered an unexpected token in frontend/__tests__/jobStream.test.js and tests/theme.smoke.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a73f8770148328bb871bd7b4c366cb