### PR TITLE
fix: restore sidebar logo sizing

### DIFF
--- a/frontend/src/LogoContext.jsx
+++ b/frontend/src/LogoContext.jsx
@@ -1,6 +1,8 @@
 import { createContext, useEffect, useState } from "react";
 import OneNew from "./media/logo/anything-llm.png";
 import OneNewDark from "./media/logo/anything-llm-dark.png";
+import DefaultLoginLogoLight from "./media/illustrations/login-logo.svg";
+import DefaultLoginLogoDark from "./media/illustrations/login-logo-light.svg";
 import System from "./models/system";
 
 export const REFETCH_LOGO_EVENT = "refetch-logo";
@@ -11,29 +13,32 @@ export function LogoProvider({ children }) {
   const [loginLogo, setLoginLogo] = useState("");
   const [isCustomLogo, setIsCustomLogo] = useState(false);
 
-  const resolveDefaultLogo = () =>
-    typeof window !== "undefined" &&
-    window.localStorage.getItem("theme") !== "default"
-      ? OneNewDark
-      : OneNew;
+  const resolveTheme = () => {
+    if (typeof window === "undefined") return "default";
+    return window.localStorage?.getItem("theme") ?? "default";
+  };
+
+  const resolveAppLogo = () =>
+    resolveTheme() !== "default" ? OneNewDark : OneNew;
+
+  const resolveLoginLogo = () =>
+    resolveTheme() !== "default" ? DefaultLoginLogoDark : DefaultLoginLogoLight;
 
   async function fetchInstanceLogo() {
     try {
       const { isCustomLogo, logoURL } = await System.fetchLogo();
       if (logoURL) {
         setLogo(logoURL);
-        setLoginLogo(logoURL);
+        setLoginLogo(isCustomLogo ? logoURL : resolveLoginLogo());
         setIsCustomLogo(isCustomLogo);
       } else {
-        const fallbackLogo = resolveDefaultLogo();
-        setLogo(fallbackLogo);
-        setLoginLogo(fallbackLogo);
+        setLogo(resolveAppLogo());
+        setLoginLogo(resolveLoginLogo());
         setIsCustomLogo(false);
       }
     } catch (err) {
-      const fallbackLogo = resolveDefaultLogo();
-      setLogo(fallbackLogo);
-      setLoginLogo(fallbackLogo);
+      setLogo(resolveAppLogo());
+      setLoginLogo(resolveLoginLogo());
       setIsCustomLogo(false);
       console.error("Failed to fetch logo:", err);
     }

--- a/frontend/src/components/SettingsSidebar/index.jsx
+++ b/frontend/src/components/SettingsSidebar/index.jsx
@@ -23,8 +23,6 @@ import System from "@/models/system";
 import Option from "./MenuOption";
 import { CanViewChatHistoryProvider } from "../CanViewChatHistory";
 import useAppVersion from "@/hooks/useAppVersion";
-import BrandLogo from "@/components/BrandLogo";
-
 export default function SettingsSidebar() {
   const { t } = useTranslation();
   const { logo } = useLogo();
@@ -58,10 +56,11 @@ export default function SettingsSidebar() {
             <List className="h-6 w-6" />
           </button>
           <div className="flex items-center justify-center flex-grow">
-            <BrandLogo
-              logoUrl={logo}
+            <img
+              src={logo}
               alt={brandName}
-              className="mx-auto !h-6"
+              className="block mx-auto h-6 w-auto"
+              style={{ maxHeight: "40px", objectFit: "contain" }}
             />
           </div>
           <div className="w-12"></div>
@@ -88,10 +87,11 @@ export default function SettingsSidebar() {
               {/* Header Information */}
               <div className="flex w-full items-center justify-between gap-x-4">
                 <div className="flex shrink-1 w-fit items-center justify-start">
-                  <BrandLogo
-                    logoUrl={logo}
+                  <img
+                    src={logo}
                     alt={brandName}
-                    className="!mx-0 !text-left"
+                    className="rounded w-full max-h-[40px]"
+                    style={{ objectFit: "contain" }}
                   />
                 </div>
                 <div className="flex gap-x-2 items-center text-slate-500 shrink-0">
@@ -141,10 +141,11 @@ export default function SettingsSidebar() {
           to={paths.home()}
           className="flex shrink-0 max-w-[55%] items-center justify-start mx-[38px] my-[18px]"
         >
-          <BrandLogo
-            logoUrl={logo}
+          <img
+            src={logo}
             alt={brandName}
-            className="!mx-0 !text-left"
+            className="rounded w-full max-h-[40px]"
+            style={{ objectFit: "contain" }}
           />
         </Link>
         <div

--- a/frontend/src/components/Sidebar/index.jsx
+++ b/frontend/src/components/Sidebar/index.jsx
@@ -13,8 +13,6 @@ import paths from "@/utils/paths";
 import { useTranslation } from "react-i18next";
 import { useSidebarToggle, ToggleSidebarButton } from "./SidebarToggle";
 import SearchBox from "./SearchBox";
-import BrandLogo from "@/components/BrandLogo";
-
 export default function Sidebar() {
   const { user } = useUser();
   const { logo } = useLogo();
@@ -40,15 +38,11 @@ export default function Sidebar() {
         <div className="flex shrink-0 w-full justify-center my-[18px]">
           <div className="flex justify-between w-[250px] min-w-[250px]">
             <Link to={paths.home()} aria-label="Home">
-              <div
-                className={`transition-opacity duration-500 ${showSidebar ? "opacity-100" : "opacity-0"}`}
-              >
-                <BrandLogo
-                  logoUrl={logo}
-                  alt={brandName}
-                  className="!mx-0 !text-left"
-                />
-              </div>
+              <img
+                src={logo}
+                alt={brandName}
+                className={`rounded max-h-[24px] object-contain transition-opacity duration-500 ${showSidebar ? "opacity-100" : "opacity-0"}`}
+              />
             </Link>
             {canToggleSidebar && (
               <ToggleSidebarButton
@@ -87,6 +81,7 @@ export function SidebarMobileHeader() {
   const sidebarRef = useRef(null);
   const [showSidebar, setShowSidebar] = useState(false);
   const [showBgOverlay, setShowBgOverlay] = useState(false);
+  const brandName = process.env?.NEXT_PUBLIC_BRAND_NAME || "OneNew";
   const {
     showing: showingNewWsModal,
     showModal: showNewWsModal,
@@ -123,7 +118,12 @@ export function SidebarMobileHeader() {
           <List className="h-6 w-6" />
         </button>
         <div className="flex items-center justify-center flex-grow">
-          <BrandLogo logoUrl={logo} alt={brandName} className="mx-auto !h-6" />
+          <img
+            src={logo}
+            alt={brandName}
+            className="block mx-auto h-6 w-auto"
+            style={{ maxHeight: "40px", objectFit: "contain" }}
+          />
         </div>
         <div className="w-12"></div>
       </div>
@@ -149,10 +149,11 @@ export function SidebarMobileHeader() {
             {/* Header Information */}
             <div className="flex w-full items-center justify-between gap-x-4">
               <div className="flex shrink-1 w-fit items-center justify-start">
-                <BrandLogo
-                  logoUrl={logo}
+                <img
+                  src={logo}
                   alt={brandName}
-                  className="!mx-0 !text-left"
+                  className="rounded w-full max-h-[40px]"
+                  style={{ objectFit: "contain" }}
                 />
               </div>
               {(!user || user?.role !== "default") && (


### PR DESCRIPTION
## Summary
- revert sidebar surfaces to render stored logo assets directly so sizing matches the codex branch state
- restore theme-aware login logo fallbacks while keeping support for tenant-provided branding

## Testing
- yarn lint *(fails: workspace missing from lockfile; run `yarn install` to populate)*

------
https://chatgpt.com/codex/tasks/task_e_68c9afbce5d883288b733bbe41877d61