### PR TITLE
feat: scaffold triune runtime stubs

### DIFF
--- a/deploy/cpu_runner/README.md
+++ b/deploy/cpu_runner/README.md
@@ -1,0 +1,7 @@
+# Triune CPU Runner (Stub)
+
+Build with:
+
+```
+g++ -O3 -std=c++17 -o triune-cpu main.cpp
+```

--- a/deploy/cpu_runner/main.cpp
+++ b/deploy/cpu_runner/main.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+#include <fstream>
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::cerr << "usage: triune-cpu --model <path> --prompt <text>" << std::endl;
+        return 1;
+    }
+    std::string model_path;
+    std::string prompt;
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--model" && i + 1 < argc) {
+            model_path = argv[++i];
+        } else if (arg == "--prompt" && i + 1 < argc) {
+            prompt = argv[++i];
+        }
+    }
+    if (model_path.empty()) {
+        std::cerr << "missing --model" << std::endl;
+        return 1;
+    }
+    std::ifstream file(model_path);
+    if (!file.good()) {
+        std::cerr << "failed to open model: " << model_path << std::endl;
+        return 1;
+    }
+    std::string first_line;
+    std::getline(file, first_line);
+    std::cout << "Loaded model artifact from " << model_path << std::endl;
+    std::cout << "Prompt: " << prompt << std::endl;
+    std::cout << "(stubbed response)" << std::endl;
+    return 0;
+}

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y build-essential cmake && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY . .
+RUN pip install pytest
+
+CMD ["pytest", "tests"]

--- a/tests/test_swapper.py
+++ b/tests/test_swapper.py
@@ -1,0 +1,14 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+nn = torch.nn
+
+from triune.models.bitlinear import BitLinearV2
+from triune.models.swapper import convert_model
+
+
+def test_convert_model_replaces_linear():
+    model = nn.Sequential(nn.Linear(4, 2))
+    manifest = convert_model(model)
+    assert isinstance(model[0], BitLinearV2)
+    assert manifest

--- a/tests/test_tlora.py
+++ b/tests/test_tlora.py
@@ -1,0 +1,14 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+nn = torch.nn
+
+from triune.adapters.tlora import TLoraAdapter, TLoraConfig
+
+
+def test_tlora_forward_shape():
+    base = nn.Linear(4, 3)
+    adapter = TLoraAdapter(base, TLoraConfig(r=2))
+    x = torch.randn(2, 4)
+    out = adapter(x)
+    assert out.shape == (2, 3)

--- a/triune/README.md
+++ b/triune/README.md
@@ -1,0 +1,3 @@
+# Triune Runtime (Stub)
+
+This directory contains a minimal placeholder implementation of the Triune runtime components.

--- a/triune/__init__.py
+++ b/triune/__init__.py
@@ -1,0 +1,5 @@
+"""Triune runtime package."""
+
+from .models.bitlinear import BitLinearV2
+
+__all__ = ["BitLinearV2"]

--- a/triune/adapters/tlora.py
+++ b/triune/adapters/tlora.py
@@ -1,0 +1,73 @@
+"""Ternary LoRA adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+import torch
+from torch import nn
+
+from triune.models.bitlinear import BitLinearV2, ternarize
+
+
+@dataclass
+class TLoraConfig:
+    r: int = 8
+    alpha: float = 16.0
+    dropout: float = 0.0
+
+
+class TLoraAdapter(nn.Module):
+    """Ternary LoRA adapter with straight-through gradients."""
+
+    def __init__(self, base: nn.Linear, config: TLoraConfig):
+        super().__init__()
+        self.base = base
+        self.config = config
+        self.lora_a = nn.Parameter(torch.zeros((config.r, base.in_features)))
+        self.lora_b = nn.Parameter(torch.zeros((base.out_features, config.r)))
+        self.register_buffer("scale", torch.tensor(config.alpha / config.r))
+        self.dropout = nn.Dropout(config.dropout)
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        nn.init.kaiming_uniform_(self.lora_a, a=5 ** 0.5)
+        nn.init.zeros_(self.lora_b)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        base_out = self.base(x)
+        lora_out = self.dropout(x) @ self.lora_a.t()
+        ternary_b, _ = ternarize(self.lora_b, torch.full_like(self.lora_b, 0.05))
+        adapted = lora_out @ ternary_b.t()
+        return base_out + adapted * self.scale
+
+    def merge(self) -> None:
+        update = (self.scale * (self.lora_b @ self.lora_a)).to(self.base.weight)
+        self.base.weight.data.add_(update)
+
+    def unmerge(self) -> None:
+        update = (self.scale * (self.lora_b @ self.lora_a)).to(self.base.weight)
+        self.base.weight.data.sub_(update)
+
+
+def attach_tlora(model: nn.Module, config: TLoraConfig) -> List[Tuple[str, TLoraAdapter]]:
+    adapters: List[Tuple[str, TLoraAdapter]] = []
+    for name, module in list(model.named_modules()):
+        if isinstance(module, nn.Linear):
+            parent, attr = _resolve_parent(model, name)
+            adapter = TLoraAdapter(module, config)
+            setattr(parent, attr, adapter)
+            adapters.append((name, adapter))
+    return adapters
+
+
+def _resolve_parent(module: nn.Module, path: str) -> Tuple[nn.Module, str]:
+    parts = path.split(".")
+    parent = module
+    for part in parts[:-1]:
+        parent = getattr(parent, part)
+    return parent, parts[-1]
+
+
+__all__ = ["TLoraConfig", "TLoraAdapter", "attach_tlora"]

--- a/triune/deploy/convert_bitnetcpp.py
+++ b/triune/deploy/convert_bitnetcpp.py
@@ -1,0 +1,14 @@
+"""bitnet.cpp exporter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def export_to_bitnetcpp(model, path: Path) -> None:
+    payload = {"model": model.__class__.__name__, "format": "bitnetcpp"}
+    path.write_text(json.dumps(payload, indent=2))
+
+
+__all__ = ["export_to_bitnetcpp"]

--- a/triune/deploy/convert_gguf.py
+++ b/triune/deploy/convert_gguf.py
@@ -1,0 +1,14 @@
+"""GGUF exporter stubs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def export_to_gguf(model, path: Path) -> None:
+    payload = {"model": model.__class__.__name__}
+    path.write_text(json.dumps(payload, indent=2))
+
+
+__all__ = ["export_to_gguf"]

--- a/triune/eval/agent/eval_agentic.py
+++ b/triune/eval/agent/eval_agentic.py
@@ -1,0 +1,31 @@
+"""Agentic evaluation harness stubs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass
+class AgenticTask:
+    name: str
+    prompt: str
+    expected: str
+
+
+@dataclass
+class AgenticResult:
+    name: str
+    success: bool
+    trace: List[str]
+
+
+def evaluate(model, tasks: Iterable[AgenticTask]) -> List[AgenticResult]:
+    results: List[AgenticResult] = []
+    for task in tasks:
+        trace = [task.prompt, "...", task.expected]
+        results.append(AgenticResult(task.name, False, trace))
+    return results
+
+
+__all__ = ["AgenticTask", "AgenticResult", "evaluate"]

--- a/triune/models/bitlinear.py
+++ b/triune/models/bitlinear.py
@@ -1,0 +1,69 @@
+"""BitLinear v2 ternary linear layers."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import torch
+from torch import nn
+
+Ternary = torch.Tensor
+
+
+def ternarize(weights: torch.Tensor, threshold: torch.Tensor) -> Tuple[Ternary, torch.Tensor]:
+    """Ternarize floating-point weights with symmetric thresholding."""
+    with torch.no_grad():
+        sign = torch.sign(weights)
+        mask = torch.abs(weights) >= threshold
+        ternary = sign * mask
+    return ternary, mask
+
+
+@dataclass
+class BitLinearState:
+    ternary_weight: torch.Tensor
+    scale: torch.Tensor
+    bias: Optional[torch.Tensor]
+
+
+class BitLinearV2(nn.Module):
+    """Linear layer with ternary weights and per-row scaling."""
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True, *, device=None, dtype=None):
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super().__init__()
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty((out_features, in_features), **factory_kwargs))
+        self.bias = nn.Parameter(torch.empty(out_features, **factory_kwargs)) if bias else None
+        self.register_buffer("scale", torch.ones(out_features, **factory_kwargs))
+        self.register_buffer("threshold", torch.full((out_features, 1), 0.05, **factory_kwargs))
+        self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        nn.init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = nn.init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in)
+            nn.init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, input: torch.Tensor) -> torch.Tensor:
+        ternary, mask = ternarize(self.weight, self.threshold)
+        scale = self.scale.view(-1, 1)
+        packed = ternary * scale
+        output = nn.functional.linear(input, packed, self.bias)
+        return output
+
+    def extra_repr(self) -> str:
+        return f"in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}"
+
+    def load_state(self, state: BitLinearState) -> None:
+        self.weight.data.copy_(state.ternary_weight)
+        self.scale.copy_(state.scale)
+        if state.bias is not None and self.bias is not None:
+            self.bias.data.copy_(state.bias)
+
+
+__all__ = ["BitLinearV2", "BitLinearState", "ternarize"]

--- a/triune/models/swapper.py
+++ b/triune/models/swapper.py
@@ -1,0 +1,104 @@
+"""Model graph rewriting utilities for BitLinear conversion."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+import torch
+from torch import nn
+
+from .bitlinear import BitLinearV2
+
+
+@dataclass
+class SwapConfig:
+    """Configuration for module conversion."""
+
+    allow_modules: Set[str] = field(default_factory=lambda: {"Linear"})
+    block_modules: Set[str] = field(default_factory=lambda: {"Embedding", "LayerNorm", "RMSNorm"})
+    include_bias: bool = True
+
+
+@dataclass
+class SwapRecord:
+    module_path: str
+    original_cls: str
+    replaced_cls: str
+    scale: List[float]
+
+
+def iter_named_modules(module: nn.Module, prefix: str = "") -> Iterable[Tuple[str, nn.Module]]:
+    for name, child in module.named_children():
+        child_prefix = f"{prefix}.{name}" if prefix else name
+        yield child_prefix, child
+        yield from iter_named_modules(child, child_prefix)
+
+
+def should_convert(name: str, module: nn.Module, config: SwapConfig) -> bool:
+    if module.__class__.__name__ in config.block_modules:
+        return False
+    if module.__class__.__name__ not in config.allow_modules:
+        return False
+    if isinstance(module, nn.Linear):
+        return True
+    return False
+
+
+def linear_to_bitlinear(linear: nn.Linear, *, device: Optional[torch.device] = None) -> BitLinearV2:
+    bit = BitLinearV2(linear.in_features, linear.out_features, bias=linear.bias is not None, device=device)
+    with torch.no_grad():
+        bit.weight.copy_(linear.weight.data.sign())
+        scales = linear.weight.data.abs().mean(dim=1)
+        bit.scale.copy_(scales)
+        if linear.bias is not None and bit.bias is not None:
+            bit.bias.copy_(linear.bias.data)
+    return bit
+
+
+def convert_model(model: nn.Module, *, config: Optional[SwapConfig] = None) -> Dict[str, SwapRecord]:
+    """Convert linear layers in the model and return a manifest."""
+    config = config or SwapConfig()
+    manifest: Dict[str, SwapRecord] = {}
+    for name, module in iter_named_modules(model):
+        if should_convert(name, module, config):
+            parent, attr = _resolve_parent(model, name)
+            replacement = linear_to_bitlinear(module)
+            setattr(parent, attr, replacement)
+            manifest[name] = SwapRecord(
+                module_path=name,
+                original_cls=module.__class__.__name__,
+                replaced_cls=replacement.__class__.__name__,
+                scale=replacement.scale.detach().cpu().tolist(),
+            )
+    return manifest
+
+
+def _resolve_parent(module: nn.Module, path: str) -> Tuple[nn.Module, str]:
+    parts = path.split(".")
+    parent = module
+    for part in parts[:-1]:
+        parent = getattr(parent, part)
+    return parent, parts[-1]
+
+
+def save_manifest(manifest: Dict[str, SwapRecord], path: Path) -> None:
+    serializable = {
+        name: {
+            "original": record.original_cls,
+            "replacement": record.replaced_cls,
+            "scale": record.scale,
+        }
+        for name, record in manifest.items()
+    }
+    path.write_text(json.dumps(serializable, indent=2))
+
+
+__all__ = [
+    "SwapConfig",
+    "SwapRecord",
+    "convert_model",
+    "save_manifest",
+]

--- a/triune/moe/prune.py
+++ b/triune/moe/prune.py
@@ -1,0 +1,30 @@
+"""Mixture-of-Experts pruning utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import torch
+
+
+@dataclass
+class ExpertStats:
+    name: str
+    usage: float
+    temperature: float
+
+
+def prune_experts(stats: List[ExpertStats], max_parameters: float, expert_params: Dict[str, float]) -> List[ExpertStats]:
+    kept: List[ExpertStats] = []
+    total = 0.0
+    for stat in sorted(stats, key=lambda s: s.usage, reverse=True):
+        params = expert_params.get(stat.name, 0.0)
+        if total + params > max_parameters:
+            continue
+        kept.append(stat)
+        total += params
+    return kept
+
+
+__all__ = ["ExpertStats", "prune_experts"]

--- a/triune/quant/ptq_calib.py
+++ b/triune/quant/ptq_calib.py
@@ -1,0 +1,42 @@
+"""Post-training quantization calibration for BitLinear weights."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+import torch
+from torch import nn
+
+from triune.models.bitlinear import BitLinearV2
+
+
+@dataclass
+class CalibrationResult:
+    scales: torch.Tensor
+    thresholds: torch.Tensor
+    error: torch.Tensor
+
+
+def calibrate_module(module: nn.Linear, activations: torch.Tensor) -> CalibrationResult:
+    weight = module.weight.data
+    scales = weight.abs().mean(dim=1)
+    thresholds = torch.quantile(weight.abs(), 0.7, dim=1, keepdim=True)
+    ternary = torch.sign(weight) * (weight.abs() >= thresholds)
+    error = (weight - ternary * scales[:, None]).pow(2).mean(dim=1)
+    return CalibrationResult(scales=scales, thresholds=thresholds.squeeze(1), error=error)
+
+
+def calibrate_model(model: nn.Module, data: Iterable[torch.Tensor]) -> Dict[str, CalibrationResult]:
+    cache = list(data)
+    if not cache:
+        raise ValueError("Calibration requires non-empty activation samples")
+    results: Dict[str, CalibrationResult] = {}
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear):
+            acts = cache[min(len(cache) - 1, 0)]
+            results[name] = calibrate_module(module, acts)
+    return results
+
+
+__all__ = ["CalibrationResult", "calibrate_module", "calibrate_model"]

--- a/triune/search/postnas.py
+++ b/triune/search/postnas.py
@@ -1,0 +1,45 @@
+"""Simple post-NAS search over attention/SSM mix."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class LayerSpec:
+    layer_index: int
+    kind: str
+    memory_cost: float
+    latency_cost: float
+
+
+@dataclass
+class SearchBudget:
+    max_memory: float
+    max_latency: float
+
+
+@dataclass
+class SearchResult:
+    layers: List[LayerSpec]
+    total_memory: float
+    total_latency: float
+
+
+def search(layers: List[LayerSpec], budget: SearchBudget) -> SearchResult:
+    selected: List[LayerSpec] = []
+    total_memory = 0.0
+    total_latency = 0.0
+    for spec in sorted(layers, key=lambda s: s.latency_cost):
+        if total_memory + spec.memory_cost > budget.max_memory:
+            continue
+        if total_latency + spec.latency_cost > budget.max_latency:
+            continue
+        selected.append(spec)
+        total_memory += spec.memory_cost
+        total_latency += spec.latency_cost
+    return SearchResult(selected, total_memory, total_latency)
+
+
+__all__ = ["LayerSpec", "SearchBudget", "SearchResult", "search"]

--- a/triune/train/dfa.py
+++ b/triune/train/dfa.py
@@ -1,0 +1,32 @@
+"""Training pipeline orchestration entrypoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import torch
+
+from triune.adapters.tlora import TLoraConfig, attach_tlora
+from triune.models.swapper import SwapConfig, convert_model, save_manifest
+from triune.quant.ptq_calib import calibrate_model
+
+
+@dataclass
+class PipelineConfig:
+    output_dir: Path
+    tlora: TLoraConfig = TLoraConfig()
+    swap: SwapConfig = SwapConfig()
+
+
+def run_pipeline(model: torch.nn.Module, activations: Iterable[torch.Tensor], config: PipelineConfig) -> None:
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = convert_model(model, config=config.swap)
+    save_manifest(manifest, config.output_dir / "swap_manifest.json")
+    calibration = calibrate_model(model, activations)
+    torch.save({k: v.scales for k, v in calibration.items()}, config.output_dir / "calibration.pt")
+    attach_tlora(model, config.tlora)
+
+
+__all__ = ["PipelineConfig", "run_pipeline"]

--- a/triune/train/loops.py
+++ b/triune/train/loops.py
@@ -1,0 +1,24 @@
+"""High-level training loop utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import torch
+
+from triune.train.dfa import PipelineConfig, run_pipeline
+
+
+@dataclass
+class TrainLoopConfig:
+    pipeline: PipelineConfig
+    epochs: int = 1
+
+
+def train(model: torch.nn.Module, data: Iterable[torch.Tensor], config: TrainLoopConfig) -> None:
+    for epoch in range(config.epochs):
+        run_pipeline(model, data, config.pipeline)
+
+
+__all__ = ["TrainLoopConfig", "train"]


### PR DESCRIPTION
## Summary
- add initial Triune Python package with BitLinear conversion, TLora adapters, and calibration helpers
- scaffold deployment stubs including GGUF exporters and a minimal CPU runner CLI
- provide pytest smoke tests and a basic Dockerfile for executing the suite

## Testing
- pytest tests/test_swapper.py tests/test_tlora.py

------
https://chatgpt.com/codex/tasks/task_e_68d93ea5f00c8328b49eecdc71193fa3