### PR TITLE
feat: notify when chat attachments upload

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
@@ -5,6 +5,7 @@ import { useDropzone } from "react-dropzone";
 import DndIcon from "./dnd-icon.png";
 import Workspace from "@/models/workspace";
 import useUser from "@/hooks/useUser";
+import showToast from "@/utils/toast";
 
 export const DndUploaderContext = createContext();
 export const REMOVE_ATTACHMENT_EVENT = "ATTACHMENT_REMOVE";
@@ -173,7 +174,6 @@ export function DnDFileUploaderProvider({ workspace, children }) {
     const promises = [];
 
     for (const attachment of newAttachments) {
-
       const formData = new FormData();
       formData.append("file", attachment.file, attachment.file.name);
       promises.push(
@@ -196,6 +196,12 @@ export function DnDFileUploaderProvider({ workspace, children }) {
                 }
               );
             });
+
+            if (response.ok) {
+              showToast(`${attachment.file.name} uploaded`, "success");
+            } else {
+              showToast(`Failed to upload ${attachment.file.name}`, "error");
+            }
           }
         )
       );


### PR DESCRIPTION
## Summary
- show toast notifications after chat file uploads succeed or fail

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module 'uuid' from 'server/utils/helpers/chat')*

------
https://chatgpt.com/codex/tasks/task_e_68c276742a088328bca7e6727823496a