### PR TITLE
fix: update default site tagline

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,24 +5,24 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OneNew | Your personal LLM trained on anything</title>
+    <title>OneNew | Private AI Workspaces</title>
 
-    <meta name="title" content="OneNew | Your personal LLM trained on anything">
-    <meta name="description" content="OneNew | Your personal LLM trained on anything">
+    <meta name="title" content="OneNew | Private AI Workspaces">
+    <meta name="description" content="OneNew | Private AI Workspaces">
 
     <!-- Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://anythingllm.com">
-    <meta property="og:title" content="OneNew | Your personal LLM trained on anything">
-    <meta property="og:description" content="OneNew | Your personal LLM trained on anything">
+    <meta property="og:title" content="OneNew | Private AI Workspaces">
+    <meta property="og:description" content="OneNew | Private AI Workspaces">
     <meta property="og:image"
       content="https://raw.githubusercontent.com/Mintplex-Labs/anything-llm/master/images/promo.png">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://anythingllm.com">
-    <meta property="twitter:title" content="OneNew | Your personal LLM trained on anything">
-    <meta property="twitter:description" content="OneNew | Your personal LLM trained on anything">
+    <meta property="twitter:title" content="OneNew | Private AI Workspaces">
+    <meta property="twitter:description" content="OneNew | Private AI Workspaces">
     <meta property="twitter:image"
       content="https://raw.githubusercontent.com/Mintplex-Labs/anything-llm/master/images/promo.png">
 

--- a/frontend/src/pages/GeneralSettings/Settings/components/CustomSiteSettings/index.jsx
+++ b/frontend/src/pages/GeneralSettings/Settings/components/CustomSiteSettings/index.jsx
@@ -60,7 +60,7 @@ export default function CustomSiteSettings() {
             name="meta_page_title"
             type="text"
             className="border-none bg-theme-settings-input-bg mt-2 text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-fit py-2 px-4"
-            placeholder="OneNew | Your personal LLM trained on anything"
+            placeholder="OneNew | Private AI Workspaces"
             autoComplete="off"
             onChange={(e) => {
               setSettings((prev) => {
@@ -69,7 +69,7 @@ export default function CustomSiteSettings() {
             }}
             value={
               settings.title ??
-              "OneNew | Your personal LLM trained on anything"
+              "OneNew | Private AI Workspaces"
             }
           />
         </div>

--- a/server/utils/boot/MetaGenerator.js
+++ b/server/utils/boot/MetaGenerator.js
@@ -45,21 +45,21 @@ class MetaGenerator {
       {
         tag: "title",
         props: null,
-        content: "OneNew | Your personal LLM trained on anything",
+        content: "OneNew | Private AI Workspaces",
       },
 
       {
         tag: "meta",
         props: {
           name: "title",
-          content: "OneNew | Your personal LLM trained on anything",
+          content: "OneNew | Private AI Workspaces",
         },
       },
       {
         tag: "meta",
         props: {
           description: "title",
-          content: "OneNew | Your personal LLM trained on anything",
+          content: "OneNew | Private AI Workspaces",
         },
       },
 
@@ -73,14 +73,14 @@ class MetaGenerator {
         tag: "meta",
         props: {
           property: "og:title",
-          content: "OneNew | Your personal LLM trained on anything",
+          content: "OneNew | Private AI Workspaces",
         },
       },
       {
         tag: "meta",
         props: {
           property: "og:description",
-          content: "OneNew | Your personal LLM trained on anything",
+          content: "OneNew | Private AI Workspaces",
         },
       },
       {
@@ -105,14 +105,14 @@ class MetaGenerator {
         tag: "meta",
         props: {
           property: "twitter:title",
-          content: "OneNew | Your personal LLM trained on anything",
+          content: "OneNew | Private AI Workspaces",
         },
       },
       {
         tag: "meta",
         props: {
           property: "twitter:description",
-          content: "OneNew | Your personal LLM trained on anything",
+          content: "OneNew | Private AI Workspaces",
         },
       },
       {
@@ -191,7 +191,7 @@ class MetaGenerator {
           props: null,
           content:
             customTitle ??
-            "OneNew | Your personal LLM trained on anything",
+            "OneNew | Private AI Workspaces",
         },
       ];
     }


### PR DESCRIPTION
## Summary
- update default site title and description to "OneNew | Private AI Workspaces"
- sync server meta generator and settings placeholder with new tagline

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile without prior install)*
- `yarn test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68af05d76d30832893cf7846a31a353e