### PR TITLE
fix(frontend): show file upload progress

### DIFF
--- a/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/DnDWrapper/index.jsx
@@ -110,7 +110,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
           uid: v4(),
           file,
           contentString: await toBase64(file),
-          status: "success",
+          status: "READY",
           error: null,
           type: "attachment",
         });
@@ -119,7 +119,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
           uid: v4(),
           file,
           contentString: null,
-          status: "in_progress",
+          status: "PENDING",
           error: null,
           type: "upload",
         });
@@ -145,7 +145,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
           uid: v4(),
           file,
           contentString: await toBase64(file),
-          status: "success",
+          status: "READY",
           error: null,
           type: "attachment",
         });
@@ -154,7 +154,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
           uid: v4(),
           file,
           contentString: null,
-          status: "in_progress",
+          status: "PENDING",
           error: null,
           type: "upload",
         });
@@ -180,7 +180,7 @@ export function DnDFileUploaderProvider({ workspace, children }) {
         Workspace.uploadAndEmbedFile(workspace.slug, formData).then(
           ({ response, data }) => {
             const updates = {
-              status: response.ok ? "success" : "failed",
+              status: response.ok ? "READY" : "FAILED",
               error: data?.error ?? null,
               document: data?.document,
             };

--- a/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
+++ b/frontend/src/components/WorkspaceChat/ChatContainer/PromptInput/Attachments/index.jsx
@@ -1,5 +1,6 @@
 import {
-  CircleNotch,
+  Circle,
+  CircleHalf,
   FileCode,
   FileCsv,
   FileDoc,
@@ -56,12 +57,13 @@ function AttachmentItem({ attachment }) {
     return (
       <div className="relative flex items-center gap-x-1 rounded-lg bg-theme-attachment-bg border-none w-[180px] group">
         <div
-          className={`bg-theme-attachment-icon-spinner-bg rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
+          className={`relative ${iconBgColor} rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
         >
-          <CircleNotch
-            size={18}
-            weight="bold"
-            className="text-theme-attachment-icon-spinner animate-spin"
+          <Icon size={24} className="text-theme-attachment-icon" />
+          <CircleHalf
+            size={14}
+            weight="fill"
+            className="absolute -bottom-1 -right-1 text-theme-attachment-icon"
           />
         </div>
         <div className="flex flex-col w-[125px]">
@@ -149,16 +151,28 @@ function AttachmentItem({ attachment }) {
             </button>
           </div>
           {contentString ? (
-            <img
-              alt={`Preview of ${file.name}`}
-              src={contentString}
-              className={`${iconBgColor} w-[30px] h-[30px] rounded-lg flex items-center justify-center m-1`}
-            />
+            <div className="relative w-[30px] h-[30px] m-1">
+              <img
+                alt={`Preview of ${file.name}`}
+                src={contentString}
+                className={`${iconBgColor} w-full h-full rounded-lg`}
+              />
+              <Circle
+                size={14}
+                weight="fill"
+                className="absolute -bottom-1 -right-1 text-theme-attachment-icon"
+              />
+            </div>
           ) : (
             <div
-              className={`${iconBgColor} rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
+              className={`relative ${iconBgColor} rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
             >
               <Icon size={24} className="text-theme-attachment-icon" />
+              <Circle
+                size={14}
+                weight="fill"
+                className="absolute -bottom-1 -right-1 text-theme-attachment-icon"
+              />
             </div>
           )}
           <div className="flex flex-col w-[125px]">
@@ -198,16 +212,21 @@ function AttachmentItem({ attachment }) {
             </button>
           </div>
           <div
-            className={`${iconBgColor} rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
+            className={`relative ${iconBgColor} rounded-md flex items-center justify-center flex-shrink-0 h-[32px] w-[32px] m-1`}
           >
             <Icon
               size={24}
               weight="light"
               className="text-theme-attachment-icon"
             />
+            <Circle
+              size={14}
+              weight="fill"
+              className="absolute -bottom-1 -right-1 text-theme-attachment-icon"
+            />
           </div>
           <div className="flex flex-col w-[125px]">
-            <p className="text-white text-xs font-semibold truncate">
+            <p className="text-theme-attachment-text text-xs font-semibold truncate">
               {file.name}
             </p>
             <p className="text-theme-attachment-text-secondary text-[10px] leading-[14px] font-medium">


### PR DESCRIPTION
## Summary
- show file attachment icons during upload
- indicate upload progress with half/full circle badges

## Testing
- `yarn lint`
- `yarn test` *(fails: Cannot find module 'uuid', 'moment', '@prisma/client', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c28f3754fc832892414787511249dc