### PR TITLE
feat(frontend): add frosted glass theme styles

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,6 @@
 @import "./styles/theme.css";
 @import "./styles/overlay.css";
+@import "./styles/frosted.css";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -13,32 +14,51 @@
   -webkit-font-smoothing: antialiased;
 }
 
-:root {
+ :root {
   /* ----------------------------------------------
-     Brand tokens (added; non-breaking if unused)
+     Brand & layout tokens for frosted‑glass theme
      ---------------------------------------------- */
-  --brand-cyan-500: #1FD3E6;
-  --brand-violet-500: #8A5BFF;
-  --brand-mid-500: #4FAFF4;
-  --accent-600: #3F86E6;
-  --accent-500: #4FAFF4;
-  --accent-400: #7FBFF9;
+  --brand-cyan: #1FD3E6;
+  --brand-cyan-600: #10BFD2;
+  --brand-violet: #9A5FFB;
+  --brand-violet-600: #7F48F1;
   --success-500: #22C55E;
   --warning-500: #F59E0B;
   --danger-500: #EF4444;
   --info-500: #4FAFF4;
-  --gradient-brand: linear-gradient(135deg, #1FD3E6 0%, #4FAFF4 45%, #8A5BFF 100%);
-  --focus-ring: 0 0 0 3px rgba(79, 175, 244, 0.35);
+  --radius-xl: 18px;
+  --radius-2xl: 28px;
+  --pad-2: 12px;
+  --pad-3: 16px;
+  --shadow-1: 0 4px 30px rgba(0, 0, 0, 0.1);
+  --shadow-2: 0 2px 8px rgba(0, 0, 0, 0.1);
+  --gradient-brand: linear-gradient(135deg, var(--brand-cyan) 0%, var(--brand-cyan-600) 45%, var(--brand-violet) 100%);
+  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--brand-cyan) 35%, transparent);
 
-  /* Default theme (DARK) mapped to your palette */
+  /* Frosted glass surface tokens */
+  --bg-solid: #0E0F12;
+  --bg-grad: radial-gradient(120% 160% at 0% 0%, color-mix(in srgb, var(--brand-cyan) 15%, transparent) 0%, transparent 70%),
+    linear-gradient(135deg, color-mix(in srgb, var(--brand-cyan) 8%, var(--bg-solid)) 0%,
+    color-mix(in srgb, var(--brand-violet) 8%, var(--bg-solid)) 100%);
+  --glass: rgba(255, 255, 255, 0.05);
+  --glass-strong: rgba(255, 255, 255, 0.09);
+  --glass-border: rgba(255, 255, 255, 0.16);
+  --hairline: rgba(255, 255, 255, 0.2);
+  --chip: color-mix(in srgb, var(--brand-violet) 5%, rgba(255, 255, 255, 0.05));
+  --chip-hover: color-mix(in srgb, var(--brand-violet) 10%, rgba(255, 255, 255, 0.1));
+  --bubble-user: color-mix(in srgb, var(--brand-violet) 25%, transparent);
+  --bubble-ai: color-mix(in srgb, var(--brand-cyan) 25%, transparent);
+  --input-bg: var(--glass);
+
+  /* Default theme (DARK) */
   --theme-loader: #ffffff;
-  --theme-bg-primary: #0E0F12;
-  --theme-bg-secondary: #14161A;
-  --theme-bg-sidebar: #0E0F12;
-  --theme-bg-container: #0E0F12;
-  --theme-bg-chat: #14161A;
-  --theme-bg-chat-input: #222833;
-  --theme-text-primary: #F5F7FA;
+  --theme-bg-primary: var(--bg-grad), var(--bg-solid);
+  --theme-bg-secondary: var(--glass);
+  --theme-bg-sidebar: var(--bg-solid);
+  --theme-bg-container: var(--bg-solid);
+  --theme-bg-chat: var(--glass);
+  --theme-bg-chat-input: var(--input-bg);
+  --theme-text-primary: #E8EEF5;
   --theme-text-secondary: #C8CFD8;
   --theme-placeholder: #7D8A97;
   --theme-sidebar-item-default: rgba(255, 255, 255, 0.1);
@@ -58,37 +78,37 @@
   --theme-sidebar-footer-icon-fill: #ffffff;
   --theme-sidebar-footer-icon-hover: rgba(255, 255, 255, 0.2);
 
-  --theme-chat-input-border: #3A4552; /* from border-strong */
+  --theme-chat-input-border: var(--glass-border);
   --theme-action-menu-bg: #222833;    /* surface-2 */
   --theme-action-menu-item-hover: rgba(255, 255, 255, 0.1);
-  --theme-settings-input-bg: #0E0F12; /* bg-primary */
+  --theme-settings-input-bg: var(--bg-solid); /* bg-primary */
   --theme-settings-input-placeholder: rgba(255, 255, 255, 0.5);
   --theme-settings-input-active: rgb(255 255 255 / 0.2);
   --theme-settings-input-text: #ffffff;
   --theme-modal-border: #2E3742; /* border-subtle */
 
-  --theme-button-primary: #4FAFF4;        /* accent-500 */
-  --theme-button-primary-hover: #3F86E6;  /* accent-600 */
+  --theme-button-primary: var(--brand-cyan);
+  --theme-button-primary-hover: var(--brand-cyan-600);
 
-  --theme-button-cta: #7FBFF9; /* accent-400 */
+  --theme-button-cta: var(--brand-violet);
 
-  --theme-file-row-even: #0E0F12;   /* bg-primary */
-  --theme-file-row-odd: #14161A;    /* bg-secondary */
-  --theme-file-row-selected-even: rgba(79, 175, 244, 0.2); /* info-500 @ 0.2 */
-  --theme-file-row-selected-odd: rgba(79, 175, 244, 0.1);
-  --theme-file-picker-hover: rgb(79 175 244 / 0.2);
+  --theme-file-row-even: var(--bg-solid);
+  --theme-file-row-odd: var(--glass);
+  --theme-file-row-selected-even: color-mix(in srgb, var(--brand-cyan) 20%, transparent);
+  --theme-file-row-selected-odd: color-mix(in srgb, var(--brand-cyan) 10%, transparent);
+  --theme-file-picker-hover: color-mix(in srgb, var(--brand-cyan) 20%, transparent);
 
   --theme-home-text: #ffffff;
   --theme-home-text-secondary: #9f9fa0;
   --theme-home-bg-card: #1a1b1b;
   --theme-home-bg-button: #252626;
   --theme-home-border: rgba(255, 255, 255, 0.2);
-  --theme-home-button-primary: #36bffa;
-  --theme-home-button-primary-hover: rgba(54, 191, 250, 0.9);
+  --theme-home-button-primary: var(--brand-cyan);
+  --theme-home-button-primary-hover: color-mix(in srgb, var(--brand-cyan-600) 90%, transparent);
   --theme-home-button-secondary: #27282a;
-  --theme-home-button-secondary-hover: rgba(54, 191, 250, 0.1);
+  --theme-home-button-secondary-hover: color-mix(in srgb, var(--brand-cyan) 10%, transparent);
   --theme-home-button-secondary-text: #ffffff;
-  --theme-home-button-secondary-hover-text: #36bffa;
+  --theme-home-button-secondary-hover-text: var(--brand-cyan);
   --theme-home-update-card-bg: #1c1c1c;
   --theme-home-update-card-hover: #252525;
   --theme-home-update-source: #53b1fd;
@@ -100,12 +120,12 @@
   --theme-checklist-item-completed-text: #a6f4c5;
   --theme-checklist-checkbox-fill: #a6f4c5;
   --theme-checklist-checkbox-text: #36463d;
-  --theme-checklist-item-hover: #36bffa;
+  --theme-checklist-item-hover: var(--brand-cyan);
   --theme-checklist-checkbox-border: #ffffff;
-  --theme-checklist-button-border: #36bffa;
-  --theme-checklist-button-text: #36bffa;
-  --theme-checklist-button-hover-bg: rgba(54, 191, 250, 0.2);
-  --theme-checklist-button-hover-border: rgba(54, 191, 250, 0.8);
+  --theme-checklist-button-border: var(--brand-cyan);
+  --theme-checklist-button-text: var(--brand-cyan);
+  --theme-checklist-button-hover-bg: color-mix(in srgb, var(--brand-cyan) 20%, transparent);
+  --theme-checklist-button-hover-border: color-mix(in srgb, var(--brand-cyan) 80%, transparent);
 
   --theme-home-button-secondary-border: #acc1e6;
   --theme-home-button-secondary-border-hover: #293056;
@@ -120,7 +140,7 @@
   --theme-attachment-icon-spinner-bg: #27282a;
 
   --theme-button-text: #a8a9ab;
-  --theme-button-code-hover-text: #7FBFF9; /* accent-400 */
+  --theme-button-code-hover-text: var(--brand-violet);
   --theme-button-code-hover-bg: #22343f;
   --theme-button-disable-hover-text: #fec84b;
   --theme-button-disable-hover-bg: #3a3128;
@@ -129,29 +149,33 @@
 }
 
 [data-theme="light"] {
-  /* Light theme mapped to your palette */
-  --brand-cyan-500: #18BED2;
-  --brand-violet-500: #7C4DFF;
-  --brand-mid-500: #3A9CF1;
-  --accent-600: #2C79E0;
-  --accent-500: #3A9CF1;
-  --accent-400: #66B5F6;
-  --success-500: #16A34A;
-  --warning-500: #D97706;
-  --danger-500: #DC2626;
-  --info-500: #3A9CF1;
-  --gradient-brand: linear-gradient(135deg, #18BED2 0%, #3A9CF1 45%, #7C4DFF 100%);
-  --focus-ring: 0 0 0 3px rgba(58, 156, 241, 0.35);
+  /* Light theme overrides */
+  --gradient-brand: linear-gradient(135deg, var(--brand-cyan) 0%, var(--brand-cyan-600) 45%, var(--brand-violet) 100%);
+  --focus-ring: 0 0 0 3px color-mix(in srgb, var(--brand-cyan) 35%, transparent);
+
+  --bg-solid: #F7F9FC;
+  --bg-grad: radial-gradient(120% 160% at 100% 0%, color-mix(in srgb, var(--brand-violet) 12%, transparent) 0%, transparent 70%),
+    linear-gradient(135deg, color-mix(in srgb, var(--brand-cyan) 8%, var(--bg-solid)) 0%,
+    color-mix(in srgb, var(--brand-violet) 8%, var(--bg-solid)) 100%);
+  --glass: rgba(255, 255, 255, 0.6);
+  --glass-strong: rgba(255, 255, 255, 0.8);
+  --glass-border: rgba(0, 0, 0, 0.1);
+  --hairline: rgba(0, 0, 0, 0.08);
+  --chip: rgba(0, 0, 0, 0.05);
+  --chip-hover: rgba(0, 0, 0, 0.08);
+  --bubble-user: color-mix(in srgb, var(--brand-violet) 15%, #ffffff);
+  --bubble-ai: color-mix(in srgb, var(--brand-cyan) 15%, #ffffff);
+  --input-bg: var(--glass);
 
   --theme-loader: #000000;
-  --theme-bg-primary: #F7F9FC;
+  --theme-bg-primary: var(--bg-grad), var(--bg-solid);
   --theme-bg-secondary: #FFFFFF;
   --theme-bg-sidebar: #EDF2FA;
   --theme-bg-container: #F9FBFD;
   --theme-popup-menu-bg: #c2e7fe;
 
   --theme-bg-chat: #FFFFFF;
-  --theme-bg-chat-input: #EAEAEA; /* keeping for parity; panels would be #F1F4F8 */
+  --theme-bg-chat-input: var(--input-bg);
   --theme-text-primary: #0D1220;
   --theme-text-secondary: #3A4757;
   --theme-placeholder: #94A3B8;
@@ -175,7 +199,7 @@
   --theme-sidebar-footer-icon-fill: #6e6f6f;
   --theme-sidebar-footer-icon-hover: #d8d6d6;
 
-  --theme-chat-input-border: #cccccc;
+  --theme-chat-input-border: var(--glass-border);
   --theme-action-menu-bg: #eaeaea;
   --theme-action-menu-item-hover: rgba(0, 0, 0, 0.1);
   --theme-settings-input-bg: #EDF2FA; /* surface-1 */
@@ -184,15 +208,15 @@
   --theme-settings-input-text: #0D1220;
   --theme-modal-border: #CBD5E1; /* border-strong */
 
-  --theme-button-primary: #3A9CF1;       /* accent-500 */
-  --theme-button-primary-hover: #2C79E0; /* accent-600 */
+  --theme-button-primary: var(--brand-cyan);
+  --theme-button-primary-hover: var(--brand-cyan-600);
 
-  --theme-button-cta: #3A9CF1;
+  --theme-button-cta: var(--brand-violet);
 
   --theme-file-row-even: #f5f5f5;
   --theme-file-row-odd: #e9e9e9;
-  --theme-file-row-selected-even: rgba(58, 156, 241, 0.2);
-  --theme-file-row-selected-odd: rgba(58, 156, 241, 0.2);
+  --theme-file-row-selected-even: color-mix(in srgb, var(--brand-cyan) 20%, transparent);
+  --theme-file-row-selected-odd: color-mix(in srgb, var(--brand-cyan) 20%, transparent);
   --theme-file-picker-hover: #e2e7ee;
 
   --theme-home-text: #0D1220;
@@ -200,8 +224,8 @@
   --theme-home-bg-card: #EDF2FA;
   --theme-home-bg-button: #F3F4F6;
   --theme-home-border: rgba(0, 0, 0, 0.1);
-  --theme-home-button-primary: #36bffa;
-  --theme-home-button-primary-hover: rgba(54, 191, 250, 0.9);
+  --theme-home-button-primary: var(--brand-cyan);
+  --theme-home-button-primary-hover: color-mix(in srgb, var(--brand-cyan) 90%, transparent);
   --theme-home-button-secondary: #DBE8FE;
   --theme-home-button-secondary-hover: #B0C8F1;
   --theme-home-button-secondary-text: #293056;
@@ -217,12 +241,12 @@
   --theme-checklist-item-completed-text: #039855;
   --theme-checklist-checkbox-fill: #6ce9a6;
   --theme-checklist-checkbox-text: #ffffff;
-  --theme-checklist-item-hover: #3A9CF1; /* accent-500 */
+  --theme-checklist-item-hover: var(--brand-cyan);
   --theme-checklist-checkbox-border: #6b7280;
-  --theme-checklist-button-border: #3A9CF1; /* accent-500 */
-  --theme-checklist-button-text: #3A9CF1;   /* accent-500 */
-  --theme-checklist-button-hover-bg: rgba(58, 156, 241, 0.1);
-  --theme-checklist-button-hover-border: rgba(58, 156, 241, 0.8);
+  --theme-checklist-button-border: var(--brand-cyan);
+  --theme-checklist-button-text: var(--brand-cyan);
+  --theme-checklist-button-hover-bg: color-mix(in srgb, var(--brand-cyan) 10%, transparent);
+  --theme-checklist-button-hover-border: color-mix(in srgb, var(--brand-cyan) 80%, transparent);
 
   --theme-home-button-secondary-border-hover: #293056;
 
@@ -232,11 +256,11 @@
   --theme-attachment-text: #0D1220;
   --theme-attachment-text-secondary: rgba(0, 0, 0, 0.8);
   --theme-attachment-icon: #ffffff;
-  --theme-attachment-icon-spinner: #3A9CF1; /* accent-500 */
+  --theme-attachment-icon-spinner: var(--brand-cyan);
   --theme-attachment-icon-spinner-bg: #ffffff;
 
   --theme-button-text: #a8a9ab;
-  --theme-button-code-hover-text: #3A9CF1; /* accent-500 */
+  --theme-button-code-hover-text: var(--brand-cyan);
   --theme-button-code-hover-bg: #e8f7fe;
   --theme-button-disable-hover-text: #854708;
   --theme-button-disable-hover-bg: #fef7e6;

--- a/frontend/src/styles/frosted.css
+++ b/frontend/src/styles/frosted.css
@@ -1,0 +1,147 @@
+.frosted-chat {
+  min-height: 100vh;
+  background: var(--bg-grad), var(--bg-solid);
+  padding: var(--pad-3);
+}
+
+.frosted-chat .grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--pad-3);
+}
+
+@media (max-width: 1100px) {
+  .frosted-chat .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.theme {
+  position: relative;
+  border-radius: var(--radius-2xl);
+  overflow: hidden;
+  background: var(--bg-grad), var(--bg-solid);
+  box-shadow: var(--shadow-1), var(--shadow-2);
+}
+
+.surface {
+  display: grid;
+  gap: var(--pad-3);
+}
+
+@media (max-width: 900px) {
+  .surface {
+    grid-template-columns: 1fr;
+  }
+}
+
+.glass {
+  background: var(--glass);
+  backdrop-filter: blur(22px) saturate(160%);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-2xl);
+  padding: var(--pad-3);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-2);
+}
+
+.conv-card {
+  padding: var(--pad-2);
+  border-radius: var(--radius-xl);
+  background: var(--chip);
+  color: var(--theme-text-primary);
+  transition: background 0.2s ease;
+}
+
+.conv-card:hover {
+  background: var(--chip-hover);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--pad-2);
+  padding: var(--pad-2);
+}
+
+.hero-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--gradient-brand);
+}
+
+.pill {
+  padding: 2px var(--pad-2);
+  border-radius: var(--radius-xl);
+  background: var(--glass-strong);
+  border: 1px solid var(--glass-border);
+}
+
+.btn {
+  border-radius: var(--radius-xl);
+  padding: var(--pad-2) var(--pad-3);
+  background: var(--glass);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(22px) saturate(160%);
+  transition: background 0.2s ease;
+}
+
+.btn-primary {
+  background: linear-gradient(90deg, var(--brand-cyan), var(--brand-violet));
+  color: var(--theme-text-primary);
+  box-shadow: 0 2px 4px var(--glass-border);
+}
+
+.chat {
+  display: grid;
+  grid-template-rows: 1fr auto;
+  gap: var(--pad-3);
+}
+
+.messages {
+  overflow: auto;
+  padding: var(--pad-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--pad-2);
+}
+
+.bubble {
+  background: var(--glass-strong);
+  border: 1px solid var(--hairline);
+  border-radius: 16px;
+  padding: var(--pad-2);
+  color: var(--theme-text-primary);
+}
+
+.bubble.user {
+  background: var(--bubble-user);
+}
+
+.bubble.ai {
+  background: var(--bubble-ai);
+}
+
+.prompt {
+  background: var(--input-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-2xl);
+  padding: var(--pad-2);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: var(--pad-2);
+  backdrop-filter: blur(22px) saturate(160%);
+}
+
+.prompt .input {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--theme-text-primary);
+}


### PR DESCRIPTION
## Summary
- add brand and layout tokens for frosted-glass theming
- implement frosted chat layout and bubble styles

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9220ff248328a5ce796f776d5ad1