### PR TITLE
feat(frontend): refresh login layout with tenant branding

### DIFF
--- a/frontend/src/LogoContext.jsx
+++ b/frontend/src/LogoContext.jsx
@@ -1,8 +1,6 @@
 import { createContext, useEffect, useState } from "react";
 import OneNew from "./media/logo/anything-llm.png";
 import OneNewDark from "./media/logo/anything-llm-dark.png";
-import DefaultLoginLogoLight from "./media/illustrations/login-logo.svg";
-import DefaultLoginLogoDark from "./media/illustrations/login-logo-light.svg";
 import System from "./models/system";
 
 export const REFETCH_LOGO_EVENT = "refetch-logo";
@@ -12,30 +10,30 @@ export function LogoProvider({ children }) {
   const [logo, setLogo] = useState("");
   const [loginLogo, setLoginLogo] = useState("");
   const [isCustomLogo, setIsCustomLogo] = useState(false);
-  const DefaultLoginLogo =
-    localStorage.getItem("theme") !== "default"
-      ? DefaultLoginLogoDark
-      : DefaultLoginLogoLight;
+
+  const resolveDefaultLogo = () =>
+    typeof window !== "undefined" &&
+    window.localStorage.getItem("theme") !== "default"
+      ? OneNewDark
+      : OneNew;
 
   async function fetchInstanceLogo() {
     try {
       const { isCustomLogo, logoURL } = await System.fetchLogo();
       if (logoURL) {
         setLogo(logoURL);
-        setLoginLogo(isCustomLogo ? logoURL : DefaultLoginLogo);
+        setLoginLogo(logoURL);
         setIsCustomLogo(isCustomLogo);
       } else {
-        localStorage.getItem("theme") !== "default"
-          ? setLogo(OneNewDark)
-          : setLogo(OneNew);
-        setLoginLogo(DefaultLoginLogo);
+        const fallbackLogo = resolveDefaultLogo();
+        setLogo(fallbackLogo);
+        setLoginLogo(fallbackLogo);
         setIsCustomLogo(false);
       }
     } catch (err) {
-      localStorage.getItem("theme") !== "default"
-        ? setLogo(OneNewDark)
-        : setLogo(OneNew);
-      setLoginLogo(DefaultLoginLogo);
+      const fallbackLogo = resolveDefaultLogo();
+      setLogo(fallbackLogo);
+      setLoginLogo(fallbackLogo);
       setIsCustomLogo(false);
       console.error("Failed to fetch logo:", err);
     }

--- a/frontend/src/components/BrandLogo.tsx
+++ b/frontend/src/components/BrandLogo.tsx
@@ -1,31 +1,32 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 
 type BrandLogoProps = {
-  src?: string | null;
+  logoUrl?: string | null;
   alt?: string;
   className?: string;
 };
 
-const defaultLogoSrc =
-  process.env?.NEXT_PUBLIC_BRAND_LOGO_URL || "/brand/logo.svg";
-const fallbackBrandName = process.env?.NEXT_PUBLIC_BRAND_NAME || "LinbeckAI";
+const fallbackBrandName = process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
 
 export default function BrandLogo({
-  src = defaultLogoSrc,
+  logoUrl,
   alt = fallbackBrandName,
   className = "",
 }: BrandLogoProps) {
-  const normalizedSrc = typeof src === "string" ? src.trim() : (src ?? "");
-  const hasImageSource = Boolean(normalizedSrc);
-  const textBrand = alt || fallbackBrandName;
+  const [imageFailed, setImageFailed] = useState(false);
+  const normalizedSrc = useMemo(
+    () => (typeof logoUrl === "string" ? logoUrl.trim() : (logoUrl ?? "")),
+    [logoUrl]
+  );
+  const resolvedAlt = alt || fallbackBrandName;
+  const shouldRenderImage = Boolean(normalizedSrc) && !imageFailed;
 
-  if (hasImageSource) {
+  if (shouldRenderImage) {
     return (
       <div
         className={[
-          "relative",
-          "h-[clamp(28px,6vw,56px)] w-[clamp(140px,30vw,260px)]",
-          "shrink-0 select-none",
+          "relative select-none",
+          "h-[clamp(24px,5vw,48px)] w-[clamp(120px,25vw,220px)]",
           className,
         ]
           .filter(Boolean)
@@ -33,9 +34,10 @@ export default function BrandLogo({
       >
         <img
           src={normalizedSrc as string}
-          alt={alt}
+          alt={resolvedAlt}
           className="h-full w-full object-contain"
           loading="eager"
+          onError={() => setImageFailed(true)}
         />
       </div>
     );
@@ -44,15 +46,15 @@ export default function BrandLogo({
   return (
     <div
       className={[
-        "font-serif tracking-wide text-center",
-        "text-[clamp(22px,5vw,40px)] leading-none",
+        "mx-auto text-center font-serif tracking-wide",
+        "text-[clamp(22px,5vw,40px)] leading-tight",
         "text-theme-text-primary",
         className,
       ]
         .filter(Boolean)
         .join(" ")}
     >
-      {textBrand}
+      {resolvedAlt || fallbackBrandName}
     </div>
   );
 }

--- a/frontend/src/components/Modals/Password/MultiUserAuth.jsx
+++ b/frontend/src/components/Modals/Password/MultiUserAuth.jsx
@@ -13,7 +13,7 @@ import BrandLogo from "@/components/BrandLogo";
 const RecoveryForm = ({
   onSubmit,
   setShowRecoveryForm,
-  logoSrc,
+  logoUrl,
   brandName,
 }) => {
   const [username, setUsername] = useState("");
@@ -36,89 +36,86 @@ const RecoveryForm = ({
   };
 
   const resolvedBrandName =
-    brandName || process.env?.NEXT_PUBLIC_BRAND_NAME || "LinbeckAI";
+    brandName || process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
 
   return (
     <form onSubmit={handleSubmit} className="w-full">
-      <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-2xl border border-theme-modal-border bg-theme-bg-secondary shadow-xl backdrop-blur">
-        <div className="flex items-center justify-center overflow-hidden px-6 pt-6">
+      <div className="w-full overflow-hidden rounded-3xl border border-theme-modal-border bg-theme-bg-secondary/90 p-8 shadow-2xl backdrop-blur-xl">
+        <div className="flex flex-col items-center text-center md:items-start md:text-left">
           <BrandLogo
-            src={logoSrc}
+            logoUrl={logoUrl}
             alt={resolvedBrandName}
-            className="mx-auto"
+            className="mx-auto md:mx-0"
           />
-        </div>
-        <div className="px-6 pt-6 text-center md:text-left">
-          <h3 className="text-2xl font-semibold text-theme-text-primary">
+          <h3 className="mt-6 text-xl font-semibold text-theme-text-primary">
             {t("login.password-reset.title")}
           </h3>
-          <p className="mt-3 text-sm text-theme-text-secondary">
+          <p className="mt-2 text-sm text-theme-text-secondary">
             {t("login.password-reset.description")}
           </p>
         </div>
-        <div className="px-6 pt-6">
-          <div className="flex flex-col gap-y-4">
-            <div className="flex flex-col gap-y-2">
-              <label className="text-sm font-semibold text-theme-text-primary">
-                {t("login.multi-user.placeholder-username")}
-              </label>
+        <div className="mt-8 space-y-4">
+          <div className="space-y-2">
+            <label
+              className="text-sm font-semibold text-theme-text-primary"
+              htmlFor="recovery-username"
+            >
+              {t("login.multi-user.placeholder-username")}
+            </label>
+            <input
+              id="recovery-username"
+              name="username"
+              type="text"
+              placeholder={t("login.multi-user.placeholder-username")}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              className="h-12 w-full rounded-xl border border-transparent bg-theme-settings-input-bg px-4 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-0"
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <span className="text-sm font-semibold text-theme-text-primary">
+              {t("login.password-reset.recovery-codes")}
+            </span>
+            {recoveryCodeInputs.map((code, index) => (
               <input
-                name="username"
+                key={index}
                 type="text"
-                placeholder={t("login.multi-user.placeholder-username")}
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                className="h-12 w-full rounded-md border-none bg-theme-settings-input-bg p-2.5 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder outline-none focus:outline-primary-button active:outline-primary-button"
+                name={`recoveryCode${index + 1}`}
+                placeholder={t("login.password-reset.recovery-code", {
+                  index: index + 1,
+                })}
+                value={code}
+                onChange={(e) =>
+                  handleRecoveryCodeChange(index, e.target.value)
+                }
+                className="h-12 w-full rounded-xl border border-transparent bg-theme-settings-input-bg px-4 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-0"
                 required
               />
-            </div>
-            <div className="flex flex-col gap-y-2">
-              <label className="text-sm font-semibold text-theme-text-primary">
-                {t("login.password-reset.recovery-codes")}
-              </label>
-              {recoveryCodeInputs.map((code, index) => (
-                <div key={index}>
-                  <input
-                    type="text"
-                    name={`recoveryCode${index + 1}`}
-                    placeholder={t("login.password-reset.recovery-code", {
-                      index: index + 1,
-                    })}
-                    value={code}
-                    onChange={(e) =>
-                      handleRecoveryCodeChange(index, e.target.value)
-                    }
-                    className="h-12 w-full rounded-md border-none bg-theme-settings-input-bg p-2.5 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder outline-none focus:outline-primary-button active:outline-primary-button"
-                    required
-                  />
-                </div>
-              ))}
-            </div>
+            ))}
           </div>
         </div>
-        <div className="px-6 pb-6 pt-8">
-          <div className="flex flex-col gap-y-4">
-            <button
-              type="submit"
-              className="h-12 w-full rounded-md border-[1.5px] border-primary-button bg-primary-button text-sm font-bold text-dark-text focus:outline-none focus:ring-4 md:h-[42px] md:bg-transparent md:text-primary-button md:hover:bg-primary-button md:hover:text-white"
-            >
-              {t("login.password-reset.title")}
-            </button>
-            <button
-              type="button"
-              className="text-sm font-semibold text-theme-text-primary hover:text-primary-button hover:underline"
-              onClick={() => setShowRecoveryForm(false)}
-            >
-              {t("login.password-reset.back-to-login")}
-            </button>
-          </div>
+        <div className="mt-8 flex flex-col gap-y-3">
+          <button
+            type="submit"
+            className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-primary-button px-4 text-sm font-semibold text-dark-text transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-button disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {t("login.password-reset.title")}
+          </button>
+          <button
+            type="button"
+            className="text-sm font-semibold text-theme-text-secondary hover:text-primary-button focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-button"
+            onClick={() => setShowRecoveryForm(false)}
+          >
+            {t("login.password-reset.back-to-login")}
+          </button>
         </div>
       </div>
     </form>
   );
 };
 
-const ResetPasswordForm = ({ onSubmit, logoSrc, brandName }) => {
+const ResetPasswordForm = ({ onSubmit, logoUrl, brandName }) => {
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
 
@@ -128,54 +125,64 @@ const ResetPasswordForm = ({ onSubmit, logoSrc, brandName }) => {
   };
 
   const resolvedBrandName =
-    brandName || process.env?.NEXT_PUBLIC_BRAND_NAME || "LinbeckAI";
+    brandName || process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
+  const newPasswordLabel = t("login.password-reset.new-password", {
+    defaultValue: "New Password",
+  });
+  const confirmPasswordLabel = t("login.password-reset.confirm-password", {
+    defaultValue: "Confirm Password",
+  });
 
   return (
     <form onSubmit={handleSubmit} className="w-full">
-      <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-2xl border border-theme-modal-border bg-theme-bg-secondary shadow-xl backdrop-blur">
-        <div className="flex items-center justify-center overflow-hidden px-6 pt-6">
+      <div className="w-full overflow-hidden rounded-3xl border border-theme-modal-border bg-theme-bg-secondary/90 p-8 shadow-2xl backdrop-blur-xl">
+        <div className="flex flex-col items-center text-center md:items-start md:text-left">
           <BrandLogo
-            src={logoSrc}
+            logoUrl={logoUrl}
             alt={resolvedBrandName}
-            className="mx-auto"
+            className="mx-auto md:mx-0"
           />
-        </div>
-        <div className="px-6 pt-6 text-center md:text-left">
-          <h3 className="text-2xl font-semibold text-theme-text-primary">
-            Reset Password
+          <h3 className="mt-6 text-xl font-semibold text-theme-text-primary">
+            {t("login.password-reset.title")}
           </h3>
-          <p className="mt-3 text-sm text-theme-text-secondary">
-            Enter your new password.
+          <p className="mt-2 text-sm text-theme-text-secondary">
+            {t("login.password-reset.description")}
           </p>
         </div>
-        <div className="px-6 pt-6">
-          <div className="flex flex-col gap-y-4">
-            <input
-              type="password"
-              name="newPassword"
-              placeholder="New Password"
-              value={newPassword}
-              onChange={(e) => setNewPassword(e.target.value)}
-              className="h-12 w-full rounded-md border-none bg-theme-settings-input-bg p-2.5 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder outline-none focus:outline-primary-button active:outline-primary-button"
-              required
-            />
-            <input
-              type="password"
-              name="confirmPassword"
-              placeholder="Confirm Password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              className="h-12 w-full rounded-md border-none bg-theme-settings-input-bg p-2.5 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder outline-none focus:outline-primary-button active:outline-primary-button"
-              required
-            />
-          </div>
+        <div className="mt-8 space-y-4">
+          <label className="sr-only" htmlFor="reset-new-password">
+            {newPasswordLabel}
+          </label>
+          <input
+            id="reset-new-password"
+            type="password"
+            name="newPassword"
+            placeholder={newPasswordLabel}
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            className="h-12 w-full rounded-xl border border-transparent bg-theme-settings-input-bg px-4 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-0"
+            required
+          />
+          <label className="sr-only" htmlFor="reset-confirm-password">
+            {confirmPasswordLabel}
+          </label>
+          <input
+            id="reset-confirm-password"
+            type="password"
+            name="confirmPassword"
+            placeholder={confirmPasswordLabel}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="h-12 w-full rounded-xl border border-transparent bg-theme-settings-input-bg px-4 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-0"
+            required
+          />
         </div>
-        <div className="px-6 pb-6 pt-8">
+        <div className="mt-8">
           <button
             type="submit"
-            className="h-12 w-full rounded-md border-[1.5px] border-primary-button bg-primary-button text-sm font-bold text-dark-text focus:outline-none focus:ring-4 md:h-[42px] md:bg-transparent md:text-primary-button md:hover:bg-primary-button md:hover:text-white"
+            className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-primary-button px-4 text-sm font-semibold text-dark-text transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-button disabled:cursor-not-allowed disabled:opacity-60"
           >
-            Reset Password
+            {t("login.password-reset.title")}
           </button>
         </div>
       </div>
@@ -183,7 +190,7 @@ const ResetPasswordForm = ({ onSubmit, logoSrc, brandName }) => {
   );
 };
 
-export default function MultiUserAuth({ logoSrc, brandName }) {
+export default function MultiUserAuth({ logoUrl, brandName }) {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -193,7 +200,6 @@ export default function MultiUserAuth({ logoSrc, brandName }) {
   const [token, setToken] = useState(null);
   const [showRecoveryForm, setShowRecoveryForm] = useState(false);
   const [showResetPasswordForm, setShowResetPasswordForm] = useState(false);
-  const [customAppName, setCustomAppName] = useState(null);
 
   const {
     isOpen: isRecoveryCodeModalOpen,
@@ -276,27 +282,15 @@ export default function MultiUserAuth({ logoSrc, brandName }) {
     }
   }, [downloadComplete, user, token]);
 
-  useEffect(() => {
-    const fetchCustomAppName = async () => {
-      const { appName } = await System.fetchCustomAppName();
-      setCustomAppName(appName || "");
-      setLoading(false);
-    };
-    fetchCustomAppName();
-  }, []);
-
   const resolvedBrandName =
-    customAppName ||
-    brandName ||
-    process.env?.NEXT_PUBLIC_BRAND_NAME ||
-    "LinbeckAI";
+    brandName || process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
 
   if (showRecoveryForm) {
     return (
       <RecoveryForm
         onSubmit={handleRecoverySubmit}
         setShowRecoveryForm={setShowRecoveryForm}
-        logoSrc={logoSrc}
+        logoUrl={logoUrl}
         brandName={resolvedBrandName}
       />
     );
@@ -306,78 +300,80 @@ export default function MultiUserAuth({ logoSrc, brandName }) {
     return (
       <ResetPasswordForm
         onSubmit={handleResetSubmit}
-        logoSrc={logoSrc}
+        logoUrl={logoUrl}
         brandName={resolvedBrandName}
       />
     );
   return (
     <>
       <form onSubmit={handleLogin} className="w-full">
-        <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-2xl border border-theme-modal-border bg-theme-bg-secondary shadow-xl backdrop-blur">
-          <div className="flex items-center justify-center overflow-hidden px-6 pt-6">
+        <div className="w-full overflow-hidden rounded-3xl border border-theme-modal-border bg-theme-bg-secondary/90 p-8 shadow-2xl backdrop-blur-xl">
+          <div className="flex flex-col items-center text-center">
             <BrandLogo
-              src={logoSrc}
+              logoUrl={logoUrl}
               alt={resolvedBrandName}
               className="mx-auto"
             />
+            <h3 className="mt-6 text-xs font-semibold uppercase tracking-[0.3em] text-theme-text-secondary">
+              {t("login.multi-user.welcome")}
+            </h3>
+            <p className="mt-3 text-2xl font-semibold text-theme-text-primary">
+              {resolvedBrandName}
+            </p>
+            <p className="mt-2 text-sm text-theme-text-secondary">
+              {t("login.sign-in.start")} {resolvedBrandName}{" "}
+              {t("login.sign-in.end")}
+            </p>
           </div>
-          <div className="px-6 pt-6 text-center">
-            <div className="flex flex-col items-center gap-y-3">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-theme-text-secondary">
-                {t("login.multi-user.welcome")}
-              </h3>
-              <p className="text-3xl font-bold bg-gradient-to-r from-[#75D6FF] via-[#FFFFFF] light:via-[#75D6FF] to-[#FFFFFF] light:to-[#75D6FF] bg-clip-text text-transparent">
-                {resolvedBrandName}
-              </p>
-              <p className="text-sm text-theme-text-secondary">
-                {t("login.sign-in.start")} {resolvedBrandName}{" "}
-                {t("login.sign-in.end")}
-              </p>
-            </div>
+          <div className="mt-8 space-y-4">
+            <label className="sr-only" htmlFor="multi-user-username">
+              {t("login.multi-user.placeholder-username")}
+            </label>
+            <input
+              id="multi-user-username"
+              name="username"
+              type="text"
+              placeholder={t("login.multi-user.placeholder-username")}
+              className="h-12 w-full rounded-xl border border-transparent bg-theme-settings-input-bg px-4 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-0"
+              required
+              autoComplete="off"
+            />
+            <label className="sr-only" htmlFor="multi-user-password">
+              {t("login.multi-user.placeholder-password")}
+            </label>
+            <input
+              id="multi-user-password"
+              name="password"
+              type="password"
+              placeholder={t("login.multi-user.placeholder-password")}
+              className="h-12 w-full rounded-xl border border-transparent bg-theme-settings-input-bg px-4 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-0"
+              required
+              autoComplete="off"
+            />
+            {error && (
+              <p className="text-sm font-medium text-error">Error: {error}</p>
+            )}
           </div>
-          <div className="px-6 pt-6">
-            <div className="flex flex-col gap-y-4">
-              <input
-                name="username"
-                type="text"
-                placeholder={t("login.multi-user.placeholder-username")}
-                className="h-12 w-full rounded-md border-none bg-theme-settings-input-bg p-2.5 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder outline-none focus:outline-primary-button active:outline-primary-button"
-                required={true}
-                autoComplete="off"
-              />
-              <input
-                name="password"
-                type="password"
-                placeholder={t("login.multi-user.placeholder-password")}
-                className="h-12 w-full rounded-md border-none bg-theme-settings-input-bg p-2.5 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder outline-none focus:outline-primary-button active:outline-primary-button"
-                required={true}
-                autoComplete="off"
-              />
-              {error && <p className="text-sm text-error">Error: {error}</p>}
-            </div>
-          </div>
-          <div className="px-6 pb-6 pt-8">
-            <div className="flex flex-col gap-y-4">
-              <button
-                disabled={loading}
-                type="submit"
-                className="h-12 w-full rounded-md border-[1.5px] border-primary-button bg-primary-button text-sm font-bold text-dark-text focus:outline-none focus:ring-4 md:h-[42px] md:bg-transparent md:text-primary-button md:hover:bg-primary-button md:hover:text-white"
-              >
-                {loading
-                  ? t("login.multi-user.validating")
-                  : t("login.multi-user.login")}
-              </button>
-              <button
-                type="button"
-                className="text-sm font-semibold text-theme-text-primary hover:text-primary-button hover:underline"
-                onClick={handleResetPassword}
-              >
-                {t("login.multi-user.forgot-pass")}?
-                <span className="ml-1 font-bold">
-                  {t("login.multi-user.reset")}
-                </span>
-              </button>
-            </div>
+          <div className="mt-8 flex flex-col gap-y-3">
+            <button
+              disabled={loading}
+              type="submit"
+              className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-primary-button px-4 text-sm font-semibold text-dark-text transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-button disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {loading
+                ? t("login.multi-user.validating")
+                : t("login.multi-user.login")}
+            </button>
+            <button
+              type="button"
+              className="text-sm font-semibold text-theme-text-secondary hover:text-primary-button focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-button"
+              onClick={handleResetPassword}
+            >
+              {t("login.multi-user.forgot-pass")}?
+              <span className="ml-1 font-bold">
+                {t("login.multi-user.reset")}
+              </span>
+            </button>
           </div>
         </div>
       </form>

--- a/frontend/src/components/Modals/Password/SingleUserAuth.jsx
+++ b/frontend/src/components/Modals/Password/SingleUserAuth.jsx
@@ -8,14 +8,13 @@ import RecoveryCodeModal from "@/components/Modals/DisplayRecoveryCodeModal";
 import { useTranslation } from "react-i18next";
 import BrandLogo from "@/components/BrandLogo";
 
-export default function SingleUserAuth({ logoSrc, brandName }) {
+export default function SingleUserAuth({ logoUrl, brandName }) {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [recoveryCodes, setRecoveryCodes] = useState([]);
   const [downloadComplete, setDownloadComplete] = useState(false);
   const [token, setToken] = useState(null);
-  const [customAppName, setCustomAppName] = useState(null);
 
   const {
     isOpen: isRecoveryCodeModalOpen,
@@ -59,64 +58,52 @@ export default function SingleUserAuth({ logoSrc, brandName }) {
     }
   }, [downloadComplete, token]);
 
-  useEffect(() => {
-    const fetchCustomAppName = async () => {
-      const { appName } = await System.fetchCustomAppName();
-      setCustomAppName(appName || "");
-      setLoading(false);
-    };
-    fetchCustomAppName();
-  }, []);
-
   const resolvedBrandName =
-    customAppName ||
-    brandName ||
-    process.env?.NEXT_PUBLIC_BRAND_NAME ||
-    "LinbeckAI";
+    brandName || process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
 
   return (
     <>
       <form onSubmit={handleLogin} className="w-full">
-        <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-2xl border border-theme-modal-border bg-theme-bg-secondary shadow-xl backdrop-blur">
-          <div className="flex items-center justify-center overflow-hidden px-6 pt-6">
+        <div className="w-full overflow-hidden rounded-3xl border border-theme-modal-border bg-theme-bg-secondary/90 p-8 shadow-2xl backdrop-blur-xl">
+          <div className="flex flex-col items-center text-center">
             <BrandLogo
-              src={logoSrc}
+              logoUrl={logoUrl}
               alt={resolvedBrandName}
               className="mx-auto"
             />
+            <h3 className="mt-6 text-xs font-semibold uppercase tracking-[0.3em] text-theme-text-secondary">
+              {t("login.multi-user.welcome")}
+            </h3>
+            <p className="mt-3 text-2xl font-semibold text-theme-text-primary">
+              {resolvedBrandName}
+            </p>
+            <p className="mt-2 text-sm text-theme-text-secondary">
+              {t("login.sign-in.start")} {resolvedBrandName}{" "}
+              {t("login.sign-in.end")}
+            </p>
           </div>
-          <div className="px-6 pt-6 text-center">
-            <div className="flex flex-col items-center gap-y-3">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-theme-text-secondary">
-                {t("login.multi-user.welcome")}
-              </h3>
-              <p className="text-3xl font-bold bg-gradient-to-r from-[#75D6FF] via-[#FFFFFF] light:via-[#75D6FF] to-[#FFFFFF] light:to-[#75D6FF] bg-clip-text text-transparent">
-                {resolvedBrandName}
-              </p>
-              <p className="text-sm text-theme-text-secondary">
-                {t("login.sign-in.start")} {resolvedBrandName}{" "}
-                {t("login.sign-in.end")}
-              </p>
-            </div>
+          <div className="mt-8 space-y-4">
+            <label className="sr-only" htmlFor="single-user-password">
+              {t("login.multi-user.placeholder-password")}
+            </label>
+            <input
+              id="single-user-password"
+              name="password"
+              type="password"
+              placeholder={t("login.multi-user.placeholder-password")}
+              className="h-12 w-full rounded-xl border border-transparent bg-theme-settings-input-bg px-4 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-button focus-visible:ring-offset-0"
+              required
+              autoComplete="off"
+            />
+            {error && (
+              <p className="text-sm font-medium text-error">Error: {error}</p>
+            )}
           </div>
-          <div className="px-6 pt-6">
-            <div className="flex flex-col gap-y-4">
-              <input
-                name="password"
-                type="password"
-                placeholder="Password"
-                className="h-12 w-full rounded-md border-none bg-theme-settings-input-bg p-2.5 text-sm text-theme-text-primary placeholder:text-theme-settings-input-placeholder outline-none focus:outline-primary-button active:outline-primary-button"
-                required={true}
-                autoComplete="off"
-              />
-              {error && <p className="text-sm text-error">Error: {error}</p>}
-            </div>
-          </div>
-          <div className="px-6 pb-6 pt-8">
+          <div className="mt-8">
             <button
               disabled={loading}
               type="submit"
-              className="h-12 w-full rounded-md border-[1.5px] border-primary-button bg-primary-button text-sm font-bold text-dark-text focus:outline-none focus:ring-4 md:h-[42px] md:bg-transparent md:text-primary-button md:hover:bg-primary-button md:hover:text-white"
+              className="inline-flex h-12 w-full items-center justify-center rounded-xl bg-primary-button px-4 text-sm font-semibold text-dark-text transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-button disabled:cursor-not-allowed disabled:opacity-60"
             >
               {loading
                 ? t("login.multi-user.validating")

--- a/frontend/src/components/Modals/Password/index.jsx
+++ b/frontend/src/components/Modals/Password/index.jsx
@@ -9,38 +9,61 @@ import {
 } from "../../../utils/constants";
 import useLogo from "../../../hooks/useLogo";
 import illustration from "@/media/illustrations/login-illustration.svg";
+import BrandLogo from "@/components/BrandLogo";
+import { useTranslation } from "react-i18next";
 
 export default function PasswordModal({ mode = "single" }) {
   const { loginLogo } = useLogo();
-  const brandName = process.env?.NEXT_PUBLIC_BRAND_NAME || "LinbeckAI";
+  const { t } = useTranslation();
+  const defaultBrandName = process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
+  const [brandName, setBrandName] = useState(defaultBrandName);
+
+  useEffect(() => {
+    let isMounted = true;
+    async function hydrateBrandName() {
+      const { appName } = await System.fetchCustomAppName();
+      if (!isMounted) return;
+      setBrandName(appName || defaultBrandName);
+    }
+
+    hydrateBrandName();
+    return () => {
+      isMounted = false;
+    };
+  }, [defaultBrandName]);
 
   return (
-    <div className="fixed inset-0 z-50 flex h-full w-full flex-col items-center justify-center overflow-x-hidden overflow-y-auto bg-theme-bg-primary px-4 py-10 md:flex-row md:px-10 md:py-0">
-      <div
-        style={{
-          background: `
-    radial-gradient(circle at center, transparent 40%, black 100%),
-    linear-gradient(180deg, #85F8FF 0%, #65A6F2 100%)
-  `,
-          width: "575px",
-          filter: "blur(150px)",
-          opacity: "0.4",
-        }}
-        className="absolute left-0 top-0 z-0 h-full w-full"
-      />
-      <div className="hidden h-full w-1/2 items-center justify-center md:flex">
+    <div className="flex min-h-screen flex-col bg-theme-bg-primary md:flex-row">
+      <div className="relative hidden flex-1 items-center justify-center overflow-hidden md:flex">
         <img
-          className="w-full h-full object-contain z-50"
+          className="absolute inset-0 h-full w-full object-cover"
           src={illustration}
-          alt="login illustration"
+          alt=""
+          aria-hidden="true"
         />
+        <div
+          className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/70 to-black/80"
+          aria-hidden="true"
+        />
+        <div className="relative z-10 flex max-w-lg flex-col items-center gap-y-4 px-10 text-center text-white">
+          <BrandLogo
+            logoUrl={loginLogo}
+            alt={brandName}
+            className="drop-shadow-lg !text-white"
+          />
+          <p className="text-sm text-white/80">
+            {t("login.sign-in.start")} {brandName} {t("login.sign-in.end")}
+          </p>
+        </div>
       </div>
-      <div className="relative z-50 flex h-full w-full flex-col items-center justify-center md:w-1/2">
-        {mode === "single" ? (
-          <SingleUserAuth logoSrc={loginLogo} brandName={brandName} />
-        ) : (
-          <MultiUserAuth logoSrc={loginLogo} brandName={brandName} />
-        )}
+      <div className="flex w-full items-center justify-center px-4 py-12 md:w-[min(50%,40rem)] md:px-12">
+        <div className="w-full max-w-md">
+          {mode === "single" ? (
+            <SingleUserAuth logoUrl={loginLogo} brandName={brandName} />
+          ) : (
+            <MultiUserAuth logoUrl={loginLogo} brandName={brandName} />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/SettingsSidebar/index.jsx
+++ b/frontend/src/components/SettingsSidebar/index.jsx
@@ -23,11 +23,13 @@ import System from "@/models/system";
 import Option from "./MenuOption";
 import { CanViewChatHistoryProvider } from "../CanViewChatHistory";
 import useAppVersion from "@/hooks/useAppVersion";
+import BrandLogo from "@/components/BrandLogo";
 
 export default function SettingsSidebar() {
   const { t } = useTranslation();
   const { logo } = useLogo();
   const { user } = useUser();
+  const brandName = process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
   const sidebarRef = useRef(null);
   const [showSidebar, setShowSidebar] = useState(false);
   const [showBgOverlay, setShowBgOverlay] = useState(false);
@@ -56,11 +58,10 @@ export default function SettingsSidebar() {
             <List className="h-6 w-6" />
           </button>
           <div className="flex items-center justify-center flex-grow">
-            <img
-              src={logo}
-              alt="Logo"
-              className="block mx-auto h-6 w-auto"
-              style={{ maxHeight: "40px", objectFit: "contain" }}
+            <BrandLogo
+              logoUrl={logo}
+              alt={brandName}
+              className="mx-auto !h-6"
             />
           </div>
           <div className="w-12"></div>
@@ -87,11 +88,10 @@ export default function SettingsSidebar() {
               {/* Header Information */}
               <div className="flex w-full items-center justify-between gap-x-4">
                 <div className="flex shrink-1 w-fit items-center justify-start">
-                  <img
-                    src={logo}
-                    alt="Logo"
-                    className="rounded w-full max-h-[40px]"
-                    style={{ objectFit: "contain" }}
+                  <BrandLogo
+                    logoUrl={logo}
+                    alt={brandName}
+                    className="!mx-0 !text-left"
                   />
                 </div>
                 <div className="flex gap-x-2 items-center text-slate-500 shrink-0">
@@ -141,11 +141,10 @@ export default function SettingsSidebar() {
           to={paths.home()}
           className="flex shrink-0 max-w-[55%] items-center justify-start mx-[38px] my-[18px]"
         >
-          <img
-            src={logo}
-            alt="Logo"
-            className="rounded max-h-[24px]"
-            style={{ objectFit: "contain" }}
+          <BrandLogo
+            logoUrl={logo}
+            alt={brandName}
+            className="!mx-0 !text-left"
           />
         </Link>
         <div

--- a/frontend/src/components/Sidebar/index.jsx
+++ b/frontend/src/components/Sidebar/index.jsx
@@ -13,10 +13,12 @@ import paths from "@/utils/paths";
 import { useTranslation } from "react-i18next";
 import { useSidebarToggle, ToggleSidebarButton } from "./SidebarToggle";
 import SearchBox from "./SearchBox";
+import BrandLogo from "@/components/BrandLogo";
 
 export default function Sidebar() {
   const { user } = useUser();
   const { logo } = useLogo();
+  const brandName = process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
   const sidebarRef = useRef(null);
   const { showSidebar, setShowSidebar, canToggleSidebar } = useSidebarToggle();
   const {
@@ -38,11 +40,15 @@ export default function Sidebar() {
         <div className="flex shrink-0 w-full justify-center my-[18px]">
           <div className="flex justify-between w-[250px] min-w-[250px]">
             <Link to={paths.home()} aria-label="Home">
-              <img
-                src={logo}
-                alt="Logo"
-                className={`rounded max-h-[24px] object-contain transition-opacity duration-500 ${showSidebar ? "opacity-100" : "opacity-0"}`}
-              />
+              <div
+                className={`transition-opacity duration-500 ${showSidebar ? "opacity-100" : "opacity-0"}`}
+              >
+                <BrandLogo
+                  logoUrl={logo}
+                  alt={brandName}
+                  className="!mx-0 !text-left"
+                />
+              </div>
             </Link>
             {canToggleSidebar && (
               <ToggleSidebarButton
@@ -117,12 +123,7 @@ export function SidebarMobileHeader() {
           <List className="h-6 w-6" />
         </button>
         <div className="flex items-center justify-center flex-grow">
-          <img
-            src={logo}
-            alt="Logo"
-            className="block mx-auto h-6 w-auto"
-            style={{ maxHeight: "40px", objectFit: "contain" }}
-          />
+          <BrandLogo logoUrl={logo} alt={brandName} className="mx-auto !h-6" />
         </div>
         <div className="w-12"></div>
       </div>
@@ -148,11 +149,10 @@ export function SidebarMobileHeader() {
             {/* Header Information */}
             <div className="flex w-full items-center justify-between gap-x-4">
               <div className="flex shrink-1 w-fit items-center justify-start">
-                <img
-                  src={logo}
-                  alt="Logo"
-                  className="rounded w-full max-h-[40px]"
-                  style={{ objectFit: "contain" }}
+                <BrandLogo
+                  logoUrl={logo}
+                  alt={brandName}
+                  className="!mx-0 !text-left"
                 />
               </div>
               {(!user || user?.role !== "default") && (


### PR DESCRIPTION
## Summary
- add a more resilient BrandLogo component that supports dynamic logos and text fallbacks
- refactor the login modal into a responsive hero + card layout that hydrates tenant branding once
- update sidebar shells to consume BrandLogo so uploaded logos appear across the app

## Testing
- yarn lint
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68c9a0ede7d08328a146f610177901b6