### PR TITLE
fix: persist and display chat attachments

### DIFF
--- a/server/utils/chats/apiChatHandler.js
+++ b/server/utils/chats/apiChatHandler.js
@@ -6,7 +6,10 @@ const {
   getLLMProvider,
   workspaceVectorNamespace,
 } = require("../helpers");
-const { writeResponseChunk } = require("../helpers/chat/responses");
+const {
+  writeResponseChunk,
+  filterPromptAttachments,
+} = require("../helpers/chat/responses");
 const {
   chatPrompt,
   sourceIdentifier,
@@ -56,6 +59,7 @@ async function chatSync({
 }) {
   const uuid = uuidv4();
   const chatMode = mode ?? "chat";
+  const promptAttachments = filterPromptAttachments(attachments);
 
   // If the user wants to reset the chat history we do so pre-flight
   // and continue execution. If no message is provided then the user intended
@@ -303,7 +307,7 @@ async function chatSync({
       userPrompt: message,
       contextTexts,
       chatHistory,
-      attachments,
+      attachments: promptAttachments,
     },
     rawHistory
   );
@@ -381,6 +385,7 @@ async function streamChat({
 }) {
   const uuid = uuidv4();
   const chatMode = mode ?? "chat";
+  const promptAttachments = filterPromptAttachments(attachments);
 
   // If the user wants to reset the chat history we do so pre-flight
   // and continue execution. If no message is provided then the user intended
@@ -641,7 +646,7 @@ async function streamChat({
       userPrompt: message,
       contextTexts,
       chatHistory,
-      attachments,
+      attachments: promptAttachments,
     },
     rawHistory
   );

--- a/server/utils/chats/openaiCompatible.js
+++ b/server/utils/chats/openaiCompatible.js
@@ -6,7 +6,10 @@ const {
   getLLMProvider,
   workspaceVectorNamespace,
 } = require("../helpers");
-const { writeResponseChunk } = require("../helpers/chat/responses");
+const {
+  writeResponseChunk,
+  filterPromptAttachments,
+} = require("../helpers/chat/responses");
 const { chatPrompt, sourceIdentifier } = require("./index");
 
 const { PassThrough } = require("stream");
@@ -21,6 +24,7 @@ async function chatSync({
 }) {
   const uuid = uuidv4();
   const chatMode = workspace?.chatMode ?? "chat";
+  const promptAttachments = filterPromptAttachments(attachments);
   const LLMConnector = getLLMProvider({
     provider: workspace?.chatProvider,
     model: workspace?.chatModel,
@@ -162,7 +166,7 @@ async function chatSync({
     userPrompt: String(prompt),
     contextTexts,
     chatHistory: history,
-    attachments,
+    attachments: promptAttachments,
   });
 
   // Send the text completion.
@@ -225,6 +229,7 @@ async function streamChat({
 }) {
   const uuid = uuidv4();
   const chatMode = workspace?.chatMode ?? "chat";
+  const promptAttachments = filterPromptAttachments(attachments);
   const LLMConnector = getLLMProvider({
     provider: workspace?.chatProvider,
     model: workspace?.chatModel,
@@ -397,7 +402,7 @@ async function streamChat({
     userPrompt: String(prompt),
     contextTexts,
     chatHistory: history,
-    attachments,
+    attachments: promptAttachments,
   });
 
   if (!LLMConnector.streamingEnabled()) {

--- a/server/utils/chats/stream.js
+++ b/server/utils/chats/stream.js
@@ -6,7 +6,10 @@ const {
   getLLMProvider,
   workspaceVectorNamespace,
 } = require("../helpers");
-const { writeResponseChunk } = require("../helpers/chat/responses");
+const {
+  writeResponseChunk,
+  filterPromptAttachments,
+} = require("../helpers/chat/responses");
 const { grepAgents } = require("./agents");
 const {
   grepCommand,
@@ -29,6 +32,7 @@ async function streamChatWithWorkspace(
 ) {
   const uuid = uuidv4();
   const updatedMessage = await grepCommand(message, user);
+  const promptAttachments = filterPromptAttachments(attachments);
 
   if (Object.keys(VALID_COMMANDS).includes(updatedMessage)) {
     const data = await VALID_COMMANDS[updatedMessage](
@@ -222,7 +226,7 @@ async function streamChatWithWorkspace(
       userPrompt: updatedMessage,
       contextTexts,
       chatHistory,
-      attachments,
+      attachments: promptAttachments,
     },
     rawHistory
   );

--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -316,13 +316,19 @@ function formatChatHistory(
     )
       return historicalMessage;
 
+    const filteredAttachments = filterPromptAttachments(
+      historicalMessage.attachments
+    );
+
+    if (!filteredAttachments.length) return historicalMessage;
+
     // Some providers, like Ollama, expect the content to be embedded in the message object.
     if (mode === "spread") {
       return {
         role: historicalMessage.role,
         ...formatterFunction({
           userPrompt: historicalMessage.content,
-          attachments: historicalMessage.attachments,
+          attachments: filteredAttachments,
         }),
       };
     }
@@ -332,9 +338,17 @@ function formatChatHistory(
       role: historicalMessage.role,
       content: formatterFunction({
         userPrompt: historicalMessage.content,
-        attachments: historicalMessage.attachments,
+        attachments: filteredAttachments,
       }),
     };
+  });
+}
+
+function filterPromptAttachments(attachments = []) {
+  if (!Array.isArray(attachments)) return [];
+  return attachments.filter((attachment) => {
+    const content = attachment?.contentString;
+    return typeof content === "string" && content.trim().length > 0;
   });
 }
 
@@ -347,4 +361,5 @@ module.exports = {
   clientAbortedHandler,
   formatChatHistory,
   safeJSONStringify,
+  filterPromptAttachments,
 };


### PR DESCRIPTION
## Summary
- persist attachment metadata from drag-and-drop uploads and expose a download URL for workspace documents
- render chat attachments with previews or icons and link to the stored file when available
- filter attachments without inline content before sending to LLM providers so prompts remain valid

## Testing
- yarn lint
- yarn test *(fails: missing modules in test environment such as lodash, dotenv, uuid)*

------
https://chatgpt.com/codex/tasks/task_e_68c86735e4d08328830501705d327a6f