### PR TITLE
fix: map frosted tokens to existing classes

### DIFF
--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -1,45 +1,111 @@
 :root {
-  --brand-primary:#8A63F7;
-  --brand-secondary:#39C8F0;
-  --brand-accent:#A48CFF;
+  --brand-primary: #8a63f7;
+  --brand-secondary: #39c8f0;
+  --brand-accent: #a48cff;
 
-  --bg:#F8FAFF;
-  --fg:#101828;
-  --surface:#FFFFFF;
-  --border:#E5E7EB;
-  --muted:#EDF2FF;
-  --muted-fg:#475467;
+  --bg: #f8faff;
+  --fg: #101828;
+  --surface: #ffffff;
+  --border: #e5e7eb;
+  --muted: #edf2ff;
+  --muted-fg: #475467;
 
-  --success:#10B981;
-  --warning:#F59E0B;
-  --error:#EF4444;
+  --success: #10b981;
+  --warning: #f59e0b;
+  --error: #ef4444;
 
   /* RGB for alpha use: */
-  --brand-primary-rgb:138 99 247;
-  --brand-secondary-rgb:57 200 240;
-  --brand-accent-rgb:164 140 255;
-  --fg-rgb:16 24 40;
-  --bg-rgb:248 250 255;
+  --brand-primary-rgb: 138 99 247;
+  --brand-secondary-rgb: 57 200 240;
+  --brand-accent-rgb: 164 140 255;
+  --fg-rgb: 16 24 40;
+  --bg-rgb: 248 250 255;
 
   /* Optional helpers */
-  --brand-gradient: linear-gradient(135deg, var(--brand-secondary) 0%, var(--brand-primary) 100%);
+  --brand-gradient: linear-gradient(
+    135deg,
+    var(--brand-secondary) 0%,
+    var(--brand-primary) 100%
+  );
 }
 
 [data-theme="dark"] {
-  --brand-primary:#9B73FF;
-  --brand-secondary:#44B2F9;
-  --brand-accent:#8C7DFE;
+  --brand-primary: #9b73ff;
+  --brand-secondary: #44b2f9;
+  --brand-accent: #8c7dfe;
 
-  --bg:#151A2E;
-  --fg:#E6E8F2;
-  --surface:#1E2442;
-  --border:#2C355C;
-  --muted:#21305B;
-  --muted-fg:#A3AED0;
+  --bg: #151a2e;
+  --fg: #e6e8f2;
+  --surface: #1e2442;
+  --border: #2c355c;
+  --muted: #21305b;
+  --muted-fg: #a3aed0;
 
-  --brand-primary-rgb:155 115 255;
-  --brand-secondary-rgb:68 178 249;
-  --brand-accent-rgb:140 125 254;
-  --fg-rgb:230 232 242;
-  --bg-rgb:21 26 46;
+  --brand-primary-rgb: 155 115 255;
+  --brand-secondary-rgb: 68 178 249;
+  --brand-accent-rgb: 140 125 254;
+  --fg-rgb: 230 232 242;
+  --bg-rgb: 21 26 46;
+}
+/* ===== Frosted integration: map tokens to existing classes ===== */
+
+/* 1) Full-page gradient background */
+html,
+body,
+#root {
+  background: var(--bg-grad), var(--bg-solid) !important;
+}
+
+/* 2) Surfaces → glass */
+.bg-theme-bg-secondary,
+.bg-theme-bg-chat,
+.bg-theme-bg-container {
+  /* Use glass layers instead of solid blocks */
+  background: var(--glass) !important;
+  -webkit-backdrop-filter: blur(22px) saturate(160%);
+  backdrop-filter: blur(22px) saturate(160%);
+  border: 1px solid var(--glass-border) !important;
+  border-radius: var(--radius-2xl);
+}
+
+/* Side “cards”/chips often used in lists */
+.bg-sidebar-item,
+.sidebar-card {
+  background: var(--chip) !important;
+  border: 1px solid var(--hairline) !important;
+}
+.bg-sidebar-item:hover,
+.sidebar-card:hover {
+  background: var(--chip-hover) !important;
+}
+
+/* 3) Chat bubbles (cover common selectors safely) */
+.message.user .bubble,
+.chat-bubble.user,
+.user .chat-bubble {
+  background: var(--bubble-user) !important;
+  border: 1px solid var(--hairline) !important;
+  color: var(--theme-text-primary) !important;
+  border-radius: 16px;
+}
+.message.assistant .bubble,
+.chat-bubble.assistant,
+.assistant .chat-bubble {
+  background: var(--bubble-ai) !important;
+  border: 1px solid var(--hairline) !important;
+  color: var(--theme-text-primary) !important;
+  border-radius: 16px;
+}
+
+/* 4) Chat input pill */
+.chat-input,
+.prompt-input,
+.chatbar,
+.composer,
+.prompt {
+  background: var(--input-bg) !important;
+  border: 1px solid var(--theme-chat-input-border) !important;
+  -webkit-backdrop-filter: blur(22px) saturate(160%);
+  backdrop-filter: blur(22px) saturate(160%);
+  border-radius: var(--radius-2xl) !important;
 }


### PR DESCRIPTION
## Summary
- map frosted gradient tokens to app-level surfaces
- add glass styling to surfaces, chat bubbles, and input

## Testing
- `yarn lint`
- `yarn test` *(fails: Jest encountered an unexpected token in frontend/__tests__/jobStream.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ada24c30d8832896b344ee5985af98